### PR TITLE
Fixes to animation real-time plotting

### DIFF
--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -423,18 +423,8 @@ void AnimatedComponent::updateAnimation()
 
             double firstT = pTimeVar->first();
             double lastT = pTimeVar->last();
-            while(lastT-firstT > 3)
-            {
-                for(int i=0; i<vectors.size(); ++i)
-                {
-                    vectors[i]->chopAtBeginning();
-                }
-                firstT = pTimeVar->first();
-            }
         }
-
     }
-
 }
 
 

--- a/HopsanGUI/Widgets/AnimationWidget.cpp
+++ b/HopsanGUI/Widgets/AnimationWidget.cpp
@@ -183,6 +183,7 @@ AnimationWidget::AnimationWidget(QWidget *parent) :
     //mpContainer->collectPlotData();
     mpPlotData = mpContainer->getLogDataHandler();
     mpPlayButton->setDisabled(mpPlotData->isEmpty());
+    mpPlayRealTimeButton->setDisabled(mpPlotData->isEmpty());
     mpRewindButton->setDisabled(mpPlotData->isEmpty());
 
     if(!mpPlotData->isEmpty() && !mpPlotData->getTimeVectorVariable(-1).isNull())


### PR DESCRIPTION
Crash when real-time plotting with logging to disk enabled occurred because no generation existed in LogDataHandler before model was simulated first time. 

- Require model to be simulated before starting real-time animation. Resolves #1806.
- Removed time limit for real-time plotting. Resolves #1805.