### PR TITLE
Change the version check to be XML based and more flexible

### DIFF
--- a/HopsanCore/include/CoreUtilities/HmfLoader.h
+++ b/HopsanCore/include/CoreUtilities/HmfLoader.h
@@ -50,8 +50,8 @@ class HopsanCoreMessageHandler;
 int DLLIMPORTEXPORT getEpochVersion(const HString& version);
 int DLLIMPORTEXPORT getMajorVersion(const HString& version);
 int DLLIMPORTEXPORT getMinorVersion(const HString& version);
-bool DLLIMPORTEXPORT isVersionGreaterThan(const HString& version1, const HString& version2);
-int DLLIMPORTEXPORT compareHopsanVersions(const HString& version1, const HString& version2);
+bool DLLIMPORTEXPORT isVersionAGreaterThanB(const HString& versionA, const HString& versionB);
+int DLLIMPORTEXPORT compareHopsanVersions(const HString& versionA, const HString& versionB);
 
 ComponentSystem* loadHopsanModelFile(const HString &rFilePath, HopsanEssentials* pHopsanEssentials, double &rStartTime, double &rStopTime);
 ComponentSystem* loadHopsanModel(const std::vector<unsigned char> xmlVector, HopsanEssentials* pHopsanEssentials);

--- a/HopsanCore/src/CoreUtilities/HmfLoader.cc
+++ b/HopsanCore/src/CoreUtilities/HmfLoader.cc
@@ -241,7 +241,7 @@ void splitFullName(const HString &rFullName, HString &rCompName, HString &rPortN
 
 void updateOldModelFileParameter(rapidxml::xml_node<> *pParameterNode, const HString &rHmfCoreVersion)
 {
-    if (isVersionGreaterThan("0.6.0", rHmfCoreVersion) || rHmfCoreVersion.containes("0.6.x_r") )
+    if (isVersionAGreaterThanB("0.6.0", rHmfCoreVersion) || rHmfCoreVersion.containes("0.6.x_r") )
     {
         if (pParameterNode)
         {
@@ -661,7 +661,7 @@ ComponentSystem* loadHopsanModelFileActual(const rapidxml::xml_document<> &rDoc,
             // Check version
             HString savedwithcoreversion = readStringAttribute(pRootNode, "hopsancoreversion", "0").c_str();
             pHopsanEssentials->getCoreMessageHandler()->addDebugMessage("Model saved with core version: " + savedwithcoreversion);
-            if (isVersionGreaterThan("0.6.0", savedwithcoreversion) || (isVersionGreaterThan(savedwithcoreversion, "0.6.x") && isVersionGreaterThan("0.6.x_r5500", savedwithcoreversion)))
+            if (isVersionAGreaterThanB("0.6.0", savedwithcoreversion) || (isVersionAGreaterThanB(savedwithcoreversion, "0.6.x") && isVersionAGreaterThanB("0.6.x_r5500", savedwithcoreversion)))
             {
                 pHopsanEssentials->getCoreMessageHandler()->addErrorMessage("This hmf model was saved with HopsanCoreVersion: "+savedwithcoreversion+". This old version is not supported by the HopsanCore hmf loader, resave the model with HopsanGUI");
                 return 0;
@@ -747,18 +747,26 @@ int hopsan::getMinorVersion(const HString& version)
   return ok ? minor : -1;  
 }
 
-bool hopsan::isVersionGreaterThan(const HString& version1, const HString& version2)
+//! @brief Check if one Hopsan version number is larger then an other
+//! @param [in] versionA The version to check
+//! @param [in] versionB The version to compare to
+//! @returns true if versionA > versionB
+bool hopsan::isVersionAGreaterThanB(const HString& versionA, const HString& versionB)
 {
-  return compareHopsanVersions(version1, version2) > 0;
+  return compareHopsanVersions(versionA, versionB) > 0;
 }
 
-int hopsan::compareHopsanVersions(const HString& version1, const HString& version2)
+//! @brief Compare two Hopsan version numbers
+//! @param [in] versionA The first version number to check
+//! @param [in] versionB The second version number to check
+//! @returns 1 if versionA > versionB, 0 if versionA == versionB, -1 if versionA < versionB
+int hopsan::compareHopsanVersions(const HString& versionA, const HString& versionB)
 {
   HVector<HString> parts1, parts2;
   HString branch1, branch2;
   //! @todo Maybe ~branchname should not really be part of the version number but only the release name
-  parts1 = version1.split('~');
-  parts2 = version2.split('~');
+  parts1 = versionA.split('~');
+  parts2 = versionB.split('~');
   if (parts1.size() > 1)
   {
     branch1 = parts1[1];
@@ -788,7 +796,7 @@ int hopsan::compareHopsanVersions(const HString& version1, const HString& versio
     // Handle comparison of the old version number format
     if (i==0 && v1==0)
     {
-      oldversionformat::isVersionGreaterThan(version1, version2);
+      oldversionformat::isVersionGreaterThan(versionA, versionB);
     }
     
 

--- a/HopsanGUI/Configuration.cpp
+++ b/HopsanGUI/Configuration.cpp
@@ -1292,6 +1292,7 @@ void Configuration::registerSettings()
     mBoolSettings.insert(CFG_PROGRESSBAR, true);
     mBoolSettings.insert(CFG_SETPWDTOMWD, false);
     mBoolSettings.insert(CFG_SHOWLICENSEONSTARTUP, true);
+    mBoolSettings.insert(CFG_CHECKFORDEVELOPMENTUPDATES, false);
 #ifdef _WIN32
     mBoolSettings.insert(CFG_PREFERINCLUDEDCOMPILER, true);
 #else

--- a/HopsanGUI/Configuration.h
+++ b/HopsanGUI/Configuration.h
@@ -40,6 +40,7 @@
 #define CFG_LIBRARYSTYLE "librarystyle"
 #define CFG_PLOEXPORTVERSION "ploexportversion"
 
+#define CFG_CHECKFORDEVELOPMENTUPDATES "checkfordevelopmentupdates"
 #define CFG_SHOWLICENSEONSTARTUP "showlicenseonstartup2"
 #define CFG_SHOWHIDDENNODEDATAVARIABLES "showhiddennodedatavariables"
 #define CFG_SHOWPOPUPHELP "showpopuphelp"

--- a/HopsanGUI/Configuration.h
+++ b/HopsanGUI/Configuration.h
@@ -40,7 +40,7 @@
 #define CFG_LIBRARYSTYLE "librarystyle"
 #define CFG_PLOEXPORTVERSION "ploexportversion"
 
-#define CFG_SHOWLICENSEONSTARTUP "showlicenseonstartup2.8"
+#define CFG_SHOWLICENSEONSTARTUP "showlicenseonstartup2"
 #define CFG_SHOWHIDDENNODEDATAVARIABLES "showhiddennodedatavariables"
 #define CFG_SHOWPOPUPHELP "showpopuphelp"
 #define CFG_NATIVESTYLESHEET "nativestylesheet"

--- a/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
+++ b/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
@@ -41,8 +41,6 @@
 #include <QHeaderView>
 #include <QScrollBar>
 #include <QMenu>
-#include <QWebView>
-#include <QWebFrame>
 #include <QMainWindow>
 #include <QLineEdit>
 #include <QGroupBox>
@@ -65,6 +63,7 @@
 #include "UndoStack.h"
 #include "Utilities/GUIUtilities.h"
 #include "Utilities/HighlightingUtilities.h"
+#include "Utilities/WebviewWrapper.h"
 #include "LibraryHandler.h"
 #include "Widgets/ModelWidget.h"
 #include "Widgets/SystemParametersWidget.h"
@@ -456,7 +455,7 @@ QWidget *ComponentPropertiesDialog3::createHelpWidget()
 
         if (!mpModelObject->getHelpHtmlPath().isEmpty())
         {
-            QWebView * pHtmlView = new QWebView();
+            WebViewWrapper* pHtmlView = new WebViewWrapper(false);
             QString path = mpModelObject->getAppearanceData()->getBasePath() + mpModelObject->getHelpHtmlPath();
             if (path.endsWith(".md"))
             {
@@ -585,19 +584,19 @@ QWidget *ComponentPropertiesDialog3::createHelpWidget()
                     }
 
                     // Set html to view
-                    pHtmlView->load(QUrl::fromLocalFile(htmlFilePath));
+                    pHtmlView->loadHtmlFile(QUrl::fromLocalFile(htmlFilePath));
                 }
                 else
                 {
-                    pHtmlView->setHtml(QString("<p>Error: Could not convert %1 to HTML or load the file.</p>").arg(path));
+                    pHtmlView->showText(QString("Error: Could not convert %1 to HTML or load the file.").arg(path));
                 }
 #else
-                pHtmlView->setHtml(QString("<p>Error: Markdown support is not available in this build!</p>").arg(path));
+                pHtmlView->showText(QString("Error: Markdown support is not available in this build!").arg(path));
 #endif
             }
             else
             {
-                pHtmlView->load(QUrl::fromLocalFile(path));
+                pHtmlView->loadHtmlFile(QUrl::fromLocalFile(path));
             }
             pHelpLayout->addWidget(pHtmlView);
         }

--- a/HopsanGUI/Dialogs/HelpDialog.cpp
+++ b/HopsanGUI/Dialogs/HelpDialog.cpp
@@ -32,7 +32,7 @@
 //$Id$
 
 //Qt includes
-#include <QWebView>
+#include <QUrl>
 #include <QToolBar>
 #include <QVBoxLayout>
 #include <QApplication>
@@ -62,22 +62,9 @@ HelpDialog::HelpDialog(QWidget *parent)
     this->setMinimumSize(640, 480);
     this->setWindowModality(Qt::NonModal);
 
-    mpHelp = new QWebView(this);
-
-    QAction *pBackAction = mpHelp->pageAction(QWebPage::Back);
-    pBackAction->setIcon(QIcon(QString(QString(ICONPATH) + "Hopsan-StepLeft.png")));
-    QAction *pForwardAction = mpHelp->pageAction(QWebPage::Forward);
-    pForwardAction->setIcon(QIcon(QString(QString(ICONPATH) + "Hopsan-StepRight.png")));
-
-    QToolBar *pToolBar = new QToolBar(this);
-    pToolBar->addAction(pBackAction);
-    pToolBar->addAction(pForwardAction);
-
     QVBoxLayout *pLayout = new QVBoxLayout(this);
-    pLayout->addWidget(pToolBar);
+    mpHelp = new WebViewWrapper(true, this);
     pLayout->addWidget(mpHelp);
-    pLayout->setStretch(1,1);
-    this->setLayout(pLayout);
 
     //! @todo Set size depending one screen size
     this->resize(1024,768);
@@ -86,7 +73,7 @@ HelpDialog::HelpDialog(QWidget *parent)
 
 void HelpDialog::open()
 {
-    mpHelp->load(QUrl::fromLocalFile(gpDesktopHandler->getHelpPath() + "index.html"));
+    mpHelp->loadHtmlFile(QUrl::fromLocalFile(gpDesktopHandler->getHelpPath() + "index.html"));
 
     //Using show instead of open for modaless window
     QDialog::show();
@@ -95,7 +82,7 @@ void HelpDialog::open()
 
 void HelpDialog::open(QString file)
 {
-    mpHelp->load(QUrl::fromLocalFile(gpDesktopHandler->getHelpPath() + file));
+    mpHelp->loadHtmlFile(QUrl::fromLocalFile(gpDesktopHandler->getHelpPath() + file));
 
     //Using show instead of open for modaless window
     QDialog::show();

--- a/HopsanGUI/Dialogs/HelpDialog.h
+++ b/HopsanGUI/Dialogs/HelpDialog.h
@@ -34,8 +34,8 @@
 #ifndef HELPDIALOG_H
 #define HELPDIALOG_H
 
-#include <QWebView>
 #include <QDialog>
+#include "Utilities/WebviewWrapper.h"
 
 class HelpDialog : public QDialog
 {
@@ -50,7 +50,7 @@ public slots:
     void centerOnScreen();
 
 private:
-    QWebView *mpHelp;
+    WebViewWrapper *mpHelp;
 };
 
 #endif // HELPDIALOG_H

--- a/HopsanGUI/Dialogs/OptionsDialog.cpp
+++ b/HopsanGUI/Dialogs/OptionsDialog.cpp
@@ -265,6 +265,8 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     mpShowPopupHelpCheckBox = new QCheckBox(tr("Show Popup Help Messages"));
     mpShowPopupHelpCheckBox->setCheckable(true);
 
+    mpCheckDevelopmentUpdatesCheckBox = new QCheckBox(tr("Check for development snapshot updates"));
+    mpCheckDevelopmentUpdatesCheckBox->setCheckable(true);
 
     mpAntiAliasingCheckBox = new QCheckBox(tr("Use Anti-Aliasing"));
     mpAntiAliasingCheckBox->setCheckable(true);
@@ -297,7 +299,11 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     pInterfaceLayout->addWidget(pBackgroundColorLabel,         8, 0);
     pInterfaceLayout->addWidget(mpBackgroundColorButton,       8, 1);
     pInterfaceLayout->addWidget(new QWidget(),                 9, 0, 1, 2);
-    pInterfaceLayout->setRowStretch(8,1);
+    pInterfaceLayout->addWidget(new QLabel(tr("New version check:")), 10, 0);
+    pInterfaceLayout->addWidget(mpCheckDevelopmentUpdatesCheckBox, 11, 0);
+    pInterfaceLayout->addWidget(new QWidget(),                 12, 0, 1, 2);
+    pInterfaceLayout->setRowStretch(9,1);
+    pInterfaceLayout->setRowStretch(12,1);
     mpInterfaceWidget->setLayout(pInterfaceLayout);
 
         //Simulation Options
@@ -545,6 +551,7 @@ void OptionsDialog::setValues()
 
     gpConfig->setBoolSetting(CFG_SHOWPOPUPHELP, mpShowPopupHelpCheckBox->isChecked());
     gpConfig->setBoolSetting(CFG_NATIVESTYLESHEET, mpNativeStyleSheetCheckBox->isChecked());
+    gpConfig->setBoolSetting(CFG_CHECKFORDEVELOPMENTUPDATES, mpCheckDevelopmentUpdatesCheckBox->isChecked());
 
     if(gpConfig->getBoolSetting(CFG_NATIVESTYLESHEET))
     {
@@ -672,6 +679,7 @@ void OptionsDialog::show()
     mpBackgroundColorButton->setStyleSheet(buttonStyle);
     mPickedBackgroundColor = gpConfig->getBackgroundColor();
 
+    mpCheckDevelopmentUpdatesCheckBox->setChecked(gpConfig->getBoolSetting(CFG_CHECKFORDEVELOPMENTUPDATES));
     mpNativeStyleSheetCheckBox->setChecked(gpConfig->getBoolSetting(CFG_NATIVESTYLESHEET));
     mpShowPopupHelpCheckBox->setChecked(gpConfig->getBoolSetting(CFG_SHOWPOPUPHELP));
     mpAntiAliasingCheckBox->setChecked(gpConfig->getBoolSetting(CFG_ANTIALIASING));

--- a/HopsanGUI/Dialogs/OptionsDialog.h
+++ b/HopsanGUI/Dialogs/OptionsDialog.h
@@ -73,6 +73,7 @@ private:
     QWidget *mpInterfaceWidget;
     QToolButton *mpBackgroundColorButton;
     QColor mPickedBackgroundColor;
+    QCheckBox *mpCheckDevelopmentUpdatesCheckBox;
     QCheckBox *mpNativeStyleSheetCheckBox;
     QCheckBox *mpShowPopupHelpCheckBox;
     QCheckBox *mpInvertWheelCheckBox;

--- a/HopsanGUI/HopsanGUI.pro
+++ b/HopsanGUI/HopsanGUI.pro
@@ -14,7 +14,14 @@ QT += svg xml
 QT += core gui network
 
 isEqual(QT_MAJOR_VERSION, 5){
-    QT += widgets webkitwidgets printsupport
+    QT += widgets printsupport
+    qtHaveModule(webkitwidgets) {
+        QT += webkitwidgets
+        DEFINES *= USEWEBKIT
+        message(Using WebKit)
+    } else {
+        message(WebKit is not available)
+    }
 } else {
     QT += webkit
 }
@@ -280,7 +287,8 @@ SOURCES += main.cpp \
     Dialogs/LicenseDialog.cpp \
     Widgets/TimeOffsetWidget.cpp \
     Dialogs/NumHopScriptDialog.cpp \
-    PlotCurveStyle.cpp
+    PlotCurveStyle.cpp \
+    Utilities/WebviewWrapper.cpp
 
 HEADERS += MainWindow.h \
     Widgets/ProjectTabWidget.h \
@@ -370,7 +378,8 @@ HEADERS += MainWindow.h \
     Utilities/EventFilters.h \
     Widgets/TimeOffsetWidget.h \
     Dialogs/NumHopScriptDialog.h \
-    PlotCurveStyle.h
+    PlotCurveStyle.h \
+    Utilities/WebviewWrapper.h
 
     contains(DEFINES, USEPYTHONQT) {
         SOURCES += Widgets/PyDockWidget.cpp

--- a/HopsanGUI/Utilities/GUIUtilities.cpp
+++ b/HopsanGUI/Utilities/GUIUtilities.cpp
@@ -946,7 +946,7 @@ QString extractFilenameExtension(const QString &rFilename)
 
 bool isVersionGreaterThan(QString v1, QString v2)
 {
-    return hopsan::isVersionGreaterThan(v1.toStdString().c_str(), v2.toStdString().c_str());
+    return hopsan::isVersionAGreaterThanB(v1.toStdString().c_str(), v2.toStdString().c_str());
 }
 
 //! @brief Extracts the dirPath, fileName (including suffix), and the suffix from a file path

--- a/HopsanGUI/Utilities/WebviewWrapper.cpp
+++ b/HopsanGUI/Utilities/WebviewWrapper.cpp
@@ -17,6 +17,7 @@ public:
 #ifdef USEWEBKIT
     QWebView* mpWebView = nullptr;
 #else
+    QLabel* mpNotice = nullptr;
     QLabel* mpText = nullptr;
 #endif
 
@@ -44,10 +45,14 @@ WebViewWrapper::WebViewWrapper(const bool useToolbar, QWidget *parent) : QWidget
     mpPrivates->mpLayout->setStretch(1,1);
 #else
     Q_UNUSED(useToolbar)
+    mpPrivates->mpNotice = new QLabel(this);
     mpPrivates->mpText = new QLabel(this);
     mpPrivates->mpText->setOpenExternalLinks(true);
+    mpPrivates->mpLayout->addWidget(mpPrivates->mpNotice);
     mpPrivates->mpLayout->addWidget(mpPrivates->mpText);
+    mpPrivates->mpLayout->addStretch(1);
 #endif
+
 }
 
 WebViewWrapper::~WebViewWrapper()
@@ -62,6 +67,8 @@ void WebViewWrapper::loadHtmlFile(const QUrl &url)
 #ifdef USEWEBKIT
     mpPrivates->mpWebView->load(url);
 #else
+    mpPrivates->mpNotice->setText("Sorry, no WebKit or WebEngine support in this release, open in external browser!");
+    mpPrivates->mpNotice->show(); // If previously hidden by showText
     mpPrivates->mpText->setText(QString("<a href=\"%1\">%2</a>").arg(url.toString()).arg(url.toString()));
 #endif
 
@@ -72,6 +79,7 @@ void WebViewWrapper::showText(const QString &text)
 #ifdef USEWEBKIT
     mpPrivates->mpWebView->setHtml(QString("<p>%1</p>").arg(text));
 #else
+    mpPrivates->mpNotice->hide();
     mpPrivates->mpText->setText(text);
 #endif
 }

--- a/HopsanGUI/Utilities/WebviewWrapper.cpp
+++ b/HopsanGUI/Utilities/WebviewWrapper.cpp
@@ -1,0 +1,77 @@
+#include "WebviewWrapper.h"
+
+#include <QVBoxLayout>
+#include <QAction>
+#include <QToolBar>
+#ifdef USEWEBKIT
+#include <QWebView>
+#else
+#include <QLabel>
+#endif
+
+#include "common.h"
+
+class WebViewWrapperPrivates {
+public:
+    QVBoxLayout* mpLayout = nullptr;
+#ifdef USEWEBKIT
+    QWebView* mpWebView = nullptr;
+#else
+    QLabel* mpText = nullptr;
+#endif
+
+};
+
+WebViewWrapper::WebViewWrapper(const bool useToolbar, QWidget *parent) : QWidget(parent), mpPrivates(new WebViewWrapperPrivates())
+{
+    mpPrivates->mpLayout = new QVBoxLayout(this);
+#ifdef USEWEBKIT
+    mpPrivates->mpWebView = new QWebView(this);
+    if (useToolbar)
+    {
+        QAction *pBackAction = mpPrivates->mpWebView->pageAction(QWebPage::Back);
+        pBackAction->setIcon(QIcon(QString(QString(ICONPATH) + "Hopsan-StepLeft.png")));
+        QAction *pForwardAction = mpPrivates->mpWebView->pageAction(QWebPage::Forward);
+        pForwardAction->setIcon(QIcon(QString(QString(ICONPATH) + "Hopsan-StepRight.png")));
+
+        QToolBar *pToolBar = new QToolBar(this);
+        pToolBar->addAction(pBackAction);
+        pToolBar->addAction(pForwardAction);
+
+        mpPrivates->mpLayout->addWidget(pToolBar);
+    }
+    mpPrivates->mpLayout->addWidget(mpPrivates->mpWebView);
+    mpPrivates->mpLayout->setStretch(1,1);
+#else
+    Q_UNUSED(useToolbar)
+    mpPrivates->mpText = new QLabel(this);
+    mpPrivates->mpText->setOpenExternalLinks(true);
+    mpPrivates->mpLayout->addWidget(mpPrivates->mpText);
+#endif
+}
+
+WebViewWrapper::~WebViewWrapper()
+{
+    delete mpPrivates;
+    // Note! member data should be deleted automatically by qt when parent dialog is destoryed
+}
+
+
+void WebViewWrapper::loadHtmlFile(const QUrl &url)
+{
+#ifdef USEWEBKIT
+    mpPrivates->mpWebView->load(url);
+#else
+    mpPrivates->mpText->setText(QString("<a href=\"%1\">%2</a>").arg(url.toString()).arg(url.toString()));
+#endif
+
+}
+
+void WebViewWrapper::showText(const QString &text)
+{
+#ifdef USEWEBKIT
+    mpPrivates->mpWebView->setHtml(QString("<p>%1</p>").arg(text));
+#else
+    mpPrivates->mpText->setText(text);
+#endif
+}

--- a/HopsanGUI/Utilities/WebviewWrapper.h
+++ b/HopsanGUI/Utilities/WebviewWrapper.h
@@ -1,0 +1,26 @@
+#ifndef WEBVIEWWRAPPER_H
+#define WEBVIEWWRAPPER_H
+
+#include <QWidget>
+#include <QUrl>
+
+class WebViewWrapperPrivates;
+
+class WebViewWrapper : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit WebViewWrapper(const bool useToolbar, QWidget *parent = nullptr);
+    ~WebViewWrapper();
+    void loadHtmlFile(const QUrl &url);
+    void showText(const QString &text);
+
+private:
+    WebViewWrapperPrivates* mpPrivates;
+
+signals:
+
+public slots:
+};
+
+#endif // WEBVIEWWRAPPER_H

--- a/HopsanGUI/Widgets/WelcomeWidget.cpp
+++ b/HopsanGUI/Widgets/WelcomeWidget.cpp
@@ -798,4 +798,6 @@ void WelcomeWidget::launchAutoUpdate()
 
     mpAUDownloadStatus = pNetworkManager->get(QNetworkRequest(QUrl(mAUFileLink)));
     connect(mpAUDownloadStatus, SIGNAL(downloadProgress(qint64,qint64)), this, SLOT(updateDownloadProgressBar(qint64, qint64)));
+    connect(mpAUDownloadDialog, SIGNAL(canceled()), mpAUDownloadStatus, SLOT(abort()));
+    connect(mpAUDownloadDialog, SIGNAL(canceled()), mpAUDownloadDialog, SLOT(close()));
 }

--- a/HopsanGUI/Widgets/WelcomeWidget.cpp
+++ b/HopsanGUI/Widgets/WelcomeWidget.cpp
@@ -664,14 +664,13 @@ void WelcomeWidget::checkVersion(QNetworkReply *pReply)
                     official_releases = parseHopsanReleases(reader, HOPSANGUIVERSION);
                 }
 
-                if (reader.readNextStartElement() && reader.name() == "development")
+                if (reader.readNextStartElement() && gpConfig->getBoolSetting(CFG_CHECKFORDEVELOPMENTUPDATES) && reader.name() == "development")
                 {
                     development_release = parseHopsanReleases(reader, HOPSANGUIVERSION);
                 }
             }
         }
 
-        //! @todo Check config option if development should be included
         if (official_releases.size() + development_release.size() > 0)
         {
             // Assume sorted, first is highest

--- a/HopsanGUI/Widgets/WelcomeWidget.cpp
+++ b/HopsanGUI/Widgets/WelcomeWidget.cpp
@@ -36,14 +36,16 @@
 #include <QGridLayout>
 #include <QDebug>
 #include <QStringList>
-#include <QWebFrame>
 #include <QtXml>
-#include <QWebPage>
 #include <QNetworkReply>
 #include <QProgressBar>
 #include <QMenu>
 #include <QApplication>
 #include <QDesktopServices>
+#ifdef USEWEBKIT
+#include <QWebPage>
+#include <QWebFrame>
+#endif
 
 // Hopsan includes
 #include "Widgets/WelcomeWidget.h"
@@ -561,6 +563,8 @@ void WelcomeWidget::checkVersion(QNetworkReply *pReply)
     {
         qDebug() << pReply->url();
         QByteArray all = pReply->readAll();
+//! @todo Auto update info should not come from parsing a html page, a text or xml or such file would be better, then webview is not needed here
+#ifdef USEWEBKIT
         QWebPage page;
         page.mainFrame()->setHtml(QString(all));
         QMultiMap<QString,QString> metadata = page.mainFrame()->metaData();
@@ -582,6 +586,7 @@ void WelcomeWidget::checkVersion(QNetworkReply *pReply)
             mAUFileLink = metadata.value("hopsanupdatelink");
 #endif
         }
+#endif
     }
 }
 

--- a/HopsanGUI/Widgets/WelcomeWidget.cpp
+++ b/HopsanGUI/Widgets/WelcomeWidget.cpp
@@ -373,9 +373,9 @@ WelcomeWidget::WelcomeWidget(QWidget *parent) :
 
     QMenu *pNewVersionMenu = new QMenu(this);
 #ifdef _WIN32
-    QAction *pAutoUpdateAction = new QAction("Launch Auto Updater", this);
-    pNewVersionMenu->addAction(pAutoUpdateAction);
-    connect(pAutoUpdateAction, SIGNAL(triggered()), this, SLOT(launchAutoUpdate()));
+    mpAutoUpdateAction = new QAction("Launch Auto Updater", this);
+    pNewVersionMenu->addAction(mpAutoUpdateAction);
+    connect(mpAutoUpdateAction, SIGNAL(triggered()), this, SLOT(launchAutoUpdate()));
 #endif
     QAction *pGoToDownloadPageAction = new QAction("Open Download Page In Browser", this);
     pNewVersionMenu->addAction(pGoToDownloadPageAction);
@@ -690,6 +690,12 @@ void WelcomeWidget::checkVersion(QNetworkReply *pReply)
             else
             {
                 mAUFileLink = newest_release.url_installer;
+            }
+
+            // Disable auto update if no file given
+            if (mpAutoUpdateAction && mAUFileLink.isEmpty())
+            {
+                mpAutoUpdateAction->setDisabled(true);
             }
         }
     }

--- a/HopsanGUI/Widgets/WelcomeWidget.cpp
+++ b/HopsanGUI/Widgets/WelcomeWidget.cpp
@@ -36,16 +36,15 @@
 #include <QGridLayout>
 #include <QDebug>
 #include <QStringList>
-#include <QtXml>
+#include <QTimer>
+#include <QDir>
+#include <QXmlStreamReader>
 #include <QNetworkReply>
 #include <QProgressBar>
 #include <QMenu>
 #include <QApplication>
 #include <QDesktopServices>
-#ifdef USEWEBKIT
-#include <QWebPage>
-#include <QWebFrame>
-#endif
+#include <QProcess>
 
 // Hopsan includes
 #include "Widgets/WelcomeWidget.h"
@@ -59,6 +58,97 @@
 #include "MessageHandler.h"
 #include "version_gui.h"
 
+// Hopsan Core includes
+#include "CoreUtilities/HmfLoader.h"
+
+namespace {
+
+struct HopsanRelease
+{
+    QString version;
+    QString url;
+    QString url_installer;
+    QString url_installer_wo_compiler;
+};
+
+QVector<HopsanRelease> parseHopsanReleases(QXmlStreamReader &reader, const QString &minimumVersion)
+{
+    QVector<HopsanRelease> releases;
+    while (reader.readNextStartElement() && reader.name() == "release")
+    {
+        bool addThis = true;
+        HopsanRelease release;
+        while (reader.readNextStartElement())
+        {
+            if (reader.name() == "version")
+            {
+                release.version =  reader.readElementText();
+                addThis = hopsan::isVersionAGreaterThanB( release.version.toStdString().c_str(), minimumVersion.toStdString().c_str());
+            }
+
+            if (reader.name() == "url")
+            {
+                release.url = reader.readElementText();
+            }
+#ifdef _WIN32
+#ifdef HOPSANCOMPILED64BIT
+            if (reader.name() == "win64_installer")
+            {
+                release.url_installer = reader.readElementText();
+            }
+
+            if (reader.name() == "win64_installer_wo_compiler")
+            {
+                release.url_installer_wo_compiler = reader.readElementText();
+            }
+#else
+            if (reader.name() == "win32_installer")
+            {
+                release.url_installer = reader.readElementText();
+            }
+
+            if (reader.name() == "win32_installer_wo_compiler")
+            {
+                release.url_installer_wo_compiler = reader.readElementText();
+            }
+#endif
+#endif
+        }
+
+        if (addThis)
+        {
+            releases.append(release);
+        }
+    }
+    return releases;
+}
+
+HopsanRelease getNewestRelease(QVector<HopsanRelease> &official, QVector<HopsanRelease> &development)
+{
+    // Assume sorted, newest first
+    if (official.isEmpty() && !development.isEmpty())
+    {
+        return development.front();
+    }
+    else if (!official.isEmpty() && development.isEmpty())
+    {
+        return official.front();
+    }
+    else
+    {
+        if (hopsan::isVersionAGreaterThanB(official.front().version.toStdString().c_str(),
+                                           development.front().version.toStdString().c_str()))
+        {
+            return official.front();
+        }
+        else
+        {
+            return development.front();
+        }
+    }
+}
+
+} // End anonymous namespace
 
 WelcomeWidget::WelcomeWidget(QWidget *parent) :
     QWidget(parent)
@@ -363,12 +453,6 @@ void WelcomeWidget::mouseMoveEvent(QMouseEvent *event)
 }
 
 
-void WelcomeWidget::debugSlot()
-{
-    qDebug() << "Debug slot!";
-}
-
-
 void WelcomeWidget::updateHoverEffects()
 {
     if(mpNewFrame->underMouse())
@@ -561,32 +645,53 @@ void WelcomeWidget::checkVersion(QNetworkReply *pReply)
 
     if (pReply->error() == QNetworkReply::NoError)
     {
-        qDebug() << pReply->url();
         QByteArray all = pReply->readAll();
-//! @todo Auto update info should not come from parsing a html page, a text or xml or such file would be better, then webview is not needed here
-#ifdef USEWEBKIT
-        QWebPage page;
-        page.mainFrame()->setHtml(QString(all));
-        QMultiMap<QString,QString> metadata = page.mainFrame()->metaData();
+        QXmlStreamReader reader(all);
 
-        //Verify that the loaded page is the correct one, otherwise do not show it
-        if(metadata.contains("type", "hopsanngnews"))
+        QString format;
+        QVector<HopsanRelease> official_releases, development_release;
+        while (!reader.atEnd())
         {
-            QString webVersionString = metadata.find("hopsanversionfull").value();
-            mpNewVersionButton->setText("Version " + webVersionString + " is now available!");
+            if (reader.readNextStartElement() && reader.name() == "hopsan_releases")
+            {
+                format = reader.attributes().value("format").toString();
+            }
+
+            if (format == "1")
+            {
+                if (reader.readNextStartElement() && reader.name() == "official")
+                {
+                    official_releases = parseHopsanReleases(reader, HOPSANGUIVERSION);
+                }
+
+                if (reader.readNextStartElement() && reader.name() == "development")
+                {
+                    development_release = parseHopsanReleases(reader, HOPSANGUIVERSION);
+                }
+            }
+        }
+
+        //! @todo Check config option if development should be included
+        if (official_releases.size() + development_release.size() > 0)
+        {
+            // Assume sorted, first is highest
+            HopsanRelease newest_release = getNewestRelease(official_releases, development_release);
+
+            mpNewVersionButton->setText("Version " + newest_release.version + " is now available!");
 #ifdef DEVELOPMENT
             mpNewVersionButton->setVisible(true);
 #else
-            //const QString thisVersionString = QString(HOPSANGUIVERSION);
-            mpNewVersionButton->setVisible(isHospanGUIVersionHigherThan(webVersionString.toStdString().c_str()));
+            mpNewVersionButton->setVisible(isVersionHigherThanCurrentHospanGUI(newest_release.version.toStdString().c_str()));
 #endif
-#ifdef HOPSANCOMPILED64BIT
-            mAUFileLink = metadata.value("hopsanupdatelink64");
-#else
-            mAUFileLink = metadata.value("hopsanupdatelink");
-#endif
+            if (gpDesktopHandler->getIncludedCompilerPath().isEmpty())
+            {
+                mAUFileLink = newest_release.url_installer_wo_compiler;
+            }
+            else
+            {
+                mAUFileLink = newest_release.url_installer;
+            }
         }
-#endif
     }
 }
 
@@ -640,17 +745,19 @@ void WelcomeWidget::updateDownloadProgressBar(qint64 bytesReceived, qint64 bytes
 //! @param reply Contains information about the downloaded installation executable
 void WelcomeWidget::commenceAutoUpdate(QNetworkReply* reply)
 {
-    QUrl url = reply->url();
+    QFileInfo auf_info(mAUFileLink);
+    const QString file_name = gpDesktopHandler->getDataPath()+QString("/%1").arg(auf_info.fileName());
+    QUrl update_url = reply->url();
     if (reply->error())
     {
-        gpMessageHandler->addErrorMessage("Download of " + QString(url.toEncoded().constData()) + "failed: "+reply->errorString()+"\n");
+        gpMessageHandler->addErrorMessage("Download of " + QString(update_url.toEncoded().constData()) + "failed: "+reply->errorString()+"\n");
         return;
     }
     else
     {
-        QFile file(gpDesktopHandler->getDataPath()+"update.exe");
+        QFile file(file_name);
         if (!file.open(QIODevice::WriteOnly)) {
-            gpMessageHandler->addErrorMessage("Could not open update.exe for writing.");
+            gpMessageHandler->addErrorMessage(QString("Could not open %1 for writing.").arg(file_name));
             return;
         }
         file.write(reply->readAll());
@@ -665,8 +772,8 @@ void WelcomeWidget::commenceAutoUpdate(QNetworkReply* reply)
     // Note Do NOT add "dir" quotes to dir here, then QProcess or innosetup will somehow messup the dir argument and add C:\ twice.
     // QProcess::start will add " " automatically if needed (on windows)
     arguments << QString("/dir=%1").arg(dir);
-    pProcess->start(gpDesktopHandler->getDataPath()+"update.exe", arguments);
-    pProcess->waitForStarted();
+    pProcess->startDetached(file_name, arguments);
+    pProcess->deleteLater();
     QApplication::quit();
 }
 
@@ -677,14 +784,12 @@ void WelcomeWidget::launchAutoUpdate()
     QNetworkAccessManager *pNetworkManager = new QNetworkAccessManager();
     connect(pNetworkManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(commenceAutoUpdate(QNetworkReply*)));
 
-    QUrl url = QUrl(mAUFileLink);
-
     mpAUDownloadDialog = new QProgressDialog("Downloading new version...", "Cancel",0, 100, this);
     mpAUDownloadDialog->setWindowTitle("Hopsan Auto Updater");
     mpAUDownloadDialog->setWindowModality(Qt::WindowModal);
     mpAUDownloadDialog->setMinimumWidth(300);
     mpAUDownloadDialog->setValue(0);
 
-    mpAUDownloadStatus = pNetworkManager->get(QNetworkRequest(url));
+    mpAUDownloadStatus = pNetworkManager->get(QNetworkRequest(QUrl(mAUFileLink)));
     connect(mpAUDownloadStatus, SIGNAL(downloadProgress(qint64,qint64)), this, SLOT(updateDownloadProgressBar(qint64, qint64)));
 }

--- a/HopsanGUI/Widgets/WelcomeWidget.h
+++ b/HopsanGUI/Widgets/WelcomeWidget.h
@@ -112,7 +112,6 @@ public slots:
     void autoHide();
 
 private slots:
-    void debugSlot();
     void updateHoverEffects();
     void openRecentModel();
     void openExampleModel();

--- a/HopsanGUI/Widgets/WelcomeWidget.h
+++ b/HopsanGUI/Widgets/WelcomeWidget.h
@@ -103,6 +103,7 @@ private:
     QPushButton *mpNewVersionButton;
     QNetworkReply *mpAUDownloadStatus;
     QProgressDialog *mpAUDownloadDialog;
+    QAction *mpAutoUpdateAction=nullptr;
     QString mAUFileLink;
 
 signals:

--- a/HopsanGUI/common.h
+++ b/HopsanGUI/common.h
@@ -94,6 +94,6 @@ enum HiddenVisibleEnumT {Hidden, Visible};
 enum LocklevelEnumT {NotLocked, LimitedLock, FullyLocked};
 
 extern const char* getHopsanGUIBuildTime();
-extern bool isHospanGUIVersionHigherThan(const char*);
+extern bool isVersionHigherThanCurrentHospanGUI(const char*);
 
 #endif // COMMON_H

--- a/HopsanGUI/common.h
+++ b/HopsanGUI/common.h
@@ -41,10 +41,9 @@
 
 // Web link definitions
 #define HOPSANLINK "http://tiny.cc/hopsan"
-#define VERSIONLINK "http://tiny.cc/hopsannews"
+#define VERSIONLINK "http://tiny.cc/hopsanreleases"
 #define NEWSLINK "http://tiny.cc/hopsannewsfeed"
 #define DOWNLOADLINK "http://tiny.cc/hopsanarchive"
-#define AUTOUPDATELINK "http://tiny.cc/hopsanupdate"
 
 // Path definitions (development and release)
 // qrc paths

--- a/HopsanGUI/main.cpp
+++ b/HopsanGUI/main.cpp
@@ -158,7 +158,7 @@ const char* getHopsanGUIBuildTime()
 }
 
 
-bool isHospanGUIVersionHigherThan(const char *version)
+bool isVersionHigherThanCurrentHospanGUI(const char *version)
 {
-    return hopsan::isVersionGreaterThan(QString(version).toStdString().c_str(), QString(HOPSANGUIVERSION).toStdString().c_str());
+    return hopsan::isVersionAGreaterThanB(QString(version).toStdString().c_str(), QString(HOPSANGUIVERSION).toStdString().c_str());
 }

--- a/UnitTests/HopsanCoreTests/UtilitiesTest/tst_utilitiestesttest.cpp
+++ b/UnitTests/HopsanCoreTests/UtilitiesTest/tst_utilitiestesttest.cpp
@@ -54,8 +54,8 @@ private Q_SLOTS:
         QFETCH(QString, version1);
         QFETCH(QString, version2);
         QFETCH(bool, ans);
-        bool test = isVersionGreaterThan(version1.toStdString().c_str(), version2.toStdString().c_str());
-        QVERIFY2(isVersionGreaterThan(version1.toStdString().c_str(), version2.toStdString().c_str()) == ans, "Version check returned wrong answer.");
+        bool test = isVersionAGreaterThanB(version1.toStdString().c_str(), version2.toStdString().c_str());
+        QVERIFY2(isVersionAGreaterThanB(version1.toStdString().c_str(), version2.toStdString().c_str()) == ans, "Version check returned wrong answer.");
     }
 
     void Version_Check_data()


### PR DESCRIPTION
Since QWebView might not be available on Qt  >=5.6 builds we should use XML instead of HTML meta data for the version information.
This PR also make general improvements to the version check and auto update code.