### PR TITLE
Use Qt::MatchContains in library autocompleter

### DIFF
--- a/HopsanGUI/Widgets/LibraryWidget.cpp
+++ b/HopsanGUI/Widgets/LibraryWidget.cpp
@@ -99,6 +99,9 @@ LibraryWidget::LibraryWidget(QWidget *parent)
     mpFilterEdit->setCompleter(new QCompleter(mpFilterEdit));
     mpFilterEdit->completer()->setCompletionMode(QCompleter::PopupCompletion);
     mpFilterEdit->completer()->setCaseSensitivity(Qt::CaseInsensitive);
+#if QT_VERSION >= 0x050000
+    mpFilterEdit->completer()->setFilterMode(Qt::MatchContains);
+#endif
 
     QToolButton *pClearFilterButton = new QToolButton(this);
     pClearFilterButton->setIcon(QIcon(QString(ICONPATH) + "Hopsan-Discard.png"));


### PR DESCRIPTION
Matching only at beginning of name is not very useful. If user for example writes "orif", "Laminar Orifice" should be suggested even though it doesn't begin with the filter text.