### PR TITLE
Improve find widget

### DIFF
--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -1199,6 +1199,7 @@ void ContainerObject::removeSubConnector(Connector* pConnector, UndoStatusEnumT 
     if (pConnector->isDangling() && !pConnector->isBroken())
     {
         cancelCreatingConnector();
+
         return;
     }
 
@@ -2431,6 +2432,7 @@ void ContainerObject::removeOneConnectorLine(QPointF pos)
         mpTempConnector->getStartPort()->getParentModelObject()->forgetConnector(mpTempConnector);
         mIsCreatingConnector = false;
         mpModelWidget->getGraphicsView()->setIgnoreNextContextMenuEvent();
+        mpModelWidget->getGraphicsView()->setIgnoreNextMouseReleaseEvent();
         delete(mpTempConnector);
         gpHelpPopupWidget->hide();
     }

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -1287,8 +1287,8 @@ QAction *ModelObject::buildBaseContextMenu(QMenu &rMenu, QGraphicsSceneContextMe
     {
         pRotateRightAction = rMenu.addAction(tr("Rotate Clockwise (Ctrl+R)"));
         pRotateLeftAction = rMenu.addAction(tr("Rotate Counter-Clockwise (Ctrl+E)"));
-        pFlipVerticalAction = rMenu.addAction(tr("Flip Vertically (Ctrl+D)"));
-        pFlipHorizontalAction = rMenu.addAction(tr("Flip Horizontally (Ctrl+F)"));
+        pFlipVerticalAction = rMenu.addAction(tr("Flip Vertically (Ctrl+Shift+R)"));
+        pFlipHorizontalAction = rMenu.addAction(tr("Flip Horizontally (Ctrl+Shift+E)"));
         pRotateRightAction->setEnabled(allowFullEditing);
         pRotateLeftAction->setEnabled(allowFullEditing);
         pFlipVerticalAction->setEnabled(allowFullEditing);

--- a/HopsanGUI/GUIPort.cpp
+++ b/HopsanGUI/GUIPort.cpp
@@ -271,6 +271,9 @@ void Port::mousePressEvent(QGraphicsSceneMouseEvent *event)
         if (event->button() == Qt::LeftButton && !pView->isCtrlKeyPressed())
         {
             getParentContainerObject()->createConnector(this);
+
+            //Avoid opening add component line edit after finishing connector
+            pView->setIgnoreNextMouseReleaseEvent();
         }
         else if (event->button() == Qt::RightButton)
         {

--- a/HopsanGUI/GraphicsView.h
+++ b/HopsanGUI/GraphicsView.h
@@ -36,6 +36,7 @@
 
 #include <QMenu>
 #include <QGraphicsView>
+#include <QLineEdit>
 
 #include "common.h"
 #include "GraphicsViewPort.h"
@@ -62,6 +63,7 @@ public:
     bool isShiftKeyPressed();
     bool isLeftMouseButtonPressed();
     void setIgnoreNextContextMenuEvent();
+    void setIgnoreNextMouseReleaseEvent();
     void setZoomFactor(double zoomFactor);
     double getZoomFactor();
     void clearHighlights();
@@ -101,13 +103,18 @@ protected:
     virtual void keyReleaseEvent(QKeyEvent *event);
     virtual void contextMenuEvent ( QContextMenuEvent * event );
 
+private slots:
+    void insertComponentFromLineEdit();
+
 private:
     QColor mIsoColor;
     bool mCtrlKeyPressed;
     bool mShiftKeyPressed;
     bool mLeftMouseButtonPressed;
     bool mIgnoreNextContextMenuEvent;
+    bool mIgnoreNextMouseReleaseEvent;
     double mZoomFactor;
+    QLineEdit *mpAddComponentLineEdit;
 
     ContainerObject *mpContainerObject;
 };

--- a/HopsanGUI/MainWindow.cpp
+++ b/HopsanGUI/MainWindow.cpp
@@ -595,7 +595,7 @@ void MainWindow::createActions()
     connect(mpOpenDataExplorerAction, SIGNAL(triggered()), this, SLOT(openDataExplorerWidget()));
 
     mpOpenFindWidgetAction = new QAction(tr("&Find Widget"), this);
-    mpOpenFindWidgetAction->setShortcut(QKeySequence("Ctrl+Shift+f"));
+    mpOpenFindWidgetAction->setShortcut(QKeySequence("Ctrl+f"));
     mpOpenFindWidgetAction->setToolTip("Open the Find Widget (Ctrl+Shift+f)");
     connect(mpOpenFindWidgetAction, SIGNAL(triggered()), this, SLOT(openFindWidget()));
 
@@ -730,14 +730,14 @@ void MainWindow::createActions()
     connect(mpRotateRightAction, SIGNAL(hovered()), this, SLOT(showToolBarHelpPopup()));
 
     mpFlipHorizontalAction = new QAction(QIcon(QString(ICONPATH) + "Hopsan-FlipHorizontal.png"), tr("&Flip Horizontal"), this);
-    mpFlipHorizontalAction->setText("Flip Horizontal (Ctrl+F)");
-    mpFlipHorizontalAction->setShortcut(QKeySequence("Ctrl+F"));
+    mpFlipHorizontalAction->setText("Flip Horizontal (Ctrl+Shift+E)");
+    mpFlipHorizontalAction->setShortcut(QKeySequence("Ctrl+Shift+E"));
     mHelpPopupTextMap.insert(mpFlipHorizontalAction, "Flip selected components horizontally.");
     connect(mpFlipHorizontalAction, SIGNAL(hovered()), this, SLOT(showToolBarHelpPopup()));
 
     mpFlipVerticalAction = new QAction(QIcon(QString(ICONPATH) + "Hopsan-FlipVertical.png"), tr("&Flip Vertical"), this);
-    mpFlipVerticalAction->setText("Flip Vertical (Ctrl+D");
-    mpFlipVerticalAction->setShortcut(QKeySequence("Ctrl+D"));
+    mpFlipVerticalAction->setText("Flip Vertical (Ctrl+Shift+R");
+    mpFlipVerticalAction->setShortcut(QKeySequence("Ctrl+Shift+R"));
     mHelpPopupTextMap.insert(mpFlipVerticalAction, "Flip selected components vertically.");
     connect(mpFlipVerticalAction, SIGNAL(hovered()), this, SLOT(showToolBarHelpPopup()));
 
@@ -1554,7 +1554,7 @@ void MainWindow::openDataExplorerWidget()
 
 void MainWindow::openFindWidget()
 {
-    gpFindWidget->setVisible(true);
+    gpFindWidget->setVisible(!gpFindWidget->isVisible());
 }
 
 void MainWindow::revertModel()

--- a/HopsanGUI/MainWindow.cpp
+++ b/HopsanGUI/MainWindow.cpp
@@ -433,6 +433,7 @@ void MainWindow::initializeWorkspace()
 
     // Create the find widget
     gpFindWidget = new FindWidget(this);
+    mpCentralGridLayout->addWidget(gpFindWidget,5,0,1,4);
     gpFindWidget->hide();
 
     // File association - ignore everything else and open the specified file if there is a hmf file in the argument list

--- a/HopsanGUI/Widgets/FindWidget.cpp
+++ b/HopsanGUI/Widgets/FindWidget.cpp
@@ -72,7 +72,7 @@ void FindHelper::doFind()
 
 
 FindWidget::FindWidget(QWidget *parent) :
-    QDialog(parent)
+    QWidget(parent)
 {
     FindHelper *pComponentFinder = new FindHelper(this);
     FindHelper *pAliasFinder = new FindHelper(this);

--- a/HopsanGUI/Widgets/FindWidget.h
+++ b/HopsanGUI/Widgets/FindWidget.h
@@ -27,27 +27,15 @@
 #ifndef FINDWIDGET_H
 #define FINDWIDGET_H
 
-#include <QDialog>
+#include <QWidget>
 #include <QString>
 #include <QPointer>
 #include <QLineEdit>
+#include <QComboBox>
+#include <QPushButton>
 
 // Forward declaration
 class ContainerObject;
-
-class FindHelper : public QWidget
-{
-    Q_OBJECT
-public:
-    FindHelper(QWidget *pParent);
-private:
-    QLineEdit *mpLineEdit;
-private slots:
-    void doFind();
-signals:
-    void find(QString name);
-};
-
 
 class FindWidget : public QWidget
 {
@@ -59,14 +47,22 @@ public:
 signals:
 
 public slots:
+    void find();
     void findComponent(const QString &rName, const bool centerView=true);
     void findAlias(const QString &rName, const bool centerView=true);
     void findSystemParameter(const QString &rName, const bool centerView=true);
     void findSystemParameter(const QStringList &rNames, const bool centerView=true);
     void findAny(const QString &rName);
 
+public slots:
+    virtual void setVisible(bool visible);
+    virtual void keyPressEvent(QKeyEvent *event);
+
 private:
     void clearHighlights();
+    QLineEdit *mpFindLineEdit;
+    QComboBox *mpFindWhatComboBox;
+    QPushButton *mpFindButton;
     QPointer<ContainerObject> mpContainer;
 
 };

--- a/HopsanGUI/Widgets/FindWidget.h
+++ b/HopsanGUI/Widgets/FindWidget.h
@@ -33,6 +33,7 @@
 #include <QLineEdit>
 #include <QComboBox>
 #include <QPushButton>
+#include <QCheckBox>
 
 // Forward declaration
 class ContainerObject;
@@ -48,10 +49,10 @@ signals:
 
 public slots:
     void find();
-    void findComponent(const QString &rName, const bool centerView=true);
-    void findAlias(const QString &rName, const bool centerView=true);
-    void findSystemParameter(const QString &rName, const bool centerView=true);
-    void findSystemParameter(const QStringList &rNames, const bool centerView=true);
+    void findComponent(const QString &rName, const bool centerView=true, Qt::CaseSensitivity caseSensitivity=Qt::CaseInsensitive, bool wildcard=true);
+    void findAlias(const QString &rName, const bool centerView=true, Qt::CaseSensitivity caseSensitivity=Qt::CaseInsensitive, bool wildcard=true);
+    void findSystemParameter(const QString &rName, const bool centerView=true, Qt::CaseSensitivity caseSensitivity=Qt::CaseInsensitive, bool wildcard=true);
+    void findSystemParameter(const QStringList &rNames, const bool centerView=true, Qt::CaseSensitivity caseSensitivity=Qt::CaseInsensitive, bool wildcard=true);
     void findAny(const QString &rName);
 
 public slots:
@@ -60,9 +61,12 @@ public slots:
 
 private:
     void clearHighlights();
-    QLineEdit *mpFindLineEdit;
-    QComboBox *mpFindWhatComboBox;
-    QPushButton *mpFindButton;
+    QLineEdit* mpFindLineEdit;
+    QComboBox* mpFindWhatComboBox;
+    QPushButton* mpFindButton;
+    QCheckBox* mpCaseSensitivityCheckBox;
+    QCheckBox* mpWildcardCheckBox;
+
     QPointer<ContainerObject> mpContainer;
 
 };

--- a/HopsanGUI/Widgets/FindWidget.h
+++ b/HopsanGUI/Widgets/FindWidget.h
@@ -49,7 +49,7 @@ signals:
 };
 
 
-class FindWidget : public QDialog
+class FindWidget : public QWidget
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
Resolves #1783.

Improvements to HopsanGUI find widget:
- [x] Show find widget beneath the workspace instead of a popup dialog
- [x] Open with Ctrl-F instead of Ctrl-Shift-F
- [x] Have one line edit, for all searches
- [x] Use combo box for search targets (components, aliases or system parameters)
- [x] Checkbox for case-sensitive matching
- [x] Checkbox for wildcard matching
- [x] Use "contains" matching by default

Note: "Find next" and "Find previous" buttons are not implemented. They are not really needed with the highlighting features anyway.