### PR TITLE
Check for Inf and NaN in animation

### DIFF
--- a/HopsanGUI/Widgets/AnimationWidget.cpp
+++ b/HopsanGUI/Widgets/AnimationWidget.cpp
@@ -680,6 +680,19 @@ AnimatedComponent *AnimationWidget::getAnimatedComponent(QString name)
     return 0;
 }
 
+void AnimationWidget::disablePlayback()
+{
+    mpPlayButton->setDisabled(true);
+    mpPlayRealTimeButton->setDisabled(true);
+    mpSettingsButton->setDisabled(true);
+    mpStopButton->setDisabled(true);
+    mpRewindButton->setDisabled(true);
+    mpPauseButton->setDisabled(true);
+    mpTimeSlider->setDisabled(true);
+    mpSpeedSpinBox->setDisabled(true);
+    mpTimeDisplay->setDisabled(true);
+}
+
 
 //! @brief Returns a pointer to the graphics scene
 QGraphicsScene* AnimationWidget::getGraphicsScene()

--- a/HopsanGUI/Widgets/AnimationWidget.h
+++ b/HopsanGUI/Widgets/AnimationWidget.h
@@ -91,6 +91,8 @@ public:
     double getLastAnimationTime();
     AnimatedComponent *getAnimatedComponent(QString name);
 
+    void disablePlayback();
+
     //Public member pointers
     AnimatedGraphicsView *mpGraphicsView=nullptr;
     ContainerObject *mpContainer=nullptr;
@@ -108,9 +110,11 @@ public:
     double mHydraulicIntensityMin;
     double mHydraulicSpeed;
 
+public slots:
+    void stop();
+
 private slots:
     void openPreferencesDialog();
-    void stop();
     void rewind();
     void pause();
     void play();


### PR DESCRIPTION
Prevents crashes when animation data contains on-finite values. Resolves #1695.
- Disable playback buttons if a non-finite value is detected in animation data
- Abort real-time playback if a non-finite value is detected
- No noticable slowdown detected on my machine

I am actually not sure if Inf or NaN causes crashes, or it if just takes a very long time to compute the position. I have seen cases where the GUI freezes for some minutes and then starts working again. In either case, this check is useful.