### PR TITLE
Base unit Ohm 

### DIFF
--- a/HopsanCore/src/Quantities.cpp
+++ b/HopsanCore/src/Quantities.cpp
@@ -61,6 +61,8 @@ hopsan::QuantityRegister::QuantityRegister()
 
     registerQuantity("Temperature", "K");
 
+    registerQuantity("Resistance", "ohm");
+
     // Register quantity aliases
     registerQuantityAlias("Position", "Length");
 }

--- a/Models/Component Test/ElectricComponent Test/ElectricMotorGearTest.hmf
+++ b/Models/Component Test/ElectricComponent Test/ElectricMotorGearTest.hmf
@@ -74,7 +74,7 @@
           <parameter unit="-" value="0" type="double" name="Pin::Value"/>
           <parameter unit="-" value="0" type="double" name="Pout::Value"/>
           <parameter unit="V/rpm" value="0.13" type="double" name="Ke"/>
-          <parameter unit="Ohm" value="0.004" type="double" name="Ra"/>
+          <parameter unit="ohm" value="0.004" type="double" name="Ra"/>
           <parameter unit="Nm" value="1" type="double" name="Tm0"/>
           <parameter unit="rad/s" value="1" type="double" name="wc"/>
           <parameter unit="Ns/m" value="0.0012" type="double" name="Bm"/>

--- a/Models/Component Test/ElectricComponent Test/ElectricMotorTest.hmf
+++ b/Models/Component Test/ElectricComponent Test/ElectricMotorTest.hmf
@@ -418,7 +418,7 @@
       <component typename="ElectricMotor" name="DC_Motor">
         <parameters>
           <parameter unit="V s/rad" value="0.13" type="double" name="Ke#Value"/>
-          <parameter unit="Ohm" value="0.04" type="double" name="Ra#Value"/>
+          <parameter unit="ohm" value="0.04" type="double" name="Ra#Value"/>
           <parameter unit="Nm" value="0" type="double" name="Tm0#Value"/>
           <parameter unit="rad/s" value="1" type="double" name="wc#Value"/>
           <parameter unit="Ns/m" value="0.0012" type="double" name="Bm#Value"/>
@@ -519,7 +519,7 @@
       <component typename="ElectricMotor" name="DC_Motor_1">
         <parameters>
           <parameter unit="V s/rad" value="0.13" type="double" name="Ke#Value"/>
-          <parameter unit="Ohm" value="0.04" type="double" name="Ra#Value"/>
+          <parameter unit="ohm" value="0.04" type="double" name="Ra#Value"/>
           <parameter unit="Nm" value="0" type="double" name="Tm0#Value"/>
           <parameter unit="rad/s" value="1" type="double" name="wc#Value"/>
           <parameter unit="Ns/m" value="0.0012" type="double" name="Bm#Value"/>

--- a/Models/Component Test/ElectricComponent Test/Electricexample.hmf
+++ b/Models/Component Test/ElectricComponent Test/Electricexample.hmf
@@ -100,7 +100,7 @@
           <parameter unit="-" value="0" type="double" name="Pin::Value"/>
           <parameter unit="-" value="0" type="double" name="Pout::Value"/>
           <parameter unit="V s/rad" value="0.13" type="double" name="Ke"/>
-          <parameter unit="Ohm" value="0.04" type="double" name="Ra"/>
+          <parameter unit="ohm" value="0.04" type="double" name="Ra"/>
           <parameter unit="Nm" value="0" type="double" name="Tm0"/>
           <parameter unit="rad/s" value="1" type="double" name="wc"/>
           <parameter unit="Ns/m" value="0.0012" type="double" name="Bm"/>

--- a/Models/Example Models/ElectricAircraftMission.hmf
+++ b/Models/Example Models/ElectricAircraftMission.hmf
@@ -4634,7 +4634,7 @@
             <parameters>
               <parameter type="double" value="1" name="gearRatio#Value" unit=""/>
               <parameter type="double" value="0.07" name="Ke#Value" unit="V/rpm"/>
-              <parameter type="double" value="0.04" name="Ra#Value" unit="Ohm"/>
+              <parameter type="double" value="0.04" name="Ra#Value" unit="ohm"/>
               <parameter type="double" value="0" name="Tm0#Value" unit="Nm"/>
               <parameter type="double" value="1" name="wc#Value" unit="rad/s"/>
               <parameter type="double" value="0.0012" name="Bm#Value" unit="Ns/m"/>

--- a/componentLibraries/defaultLibrary/Electric/ElectricACmachine.hpp
+++ b/componentLibraries/defaultLibrary/Electric/ElectricACmachine.hpp
@@ -171,7 +171,7 @@ public:
 
         //Add inputParammeters to the component
             addInputVariable("Ke", "emf constant", "V s/rad", 0.13,&mpKe);
-            addInputVariable("Ra", "motor resistance", "Ohm", 0.04,&mpRa);
+            addInputVariable("Ra", "motor resistance", "Resistance", 0.04,&mpRa);
             addInputVariable("Tm0", "zero speed friction of motor", "Nm", \
 0.,&mpTm0);
             addInputVariable("wc", "Friction speed", "rad/s", 1.,&mpwc);

--- a/componentLibraries/defaultLibrary/Electric/ElectricIcontroller.hpp
+++ b/componentLibraries/defaultLibrary/Electric/ElectricIcontroller.hpp
@@ -138,7 +138,7 @@ public:
 (1/resistance)","A/V",0.,&mpiref);
 
         //Add inputParammeters to the component
-            addInputVariable("resist", "loss resistans (at 1)", "ohm", \
+            addInputVariable("resist", "loss resistans (at 1)", "Resistance", \
 0.01,&mpresist);
             addInputVariable("wf", "controller break frequency", "rad/s", \
 10.,&mpwf);

--- a/componentLibraries/defaultLibrary/Electric/ElectricMotor.hpp
+++ b/componentLibraries/defaultLibrary/Electric/ElectricMotor.hpp
@@ -162,7 +162,7 @@ public:
 
         //Add inputParammeters to the component
             addInputVariable("Ke", "emf constant", "V s/rad", 0.13,&mpKe);
-            addInputVariable("Ra", "motor resistance", "Ohm", 0.04,&mpRa);
+            addInputVariable("Ra", "motor resistance", "Resistance", 0.04,&mpRa);
             addInputVariable("Tm0", "zero speed friction of motor", "Nm", \
 0.,&mpTm0);
             addInputVariable("wc", "Friction speed", "rad/s", 1.,&mpwc);

--- a/componentLibraries/defaultLibrary/Electric/ElectricMotorGear.hpp
+++ b/componentLibraries/defaultLibrary/Electric/ElectricMotorGear.hpp
@@ -173,7 +173,7 @@ public:
 
         //Add inputParammeters to the component
             addInputVariable("Ke", "emf constant", "V/rpm", 0.13,&mpKe);
-            addInputVariable("Ra", "motor resistance", "Ohm", 0.04,&mpRa);
+            addInputVariable("Ra", "motor resistance", "Resistance", 0.04,&mpRa);
             addInputVariable("Tm0", "zero speed friction of motor", "Nm", \
 0.,&mpTm0);
             addInputVariable("wc", "Friction speed (for numerics)", "rad/s", \

--- a/componentLibraries/defaultLibrary/Electric/ElectricMotorGearScrewLink.hpp
+++ b/componentLibraries/defaultLibrary/Electric/ElectricMotorGearScrewLink.hpp
@@ -183,7 +183,7 @@ public:
 
         //Add inputParammeters to the component
             addInputVariable("Ke", "emf constant", "V/rpm", 0.13,&mpKe);
-            addInputVariable("Ra", "motor resistance", "Ohm", 0.04,&mpRa);
+            addInputVariable("Ra", "motor resistance", "Resistance", 0.04,&mpRa);
             addInputVariable("Tm0", "zero speed friction of motor", "Nm", \
 0.,&mpTm0);
             addInputVariable("wc", "Friction speed (for numerics)", "rad/s", \

--- a/componentLibraries/defaultLibrary/Electric/ElectricPWMdceq.hpp
+++ b/componentLibraries/defaultLibrary/Electric/ElectricPWMdceq.hpp
@@ -137,9 +137,9 @@ public:
 on)","",1.,&mptfac);
 
         //Add inputParammeters to the component
-            addInputVariable("resist0", "loss resistans (at 2)", "ohm", \
+            addInputVariable("resist0", "loss resistans (at 2)", "Resistance", \
 0.01,&mpresist0);
-            addInputVariable("resist1", "loss resistans (at 2)", "ohm", \
+            addInputVariable("resist1", "loss resistans (at 2)", "Resistance", \
 10.,&mpresist1);
             addInputVariable("umin", "minimum voltage difference", "V", \
 0.01,&mpumin);

--- a/hopsandefaults
+++ b/hopsandefaults
@@ -288,6 +288,11 @@
           <unit name="hg" scale="0.01"/>
           <unit name="t" scale="1000"/>
         </quantity>
+        <quantity name="Resistance" baseunit="ohm">
+          <unit name="milliohm" scale="1e-3"/>
+          <unit name="kilohm" scale="1e3"/>
+          <unit name="megohm" scale="1e6"/>
+        </quantity>
     </unitsettings>
     <units>
     <!-- Note! The units tag is deprecated and should no longer be used   -->


### PR DESCRIPTION
Some model uses unit ohm but there is no corresponding quantity for this. Now quantity Resistance is added. 
Unit "Ohm" used instead if "ohm" for readability in case of prefix; mOhm, kOhm etc.
Note that one may also expect ohm to be impedance or reluctance. Those (aliases?) are not added.
