### PR TITLE
Fix trusty build for 2.8.1

### DIFF
--- a/HopsanGUI/Widgets/WelcomeWidget.cpp
+++ b/HopsanGUI/Widgets/WelcomeWidget.cpp
@@ -43,6 +43,7 @@
 #include <QApplication>
 #include <QDesktopServices>
 #include <QProcess>
+#include <QDate>
 
 // Hopsan includes
 #include "Widgets/WelcomeWidget.h"

--- a/buildDebPackage/copyInstallHopsan.sh
+++ b/buildDebPackage/copyInstallHopsan.sh
@@ -63,8 +63,13 @@ cp -a    $srcDir/hopsandefaults                            $dstDir
 cp -a    $srcDir/Hopsan-release-notes.txt                  $dstDir
 
 # Strip any runpaths to Dependencies directory
-# from ELF binaries. Note! ($ORIGIN/./) will remain
-# =================================================
-mv ${srcDeps} ${srcDeps}_temporary
-find ${dstDir}/bin -type f -executable -exec patchelf --shrink-rpath {} \;
-mv ${srcDeps}_temporary ${srcDeps}
+# from ELF binaries. Note! ($ORIGIN/./) will remain.
+# By first moving the source dependencies directory
+# the runpaths will no longer be valid and patchelf
+# will remove them.
+# ==================================================
+if [[ $(command -v patchelf) ]]; then
+  mv ${srcDeps} ${srcDeps}_temporary
+  find ${dstDir}/bin -type f -executable -exec patchelf --shrink-rpath {} \;
+  mv ${srcDeps}_temporary ${srcDeps}
+fi

--- a/buildDebPackage/debconfig_trusty/debian/control
+++ b/buildDebPackage/debconfig_trusty/debian/control
@@ -2,7 +2,7 @@ Source: hopsan
 Section: non-free/x11
 Priority: extra
 Maintainer: Peter Nordin <peter.nordin@liu.se>
-Build-Depends: debhelper (>= 8.0.0), patchelf, unzip, cmake, libtool, automake, pkg-config, python-dev (<< 3.0.0), libqt4-dev, libqtwebkit-dev, libqt4-opengl-dev, libhdf5-dev
+Build-Depends: debhelper (>= 8.0.0), unzip, cmake, libtool, automake, pkg-config, python-dev (<< 3.0.0), libqt4-dev, libqtwebkit-dev, libqt4-opengl-dev, libhdf5-dev
 Standards-Version: 3.9.2
 Homepage: http://www.iei.liu.se/flumes/system-simulation/hopsan
 


### PR DESCRIPTION
Patchelf is not available on trusty so skip stripping rpaths, also debootstrap fails if trying to install it 