### PR TITLE
Update total progressbar during optimization

### DIFF
--- a/HopsanGUI/OptimizationHandler.cpp
+++ b/HopsanGUI/OptimizationHandler.cpp
@@ -1364,3 +1364,8 @@ void OptimizationMessageHandler::abort()
 {
     mIsAborted = true;
 }
+
+void OptimizationMessageHandler::stepCompleted(size_t steps)
+{
+    mpHandler->updateProgressBar(steps);
+}

--- a/HopsanGUI/OptimizationHandler.h
+++ b/HopsanGUI/OptimizationHandler.h
@@ -77,6 +77,7 @@ public:
     void objectiveChanged(size_t idx);
     void candidatesChanged();
     void candidateChanged(size_t idx);
+    void stepCompleted(size_t steps) override;
 
 public slots:
     void abort();


### PR DESCRIPTION
Resolves #1699 

Progress bar was disabled when removing Qt stuff from Ops library. It could no longer use signals and slots. I fixed it by re-implementing the stepComplete() function in HopsanGUI.