### PR TITLE
Zoom in HoLC with Ctrl+mousewheel

### DIFF
--- a/HoLC/Widgets/TextEditor.cpp
+++ b/HoLC/Widgets/TextEditor.cpp
@@ -356,6 +356,21 @@ void TextEditor::keyPressEvent(QKeyEvent *pEvent)
     }
 }
 
+void TextEditor::wheelEvent(QWheelEvent* event)
+{
+#if QT_VERSION >= 0x050000  //zoomIn() and zoomOut() not available in Qt4
+   if ((event->modifiers() == Qt::ControlModifier) && (event->delta() > 0))
+       zoomIn(2);
+   else if ((event->modifiers() == Qt::ControlModifier) && (event->delta() < 0))
+       zoomOut(2);
+   else
+       QPlainTextEdit::wheelEvent(event);
+#else
+   QPlainTextEdit::wheelEvent(event);
+#endif
+}
+
+
 
 //! @brief Highlights current line
 void TextEditor::highlightCurrentLine()

--- a/HoLC/Widgets/TextEditor.h
+++ b/HoLC/Widgets/TextEditor.h
@@ -44,6 +44,8 @@ protected:
     void resizeEvent(QResizeEvent *pEvent);
     void insertFromMimeData(const QMimeData *pData);
     void keyPressEvent(QKeyEvent *event);
+    void wheelEvent(QWheelEvent* e);
+
 public slots:
     void generateAutoCompleteList(QString filter, QStringList &variables, QStringList &dataTypes, QStringList &functions);
 private slots:


### PR DESCRIPTION
Zoom in or out (i.e. increase or decreate font size) with Ctrl+mousewheel.

Resolves #1770.