### PR TITLE
No pre-simulation check for disabled components

### DIFF
--- a/HopsanCore/src/ComponentSystem.cpp
+++ b/HopsanCore/src/ComponentSystem.cpp
@@ -1819,6 +1819,8 @@ bool ComponentSystem::checkModelBeforeSimulation()
     for ( ; scmit!=mSubComponentMap.end(); ++scmit)
     {
         Component* pComp = scmit->second; //Component pointer
+        if(pComp->isDisabled())
+            continue;
 
         // Check that ALL ports that MUST be connected are connected
         vector<Port*> ports = pComp->getPortPtrVector();


### PR DESCRIPTION
Seems to work in GUI. Enabled components must have all ports connected, but disabled components can have unconnected ports. 

Resolves #1765.