### PR TITLE
Make it possible to build HopsanGUI even when QtWebKit is not available

### DIFF
--- a/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
+++ b/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
@@ -41,8 +41,6 @@
 #include <QHeaderView>
 #include <QScrollBar>
 #include <QMenu>
-#include <QWebView>
-#include <QWebFrame>
 #include <QMainWindow>
 #include <QLineEdit>
 #include <QGroupBox>
@@ -65,6 +63,7 @@
 #include "UndoStack.h"
 #include "Utilities/GUIUtilities.h"
 #include "Utilities/HighlightingUtilities.h"
+#include "Utilities/WebviewWrapper.h"
 #include "LibraryHandler.h"
 #include "Widgets/ModelWidget.h"
 #include "Widgets/SystemParametersWidget.h"
@@ -456,7 +455,7 @@ QWidget *ComponentPropertiesDialog3::createHelpWidget()
 
         if (!mpModelObject->getHelpHtmlPath().isEmpty())
         {
-            QWebView * pHtmlView = new QWebView();
+            WebViewWrapper* pHtmlView = new WebViewWrapper(false);
             QString path = mpModelObject->getAppearanceData()->getBasePath() + mpModelObject->getHelpHtmlPath();
             if (path.endsWith(".md"))
             {
@@ -585,19 +584,19 @@ QWidget *ComponentPropertiesDialog3::createHelpWidget()
                     }
 
                     // Set html to view
-                    pHtmlView->load(QUrl::fromLocalFile(htmlFilePath));
+                    pHtmlView->loadHtmlFile(QUrl::fromLocalFile(htmlFilePath));
                 }
                 else
                 {
-                    pHtmlView->setHtml(QString("<p>Error: Could not convert %1 to HTML or load the file.</p>").arg(path));
+                    pHtmlView->showText(QString("Error: Could not convert %1 to HTML or load the file.").arg(path));
                 }
 #else
-                pHtmlView->setHtml(QString("<p>Error: Markdown support is not available in this build!</p>").arg(path));
+                pHtmlView->showText(QString("Error: Markdown support is not available in this build!").arg(path));
 #endif
             }
             else
             {
-                pHtmlView->load(QUrl::fromLocalFile(path));
+                pHtmlView->loadHtmlFile(QUrl::fromLocalFile(path));
             }
             pHelpLayout->addWidget(pHtmlView);
         }

--- a/HopsanGUI/Dialogs/HelpDialog.cpp
+++ b/HopsanGUI/Dialogs/HelpDialog.cpp
@@ -32,7 +32,7 @@
 //$Id$
 
 //Qt includes
-#include <QWebView>
+#include <QUrl>
 #include <QToolBar>
 #include <QVBoxLayout>
 #include <QApplication>
@@ -62,22 +62,9 @@ HelpDialog::HelpDialog(QWidget *parent)
     this->setMinimumSize(640, 480);
     this->setWindowModality(Qt::NonModal);
 
-    mpHelp = new QWebView(this);
-
-    QAction *pBackAction = mpHelp->pageAction(QWebPage::Back);
-    pBackAction->setIcon(QIcon(QString(QString(ICONPATH) + "Hopsan-StepLeft.png")));
-    QAction *pForwardAction = mpHelp->pageAction(QWebPage::Forward);
-    pForwardAction->setIcon(QIcon(QString(QString(ICONPATH) + "Hopsan-StepRight.png")));
-
-    QToolBar *pToolBar = new QToolBar(this);
-    pToolBar->addAction(pBackAction);
-    pToolBar->addAction(pForwardAction);
-
     QVBoxLayout *pLayout = new QVBoxLayout(this);
-    pLayout->addWidget(pToolBar);
+    mpHelp = new WebViewWrapper(true, this);
     pLayout->addWidget(mpHelp);
-    pLayout->setStretch(1,1);
-    this->setLayout(pLayout);
 
     //! @todo Set size depending one screen size
     this->resize(1024,768);
@@ -86,7 +73,7 @@ HelpDialog::HelpDialog(QWidget *parent)
 
 void HelpDialog::open()
 {
-    mpHelp->load(QUrl::fromLocalFile(gpDesktopHandler->getHelpPath() + "index.html"));
+    mpHelp->loadHtmlFile(QUrl::fromLocalFile(gpDesktopHandler->getHelpPath() + "index.html"));
 
     //Using show instead of open for modaless window
     QDialog::show();
@@ -95,7 +82,7 @@ void HelpDialog::open()
 
 void HelpDialog::open(QString file)
 {
-    mpHelp->load(QUrl::fromLocalFile(gpDesktopHandler->getHelpPath() + file));
+    mpHelp->loadHtmlFile(QUrl::fromLocalFile(gpDesktopHandler->getHelpPath() + file));
 
     //Using show instead of open for modaless window
     QDialog::show();

--- a/HopsanGUI/Dialogs/HelpDialog.h
+++ b/HopsanGUI/Dialogs/HelpDialog.h
@@ -34,8 +34,8 @@
 #ifndef HELPDIALOG_H
 #define HELPDIALOG_H
 
-#include <QWebView>
 #include <QDialog>
+#include "Utilities/WebviewWrapper.h"
 
 class HelpDialog : public QDialog
 {
@@ -50,7 +50,7 @@ public slots:
     void centerOnScreen();
 
 private:
-    QWebView *mpHelp;
+    WebViewWrapper *mpHelp;
 };
 
 #endif // HELPDIALOG_H

--- a/HopsanGUI/HopsanGUI.pro
+++ b/HopsanGUI/HopsanGUI.pro
@@ -14,7 +14,14 @@ QT += svg xml
 QT += core gui network
 
 isEqual(QT_MAJOR_VERSION, 5){
-    QT += widgets webkitwidgets printsupport
+    QT += widgets printsupport
+    qtHaveModule(webkitwidgets) {
+        QT += webkitwidgets
+        DEFINES *= USEWEBKIT
+        message(Using WebKit)
+    } else {
+        message(WebKit is not available)
+    }
 } else {
     QT += webkit
 }
@@ -280,7 +287,8 @@ SOURCES += main.cpp \
     Dialogs/LicenseDialog.cpp \
     Widgets/TimeOffsetWidget.cpp \
     Dialogs/NumHopScriptDialog.cpp \
-    PlotCurveStyle.cpp
+    PlotCurveStyle.cpp \
+    Utilities/WebviewWrapper.cpp
 
 HEADERS += MainWindow.h \
     Widgets/ProjectTabWidget.h \
@@ -370,7 +378,8 @@ HEADERS += MainWindow.h \
     Utilities/EventFilters.h \
     Widgets/TimeOffsetWidget.h \
     Dialogs/NumHopScriptDialog.h \
-    PlotCurveStyle.h
+    PlotCurveStyle.h \
+    Utilities/WebviewWrapper.h
 
     contains(DEFINES, USEPYTHONQT) {
         SOURCES += Widgets/PyDockWidget.cpp

--- a/HopsanGUI/Utilities/WebviewWrapper.cpp
+++ b/HopsanGUI/Utilities/WebviewWrapper.cpp
@@ -17,6 +17,7 @@ public:
 #ifdef USEWEBKIT
     QWebView* mpWebView = nullptr;
 #else
+    QLabel* mpNotice = nullptr;
     QLabel* mpText = nullptr;
 #endif
 
@@ -44,10 +45,14 @@ WebViewWrapper::WebViewWrapper(const bool useToolbar, QWidget *parent) : QWidget
     mpPrivates->mpLayout->setStretch(1,1);
 #else
     Q_UNUSED(useToolbar)
+    mpPrivates->mpNotice = new QLabel(this);
     mpPrivates->mpText = new QLabel(this);
     mpPrivates->mpText->setOpenExternalLinks(true);
+    mpPrivates->mpLayout->addWidget(mpPrivates->mpNotice);
     mpPrivates->mpLayout->addWidget(mpPrivates->mpText);
+    mpPrivates->mpLayout->addStretch(1);
 #endif
+
 }
 
 WebViewWrapper::~WebViewWrapper()
@@ -62,6 +67,8 @@ void WebViewWrapper::loadHtmlFile(const QUrl &url)
 #ifdef USEWEBKIT
     mpPrivates->mpWebView->load(url);
 #else
+    mpPrivates->mpNotice->setText("Sorry, no WebKit or WebEngine support in this release, open in external browser!");
+    mpPrivates->mpNotice->show(); // If previously hidden by showText
     mpPrivates->mpText->setText(QString("<a href=\"%1\">%2</a>").arg(url.toString()).arg(url.toString()));
 #endif
 
@@ -72,6 +79,7 @@ void WebViewWrapper::showText(const QString &text)
 #ifdef USEWEBKIT
     mpPrivates->mpWebView->setHtml(QString("<p>%1</p>").arg(text));
 #else
+    mpPrivates->mpNotice->hide();
     mpPrivates->mpText->setText(text);
 #endif
 }

--- a/HopsanGUI/Utilities/WebviewWrapper.cpp
+++ b/HopsanGUI/Utilities/WebviewWrapper.cpp
@@ -1,0 +1,77 @@
+#include "WebviewWrapper.h"
+
+#include <QVBoxLayout>
+#include <QAction>
+#include <QToolBar>
+#ifdef USEWEBKIT
+#include <QWebView>
+#else
+#include <QLabel>
+#endif
+
+#include "common.h"
+
+class WebViewWrapperPrivates {
+public:
+    QVBoxLayout* mpLayout = nullptr;
+#ifdef USEWEBKIT
+    QWebView* mpWebView = nullptr;
+#else
+    QLabel* mpText = nullptr;
+#endif
+
+};
+
+WebViewWrapper::WebViewWrapper(const bool useToolbar, QWidget *parent) : QWidget(parent), mpPrivates(new WebViewWrapperPrivates())
+{
+    mpPrivates->mpLayout = new QVBoxLayout(this);
+#ifdef USEWEBKIT
+    mpPrivates->mpWebView = new QWebView(this);
+    if (useToolbar)
+    {
+        QAction *pBackAction = mpPrivates->mpWebView->pageAction(QWebPage::Back);
+        pBackAction->setIcon(QIcon(QString(QString(ICONPATH) + "Hopsan-StepLeft.png")));
+        QAction *pForwardAction = mpPrivates->mpWebView->pageAction(QWebPage::Forward);
+        pForwardAction->setIcon(QIcon(QString(QString(ICONPATH) + "Hopsan-StepRight.png")));
+
+        QToolBar *pToolBar = new QToolBar(this);
+        pToolBar->addAction(pBackAction);
+        pToolBar->addAction(pForwardAction);
+
+        mpPrivates->mpLayout->addWidget(pToolBar);
+    }
+    mpPrivates->mpLayout->addWidget(mpPrivates->mpWebView);
+    mpPrivates->mpLayout->setStretch(1,1);
+#else
+    Q_UNUSED(useToolbar)
+    mpPrivates->mpText = new QLabel(this);
+    mpPrivates->mpText->setOpenExternalLinks(true);
+    mpPrivates->mpLayout->addWidget(mpPrivates->mpText);
+#endif
+}
+
+WebViewWrapper::~WebViewWrapper()
+{
+    delete mpPrivates;
+    // Note! member data should be deleted automatically by qt when parent dialog is destoryed
+}
+
+
+void WebViewWrapper::loadHtmlFile(const QUrl &url)
+{
+#ifdef USEWEBKIT
+    mpPrivates->mpWebView->load(url);
+#else
+    mpPrivates->mpText->setText(QString("<a href=\"%1\">%2</a>").arg(url.toString()).arg(url.toString()));
+#endif
+
+}
+
+void WebViewWrapper::showText(const QString &text)
+{
+#ifdef USEWEBKIT
+    mpPrivates->mpWebView->setHtml(QString("<p>%1</p>").arg(text));
+#else
+    mpPrivates->mpText->setText(text);
+#endif
+}

--- a/HopsanGUI/Utilities/WebviewWrapper.h
+++ b/HopsanGUI/Utilities/WebviewWrapper.h
@@ -1,0 +1,26 @@
+#ifndef WEBVIEWWRAPPER_H
+#define WEBVIEWWRAPPER_H
+
+#include <QWidget>
+#include <QUrl>
+
+class WebViewWrapperPrivates;
+
+class WebViewWrapper : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit WebViewWrapper(const bool useToolbar, QWidget *parent = nullptr);
+    ~WebViewWrapper();
+    void loadHtmlFile(const QUrl &url);
+    void showText(const QString &text);
+
+private:
+    WebViewWrapperPrivates* mpPrivates;
+
+signals:
+
+public slots:
+};
+
+#endif // WEBVIEWWRAPPER_H

--- a/HopsanGUI/Widgets/WelcomeWidget.cpp
+++ b/HopsanGUI/Widgets/WelcomeWidget.cpp
@@ -36,14 +36,16 @@
 #include <QGridLayout>
 #include <QDebug>
 #include <QStringList>
-#include <QWebFrame>
 #include <QtXml>
-#include <QWebPage>
 #include <QNetworkReply>
 #include <QProgressBar>
 #include <QMenu>
 #include <QApplication>
 #include <QDesktopServices>
+#ifdef USEWEBKIT
+#include <QWebPage>
+#include <QWebFrame>
+#endif
 
 // Hopsan includes
 #include "Widgets/WelcomeWidget.h"
@@ -561,6 +563,8 @@ void WelcomeWidget::checkVersion(QNetworkReply *pReply)
     {
         qDebug() << pReply->url();
         QByteArray all = pReply->readAll();
+//! @todo Auto update info should not come from parsing a html page, a text or xml or such file would be better, then webview is not needed here
+#ifdef USEWEBKIT
         QWebPage page;
         page.mainFrame()->setHtml(QString(all));
         QMultiMap<QString,QString> metadata = page.mainFrame()->metaData();
@@ -582,6 +586,7 @@ void WelcomeWidget::checkVersion(QNetworkReply *pReply)
             mAUFileLink = metadata.value("hopsanupdatelink");
 #endif
         }
+#endif
     }
 }
 


### PR DESCRIPTION
In Qt 5.6 QtWebKit has been removed and QWebEngine wont build with MinGW, so there is no longer a webview.
It might be possible to build QtWebKit manually but for now lets fall back to opening html in external browser.