### PR TITLE
Improve core log handling

### DIFF
--- a/HopsanCLI/CliUtilities.cpp
+++ b/HopsanCLI/CliUtilities.cpp
@@ -314,7 +314,7 @@ string getCurrentExecPath()
     {
         string base, file;
         splitFilePath(string(result, count), base, file);
-        cout << "base, file: " << base << " " << file << endl;
+        //cout << "base, file: " << base << " " << file << endl;
         return base;
     }
 

--- a/HopsanCLI/main.cpp
+++ b/HopsanCLI/main.cpp
@@ -238,6 +238,7 @@ int main(int argc, char *argv[])
         TCLAP::SwitchArg createHvcTestOption("", "createValidationData","Create a model validation data set based on the variables connected to scopes in the model given by option -m", cmd);
         TCLAP::SwitchArg prefixRootLevelName("", "prefixRootSystemName", "Prefix the root-level system name to exported results and parameters", cmd);
 
+        TCLAP::ValueArg<std::string> coreLogFileOption("", "log.corelogfile", "The simulation core log file destination", false, "", "Filepath", cmd);
         TCLAP::ValueArg<std::string> buildCompLibOption("", "buildComponentLibrary", "Build the specified component library (point to the library xml)", false, "", "string", cmd);
         TCLAP::ValueArg<std::string> destinationOption("d","destination","Destination for resulting files",false,"","Path to directory", cmd);
         TCLAP::ValueArg<std::string> saveSimulationStateOption("", "saveSimState", "Export the simulation state to this file", false, "Path to file", "string", cmd);
@@ -281,6 +282,11 @@ int main(int argc, char *argv[])
             }
         }
 
+        if (coreLogFileOption.isSet()) {
+            gHopsanCore.openCoreLogFile(coreLogFileOption.getValue().c_str());
+        } else {
+            gHopsanCore.openCoreLogFile("hopsan_logfile.txt");
+        }
 
 #ifndef HOPSAN_INTERNALDEFAULTCOMPONENTS
         // Load default Hopsan component lib

--- a/HopsanCore/include/HopsanEssentials.h
+++ b/HopsanCore/include/HopsanEssentials.h
@@ -61,7 +61,7 @@ private:
     LoadExternal* mpExternalLoader;
     SimulationHandler mSimulationHandler;
     QuantityRegister* mpQuantityRegister;
-    static size_t mQRctr;
+    static size_t mInstanceCounter;
 
 public:
     HopsanEssentials();
@@ -91,7 +91,7 @@ public:
     // Quantities
     bool haveQuantity(const HString &rQuantity) const;
 
-    // Messages
+    // Messages and log
     HopsanCoreMessageHandler* getCoreMessageHandler();
     void getMessage(HString &rMessage, HString &rType, HString &rTag);
     size_t checkMessage();
@@ -100,6 +100,8 @@ public:
     size_t getNumErrorMessages() const;
     size_t getNumFatalMessages() const;
     size_t getNumDebugMessages() const;
+
+    bool openCoreLogFile(const char* absoluteFilePath);
 
     // External libraries
     bool loadExternalComponentLib(const char* path);
@@ -117,12 +119,23 @@ public:
     SimulationHandler *getSimulationHandler();
 };
 
-bool openLogFile();
-void closeLogFile();
-void addLogMess(const char* message);
-inline void addLogMess(const HString &rMessage)
+
+void HOPSANCORE_DLLAPI addCoreLogMessage(const char* message);
+inline void addCoreLogMessage(const HString& message)
 {
-    addLogMess(rMessage.c_str());
+    addCoreLogMessage(message.c_str());
 }
+
+// This one is for backwards compatibility, due to name change
+inline void addLogMess(const char* message)
+{
+    addCoreLogMessage(message);
+}
+// This one is for backwards compatibility, due to name change
+inline void addLogMess(const HString& message)
+{
+    addCoreLogMessage(message.c_str());
+}
+
 }
 #endif // HopsanEssentials_H

--- a/HopsanCore/src/Component.cpp
+++ b/HopsanCore/src/Component.cpp
@@ -435,7 +435,7 @@ void Component::stopSimulation(const HString &rReason)
         infoMsg = "Simulation was stopped at t="+to_hstring(mTime)+ " : "+rReason;
     }
     addInfoMessage(infoMsg);
-    addLogMess(infoMsg);
+    addCoreLogMessage(infoMsg);
 
     mpSystemParent->stopSimulation(""); // We use string version here to make sure sub system hierarchy is printed
 }
@@ -785,7 +785,7 @@ double *Component::getTimePtr()
 //! @returns A pointer to the created port
 Port *Component::addPort(const HString &rPortName, const PortTypesEnumT portType, const HString &rNodeType, const HString &rDescription, const Port::RequireConnectionEnumT reqConnection)
 {
-    addLogMess(getName()+"::addPort "+rPortName);
+    addCoreLogMessage(getName()+"::addPort "+rPortName);
 
     //Make sure name is unique before insert
     HString newname = this->determineUniquePortName(rPortName);
@@ -1035,7 +1035,7 @@ double *Component::getSafeNodeDataPtr(const HString &rPortName, const int dataId
 //! @returns A pointer to the specified NodeData or a null pointer
 double *Component::getNodeDataPtr(Port *pPort, const int dataId)
 {
-    //addLogMess(getName()+"::getNodeDataPtr Id:"+to_hstring(dataId));
+    //addCoreLogMessage(getName()+"::getNodeDataPtr Id:"+to_hstring(dataId));
     //If this is one of the multiports then give an error message to the user so that they KNOW that they have made a mistake
     if (pPort->getPortType() >= MultiportType)
     {
@@ -1458,7 +1458,7 @@ void Component::addInfoMessage(const HString &rMessage, const HString &rTag) con
 //! @param [in] rTag The message tag, used to group similar messages
 void Component::addFatalMessage(const HString &rMessage, const HString &rTag) const
 {
-    addLogMess("Fatal error: "+rMessage+" in component: "+getName());
+    addCoreLogMessage("Fatal error: "+rMessage+" in component: "+getName());
     if (mpMessageHandler)
     {
         mpMessageHandler->addFatalMessage(getName()+"::"+rMessage, rTag);

--- a/HopsanCore/src/ComponentSystem.cpp
+++ b/HopsanCore/src/ComponentSystem.cpp
@@ -209,7 +209,7 @@ void ComponentSystem::stopSimulation(const HString &rReason)
         infoMsg = "Simulation was stopped at t="+to_hstring(mTime)+ " : "+rReason;
     }
     addInfoMessage(infoMsg);
-    addLogMess(infoMsg);
+    addCoreLogMessage(infoMsg);
 
 #if defined(HOPSANCORE_USEMULTITHREADING)
     mpMultiThreadPrivates->mStopMutex.lock();
@@ -841,7 +841,7 @@ Component* ComponentSystem::getSubComponent(const HString &rName) const
     }
     else
     {
-        addLogMess("ComponentSystem::getSubComponent(): The requested component does not exist.");
+        addCoreLogMessage("ComponentSystem::getSubComponent(): The requested component does not exist.");
         return 0;
     }
 }
@@ -2166,7 +2166,7 @@ void ComponentSystem::setNumHopScript(const HString &rScript)
 bool ComponentSystem::initialize(const double startT, const double stopT)
 {
     //cout << "Initializing SubSystem: " << this->mName << endl;
-    addLogMess("ComponentSystem::initialize() in "+getName());
+    addCoreLogMessage("ComponentSystem::initialize() in "+getName());
 
     //Move all disabled components to temporary vectors
     for(size_t i=0; i<mComponentCptrs.size();)
@@ -2296,7 +2296,7 @@ bool ComponentSystem::initialize(const double startT, const double stopT)
             static_cast<ComponentSystem*>(mComponentSignalptrs[s])->setLogStartTime(mRequestedLogStartTime);
         }
 
-        addLogMess("ComponentSystem::initialize() Initializing component: "+mComponentSignalptrs[s]->getName());
+        addCoreLogMessage("ComponentSystem::initialize() Initializing component: "+mComponentSignalptrs[s]->getName());
         if(!mComponentSignalptrs[s]->initialize(startT, stopT))
         {
             stopSimulation("Failed to initialize: "+mComponentSignalptrs[s]->getName());
@@ -2321,7 +2321,7 @@ bool ComponentSystem::initialize(const double startT, const double stopT)
             static_cast<ComponentSystem*>(mComponentCptrs[c])->setLogStartTime(mRequestedLogStartTime);
         }
 
-        addLogMess("ComponentSystem::initialize() Initializing component: "+mComponentCptrs[c]->getName());
+        addCoreLogMessage("ComponentSystem::initialize() Initializing component: "+mComponentCptrs[c]->getName());
         if(!mComponentCptrs[c]->initialize(startT, stopT))
         {
             stopSimulation("Failed to initialize: "+mComponentCptrs[c]->getName());
@@ -2346,7 +2346,7 @@ bool ComponentSystem::initialize(const double startT, const double stopT)
             static_cast<ComponentSystem*>(mComponentQptrs[q])->setLogStartTime(mRequestedLogStartTime);
         }
 
-        addLogMess("ComponentSystem::initialize() Initializing component: "+mComponentQptrs[q]->getName());
+        addCoreLogMessage("ComponentSystem::initialize() Initializing component: "+mComponentQptrs[q]->getName());
         if(!mComponentQptrs[q]->initialize(startT, stopT))
         {
             stopSimulation("Failed to initialize: "+mComponentQptrs[q]->getName());

--- a/HopsanCore/src/CoreUtilities/HmfLoader.cpp
+++ b/HopsanCore/src/CoreUtilities/HmfLoader.cpp
@@ -686,25 +686,25 @@ ComponentSystem* loadHopsanModelFileActual(const rapidxml::xml_document<> &rDoc,
             }
             else
             {
-                addLogMess("hopsan::loadHopsanModelFileActual(): No system found in file.");
+                addCoreLogMessage("hopsan::loadHopsanModelFileActual(): No system found in file.");
                 pHopsanEssentials->getCoreMessageHandler()->addErrorMessage(rFilePath+" Has no system to load");
             }
         }
         else
         {
-            addLogMess("hopsan::loadHopsanModelFileActual(): Wrong root tag name.");
+            addCoreLogMessage("hopsan::loadHopsanModelFileActual(): Wrong root tag name.");
             pHopsanEssentials->getCoreMessageHandler()->addErrorMessage(rFilePath+" Has wrong root tag name: "+pRootNode->name());
             cout << "Not correct hmf file root node name: " << pRootNode->name() << endl;
         }
     }
     catch(std::exception &e)
     {
-        addLogMess("hopsan::loadHopsanModelFileActual(): Unable to parse xml doc.");
+        addCoreLogMessage("hopsan::loadHopsanModelFileActual(): Unable to parse xml doc.");
         pHopsanEssentials->getCoreMessageHandler()->addErrorMessage("Unable to parse xml doc");
         cout << "throws: " << e.what() << endl;
     }
 
-    addLogMess("hopsan::loadHopsanModelFileActual(): Failed.");
+    addCoreLogMessage("hopsan::loadHopsanModelFileActual(): Failed.");
 
     // We failed, return 0 ptr
     return 0;
@@ -828,7 +828,7 @@ int hopsan::compareHopsanVersions(const HString& versionA, const HString& versio
 //! @todo if possible merge the two differen main load functions
 ComponentSystem* hopsan::loadHopsanModelFile(const HString &rFilePath, HopsanEssentials* pHopsanEssentials, double &rStartTime, double &rStopTime)
 {
-    addLogMess("hopsan::loadHopsanModelFile("+rFilePath+")");
+    addCoreLogMessage("hopsan::loadHopsanModelFile("+rFilePath+")");
     try
     {
         rapidxml::file<> hmfFile(rFilePath.c_str());
@@ -839,11 +839,11 @@ ComponentSystem* hopsan::loadHopsanModelFile(const HString &rFilePath, HopsanEss
     }
     catch(std::exception &e)
     {
-        addLogMess("hopsan::loadHopsanModelFile(): Unable to open file.");
+        addCoreLogMessage("hopsan::loadHopsanModelFile(): Unable to open file.");
         pHopsanEssentials->getCoreMessageHandler()->addErrorMessage("Could not open file: "+rFilePath);
         cout << "Could not open file, throws: " << e.what() << endl;
     }
-    addLogMess("hopsan::loadHopsanModelFile(): Failed.");
+    addCoreLogMessage("hopsan::loadHopsanModelFile(): Failed.");
     // We failed, return 0 ptr
     return 0;
 }
@@ -902,7 +902,7 @@ ComponentSystem* hopsan::loadHopsanModel(char* xmlStr, HopsanEssentials* pHopsan
 //! @returns A pointer to the rootsystem of the loaded model
 void hopsan::loadHopsanParameterFile(const HString &rFilePath, HopsanEssentials* pHopsanEssentials, ComponentSystem *pSystem)
 {
-    addLogMess("hopsan::loadHopsanParameterFile("+rFilePath+")");
+    addCoreLogMessage("hopsan::loadHopsanParameterFile("+rFilePath+")");
     try
     {
         rapidxml::file<> hmfFile(rFilePath.c_str());
@@ -960,25 +960,25 @@ void hopsan::loadHopsanParameterFile(const HString &rFilePath, HopsanEssentials*
             }
             else
             {
-                addLogMess("hopsan::loadHopsanParameterFile(): No system found in file.");
+                addCoreLogMessage("hopsan::loadHopsanParameterFile(): No system found in file.");
                 pHopsanEssentials->getCoreMessageHandler()->addErrorMessage(rFilePath+" Has no system to load");
             }
         }
         else
         {
-            addLogMess("hopsan::loadHopsanParameterFile(): Wrong root tag name.");
+            addCoreLogMessage("hopsan::loadHopsanParameterFile(): Wrong root tag name.");
             pHopsanEssentials->getCoreMessageHandler()->addErrorMessage(rFilePath+" Has wrong root tag name: "+pRootNode->name());
             cout << "Not correct hmf file root node name: " << pRootNode->name() << endl;
         }
     }
     catch(std::exception &e)
     {
-        addLogMess("hopsan::loadHopsanParameterFile(): Unable to open file.");
+        addCoreLogMessage("hopsan::loadHopsanParameterFile(): Unable to open file.");
         pHopsanEssentials->getCoreMessageHandler()->addErrorMessage("Could not open file: "+rFilePath);
         cout << "Could not open file, throws: " << e.what() << endl;
     }
 
-    addLogMess("hopsan::loadHopsanParameterFile(): Failed.");
+    addCoreLogMessage("hopsan::loadHopsanParameterFile(): Failed.");
 
     // We failed, return 0 ptr
     return;

--- a/HopsanGUI/Configuration.cpp
+++ b/HopsanGUI/Configuration.cpp
@@ -1363,6 +1363,7 @@ void Configuration::registerSettings()
 #endif
     mStringSettings.insert(CFG_PLOTGFXIMAGEFORMAT, "png");
     mStringSettings.insert(CFG_PLOTGFXDIMENSIONSUNIT, "px");
+    mStringSettings.insert(cfg::paths::corelogfile, "");
 
     // Bool settings
     mBoolSettings.insert(CFG_USEREMOTEADDRESSSERVER, false);

--- a/HopsanGUI/Configuration.h
+++ b/HopsanGUI/Configuration.h
@@ -124,6 +124,12 @@
 #define CFG_PWD "pwd"
 #define CFG_COMMAND "command"
 
+namespace cfg {
+    namespace paths {
+        constexpr auto corelogfile = "corelogfile";
+    }
+}
+
 #include <QMap>
 #include <QColor>
 #include <QList>

--- a/HopsanGUI/CoreAccess.cpp
+++ b/HopsanGUI/CoreAccess.cpp
@@ -55,6 +55,18 @@
 // Here the HopsanCore object is created
 hopsan::HopsanEssentials gHopsanCore;
 
+void initializaHopsanCore(QString logPath)
+{
+    if (logPath.isEmpty()) {
+        logPath = gpDesktopHandler->getTempPath();
+    }
+    QFileInfo fi(logPath);
+    if (fi.isDir()) {
+        logPath.append("hopsan_logfile.txt");
+    }
+    gHopsanCore.openCoreLogFile(logPath.toStdString().c_str());
+}
+
 //! @brief Help function to copy parameter data from core to GUI class
 void copyParameterData(const hopsan::ParameterEvaluator *pCoreParam, CoreParameterData &rGUIParam)
 {

--- a/HopsanGUI/CoreAccess.h
+++ b/HopsanGUI/CoreAccess.h
@@ -51,6 +51,7 @@ class SimulationHandler;
 class CSVParserNG;
 }
 
+void initializaHopsanCore(QString logPath);
 
 class CoreCSVParserAccess
 {

--- a/HopsanGUI/MainWindow.cpp
+++ b/HopsanGUI/MainWindow.cpp
@@ -65,6 +65,7 @@
 #include "HcomHandler.h"
 #include "ModelicaLibrary.h"
 #include "SimulationThreadHandler.h"
+#include "CoreAccess.h"
 
 #include "Widgets/DebuggerWidget.h"
 #include "Widgets/PlotWidget2.h"
@@ -210,6 +211,7 @@ void MainWindow::createContents()
     //Load configuration from settings file
     gpSplash->showMessage("Loading configuration...");
     gpConfig->loadFromXml();      //!< @todo This does not really belong in main window constructor, but it depends on main window so keep it for now
+    initializaHopsanCore(gpConfig->getStringSetting(cfg::paths::corelogfile));
 
     gpSplash->showMessage("Initializing GUI...");
 


### PR DESCRIPTION
Make it possible to choose if the log should be active and where to put it in the cli.
Default log location for hopsan gui is now the temp directory.
The log is disabled if not explicitly opened by the user code.
Various related cleanup.