### PR TITLE
Removed unused include.

### DIFF
--- a/HopsanCore/src/ComponentSystem.cc
+++ b/HopsanCore/src/ComponentSystem.cc
@@ -49,7 +49,6 @@
 #include <chrono>
 #include <ctime>
 #endif
-#include <unistd.h>
 
 #include "ComponentSystem.h"
 #include "CoreUtilities/HopsanCoreMessageHandler.h"


### PR DESCRIPTION
This include fails to compile in Matlab using MSVC, since it only exists on Unix systems. It seems like it is not used anywhere, so I removed it.