### PR TITLE
Sort units by scale

### DIFF
--- a/HopsanGUI/Configuration.cpp
+++ b/HopsanGUI/Configuration.cpp
@@ -961,31 +961,16 @@ QString Configuration::getDefaultUnit(const QString &rPhysicalQuantity) const
         return "";
 }
 
-
-//! @brief Returns a map with custom units (names and scale factor) for specified physical quantity
-//! @param[in] rPhysicalQuantity Name of the physical quantity (e.g. "Pressure" or "Velocity")
-//! @todo We should rewrite the code using this function to handle unitscale objects directly instead
-QMap<QString, double> Configuration::getUnitScales(const QString &rPhysicalQuantity)
-{
-    QMap<QString, double> dummy;
-    if(mUnitScales.contains(rPhysicalQuantity))
-    {
-        QMap<QString, UnitConverter> &rMap = mUnitScales.find(rPhysicalQuantity).value().customUnits;
-        QMap<QString, UnitConverter>::iterator it;
-        for (it=rMap.begin(); it!=rMap.end(); ++it)
-        {
-            dummy.insert(it.value().mUnit, it.value().scaleToDouble());
-        }
-    }
-    return dummy;
-}
-
+//! @brief Populates a list with custom units (names and scale factor) for specified physical quantity.
+//! @param[in] rQuantity Name of the physical quantity (e.g. "Pressure" or "Velocity").
+//! @param[out] rUnitScales A list of UnitConverter objects.
 void Configuration::getUnitScales(const QString &rQuantity, QList<UnitConverter> &rUnitScales)
 {
     QMap<QString, QuantityUnitScale>::iterator qit = mUnitScales.find(rQuantity);
     if (qit != mUnitScales.end())
     {
         rUnitScales = qit.value().customUnits.values();
+        std::sort(rUnitScales.begin(), rUnitScales.end(), UnitConverter::isScaleLesserThan);
     }
 }
 

--- a/HopsanGUI/Configuration.h
+++ b/HopsanGUI/Configuration.h
@@ -220,7 +220,6 @@ public:
     QString getDefaultUnit(const QString &rPhysicalQuantity) const;
     void setDefaultUnit(QString key, QString value);
     void addCustomUnit(QString quantity, QString unitname, QString scale, QString offset);
-    QMap<QString, double> getUnitScales(const QString &rPhysicalQuantity);
     void getUnitScales(const QString &rQuantity, QList<UnitConverter> &rUnitScales);
     bool hasUnitScale(const QString &rPhysicalQuantity, const QString &rUnit) const;
     double getUnitScale(const QString &rPhysicalQuantity, const QString &rUnit) const;

--- a/HopsanGUI/Dialogs/OptionsDialog.cpp
+++ b/HopsanGUI/Dialogs/OptionsDialog.cpp
@@ -99,11 +99,13 @@ public:
         {
             defaultUnit = gpConfig->getBaseUnit(mQuantity);
         }
-        QMap<QString, double> unit_scales = gpConfig->getUnitScales(mQuantity);
-        QMap<QString, double>::iterator it;
-        for(it = unit_scales.begin(); it != unit_scales.end(); ++it)
+
+        QList<UnitConverter> unitScales;
+        gpConfig->getUnitScales(mQuantity, unitScales);
+        QList<UnitConverter>::iterator it;
+        for(it = unitScales.begin(); it != unitScales.end(); ++it)
         {
-            mpDefaultUnitComboBox->addItem(it.key());
+            mpDefaultUnitComboBox->addItem((*it).mUnit);
         }
         for(int i=0; i<mpDefaultUnitComboBox->count(); ++i)
         {

--- a/HopsanGUI/PlotArea.cpp
+++ b/HopsanGUI/PlotArea.cpp
@@ -1110,9 +1110,10 @@ void PlotArea::contextMenuEvent(QContextMenuEvent *event)
     pChangeUnitsMenu = menu.addMenu(QString("Change Units"));
     pResetUnitsMenu = menu.addMenu(QString("Reset Units"));
     QMap<QAction *, PlotCurve *> actionToCurveMap;
-    QMap<QString, double> unitMap;
+    QList<UnitConverter> unitScales;
     QList<PlotCurve *>::iterator itc;
-    QMap<QString, double>::iterator itu;
+    QList<UnitConverter>::iterator itu;
+
     for(itc=mPlotCurves.begin(); itc!=mPlotCurves.end(); ++itc)
     {
         PlotCurve *pCurve = *itc;
@@ -1126,17 +1127,17 @@ void PlotArea::contextMenuEvent(QContextMenuEvent *event)
             QStringList pqs = gpConfig->getQuantitiesForUnit(pCurve->getDataUnit());
             if (pqs.size() == 1)
             {
-                unitMap = gpConfig->getUnitScales(pqs.first());
+                gpConfig->getUnitScales(pqs.first(), unitScales);
             }
         }
         else
         {
-            unitMap = gpConfig->getUnitScales(pCurve->getDataQuantity());
+            gpConfig->getUnitScales(pCurve->getDataQuantity(), unitScales);
         }
 
-        for(itu=unitMap.begin(); itu!=unitMap.end(); ++itu)
+        for(itu=unitScales.begin(); itu!=unitScales.end(); ++itu)
         {
-            QAction *pTempAction = pTempChangeUnitMenu->addAction(itu.key());
+            QAction *pTempAction = pTempChangeUnitMenu->addAction((*itu).mUnit);
             actionToCurveMap.insert(pTempAction, pCurve);
         }
     }

--- a/HopsanGUI/UnitScale.cpp
+++ b/HopsanGUI/UnitScale.cpp
@@ -128,6 +128,11 @@ bool UnitConverter::isScaleMinusOne() const
     return ((mScale == "-1") || (mScale == "-1.0")) && mOffset.isEmpty();
 }
 
+bool UnitConverter::isScaleLesserThan (const UnitConverter &lhs, const UnitConverter &rhs)
+{
+    return (lhs.mScale.toDouble() < rhs.mScale.toDouble());
+}
+
 //! @brief Set the scale from a double
 //! @param [in] The scale value
 void UnitConverter::setScaleAndOffset(const double scale, const double offset)

--- a/HopsanGUI/UnitScale.h
+++ b/HopsanGUI/UnitScale.h
@@ -52,6 +52,7 @@ public:
     bool isOffsetEmpty() const;
     bool isScaleOne() const;
     bool isScaleMinusOne() const;
+    static bool isScaleLesserThan (const UnitConverter &lhs, const UnitConverter &rhs);
 
     void setScaleAndOffset(const double scale, const double offset=0.0);
     void setOnlyScaleAndOffset(const double scale, const double offset=0.0);


### PR DESCRIPTION
The natural way to display units in menus are in sorted by scale order.
Therefore;
- Configuration::getUnitScales() now sorts units by scales in ascending
order.
- Deleted QMap<QString, double> Configuration::getUnitScales(const
QString &rPhysicalQuantity) and...
- Completed a TODO: Rewrite code using deleted method to use void
Configuration::getUnitScales(const QString &rQuantity,
QList<UnitConverter> &rUnitScales) instead.

Resolves #1802 
Resolves #1483