### PR TITLE
Don't clear optimization script when closing dialog

### DIFF
--- a/HopsanGUI/Dialogs/OptimizationDialog.cpp
+++ b/HopsanGUI/Dialogs/OptimizationDialog.cpp
@@ -853,8 +853,6 @@ void OptimizationDialog::open()
     mpParameterMaxLineEdits.clear();
     mpParameterRemoveButtons.clear();
 
-    mScript.clear();
-    mpOutputBox->clear();
     //mpRunButton->setDisabled(true);
 
     loadConfiguration();


### PR DESCRIPTION
Resolves #1701 

Drawback is that users may forget to click "Regenerate Script" if the previous script is already there. But this is still a better solution, since you no longer risk to lose manual changes to the script.