### PR TITLE
Make save/restore state work for recompiling/reloading libraries

### DIFF
--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -393,7 +393,7 @@ void AnimatedComponent::updateAnimation()
 
     if(mpModelObject->getTypeName() == HOPSANGUISCOPECOMPONENTTYPENAME)
     {
-        LogDataHandler2 *pHandler = mpModelObject->getParentContainerObject()->getLogDataHandler();
+        LogDataHandler2* pHandler = mpModelObject->getParentContainerObject()->getLogDataHandler().data();
 
         QList<SharedVectorVariableT> vectors;
 
@@ -912,7 +912,7 @@ void AnimatedIcon::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
     //Open plot window if double-clicking on scope component
     if(mpAnimatedComponent->mpModelObject->getTypeName() == HOPSANGUISCOPECOMPONENTTYPENAME)
     {
-        LogDataHandler2 *pHandler = mpAnimatedComponent->mpModelObject->getParentContainerObject()->getLogDataHandler();
+        LogDataHandler2* pHandler = mpAnimatedComponent->mpModelObject->getParentContainerObject()->getLogDataHandler().data();
         QString name = mpAnimatedComponent->mpModelObject->getName();
         PlotWindow *pPlotWindow = mpAnimatedComponent->mpPlotWindow;
 

--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -3488,7 +3488,7 @@ QList<Connector *> ContainerObject::getSubConnectorPtrs()
 
 
 
-LogDataHandler2 *ContainerObject::getLogDataHandler()
+QSharedPointer<LogDataHandler2> ContainerObject::getLogDataHandler()
 {
     return mpModelWidget->getLogDataHandler();
     //return mpLogDataHandler;

--- a/HopsanGUI/GUIObjects/GUIContainerObject.h
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.h
@@ -156,7 +156,7 @@ public:
     void calcSubsystemPortPosition(const double w, const double h, const double angle, double &x, double &y); //!< @todo maybe not public
 
     //Plot and simulation results methods
-    LogDataHandler2 *getLogDataHandler();
+    QSharedPointer<LogDataHandler2> getLogDataHandler();
 
     // Get the IDs of the component libraries that the components in this model come from
     QStringList getRequiredComponentLibraries() const;

--- a/HopsanGUI/GUIPort.cpp
+++ b/HopsanGUI/GUIPort.cpp
@@ -349,7 +349,7 @@ void Port::openRightClickMenu(QPoint screenPos)
     // Now build plot menu
     QMap<QAction*, int> plotActions;
 
-    LogDataHandler2 *pLogHandler = mpParentModelObject->getParentContainerObject()->getLogDataHandler();
+    LogDataHandler2* pLogHandler = mpParentModelObject->getParentContainerObject()->getLogDataHandler().data();
     QList<SharedVectorVariableT> logVars;
     QString comp, port;
     if(getPortType() == QString("PowerMultiportType"))

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -5781,7 +5781,7 @@ void HcomHandler::evaluateExpression(QString expr, VariableType desiredType)
     LogDataHandler2 *pLogDataHandler=0;
     if(mpModel && mpModel->getViewContainerObject())
     {
-        pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler();
+        pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler().data();
     }
 
     if(isHcomFunctionCall("round", expr))
@@ -7713,7 +7713,7 @@ void HcomHandler::getMatchingLogVariableNames(QString pattern, QStringList &rVar
     if(!mpModel) { return; }
 
     // Get pointers to logdatahandler
-    LogDataHandler2 *pLogDataHandler = mpModel->getLogDataHandler();
+    LogDataHandler2* pLogDataHandler = mpModel->getLogDataHandler().data();
 
     // Parse and chop the desired generation
     int desiredGen = -3;
@@ -8162,7 +8162,7 @@ void HcomHandler::executeGtBuiltInFunction(QString fnc_call)
 
         LogDataHandler2 *pLogDataHandler = 0;
         if(mpModel)
-             pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler();
+             pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler().data();
 
         // Handle both scalars
         if (arg1IsDouble && arg2IsDouble)
@@ -8267,7 +8267,7 @@ void HcomHandler::executeLtBuiltInFunction(QString fnc_call)
             pVar2 = mAnsVector;
         }
 
-        LogDataHandler2 *pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler();
+        LogDataHandler2 *pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler().data();
 
         // Handle both scalars
         if (arg1IsDouble && arg2IsDouble)
@@ -8389,7 +8389,7 @@ void HcomHandler::executeEqBuiltInFunction(QString fnc_call)
             pVar2 = mAnsVector;
         }
 
-        LogDataHandler2 *pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler();
+        LogDataHandler2 *pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler().data();
 
         // Handle both scalars
         if (arg1IsDouble && arg2IsDouble)

--- a/HopsanGUI/ModelHandler.h
+++ b/HopsanGUI/ModelHandler.h
@@ -38,6 +38,8 @@
 #include <QDomElement>
 #include <QAction>
 
+#include "GraphicsViewPort.h"
+
 class ModelWidget;
 class CentralTabWidget;
 class SystemContainer;
@@ -46,6 +48,19 @@ class LogDataHandler2;
 class SimulationThreadHandler;
 class DebuggerWidget;
 class ScriptEditor;
+
+class ModelStateInfo
+{
+public:
+    QString modelFile;
+    QString backupFile;
+    bool hasChanged;
+    QString tabName;
+    LogDataHandler2* logDataHandler;
+    QDomDocument model;
+    GraphicsViewPort viewPort;
+};
+
 
 class ModelHandler : public QObject
 {
@@ -128,12 +143,8 @@ private:
     int mNumberOfUntitledModels;
     int mNumberOfUntitledScripts;
 
-    QStringList mStateInfoHmfList;
-    QStringList mStateInfoBackupList;
-    QList<bool> mStateInfoHasChanged;
-    QStringList mStateInfoTabNames;
-    QList<LogDataHandler2*> mStateInfoLogDataHandlersList;
-    QList<QDomDocument> mStateInfoModels;
+    QList<ModelStateInfo> mStateInfoList;
+    int mStateInfoIndex;
 
     DebuggerWidget *mpDebugger;
 };

--- a/HopsanGUI/ModelHandler.h
+++ b/HopsanGUI/ModelHandler.h
@@ -56,7 +56,7 @@ public:
     QString backupFile;
     bool hasChanged;
     QString tabName;
-    LogDataHandler2* logDataHandler;
+    QSharedPointer<LogDataHandler2> logDataHandler;
     QDomDocument model;
     GraphicsViewPort viewPort;
 };
@@ -81,7 +81,7 @@ public:
     SystemContainer *getCurrentTopLevelSystem();
     ContainerObject *getViewContainerObject(int idx);
     ContainerObject *getCurrentViewContainerObject();
-    LogDataHandler2 *getCurrentLogDataHandler();
+    QSharedPointer<LogDataHandler2> getCurrentLogDataHandler();
 
     int count() const;
 

--- a/HopsanGUI/PlotWindow.cpp
+++ b/HopsanGUI/PlotWindow.cpp
@@ -322,7 +322,7 @@ PlotWindow::PlotWindow(const QString name, QWidget *parent)
     if(gpModelHandler->count() != 0)
     {
         //pLocalPlotWidget->setLogDataHandler(gpModelHandler->getCurrentViewContainerObject()->getLogDataHandler()); //!< @todo not necessarily the same as where the plot data will come from if plot by script
-        pLocalPlotWidget->setLogDataHandler(gpModelHandler->getCurrentLogDataHandler()); //!< @todo not necessarily the same as where the plot data will come from if plot by script
+        pLocalPlotWidget->setLogDataHandler(gpModelHandler->getCurrentLogDataHandler().data()); //!< @todo not necessarily the same as where the plot data will come from if plot by script
     }
 
     pLocalPlotWidgetDock->toggleViewAction()->setToolTip("Toggle Variable List");

--- a/HopsanGUI/Widgets/AnimationWidget.cpp
+++ b/HopsanGUI/Widgets/AnimationWidget.cpp
@@ -181,7 +181,7 @@ AnimationWidget::AnimationWidget(QWidget *parent) :
 
     //Collect plot data from container (for non-realtime animations)
     //mpContainer->collectPlotData();
-    mpPlotData = mpContainer->getLogDataHandler();
+    mpPlotData = mpContainer->getLogDataHandler().data();
     mpPlayButton->setDisabled(mpPlotData->isEmpty());
     mpPlayRealTimeButton->setDisabled(mpPlotData->isEmpty());
     mpRewindButton->setDisabled(mpPlotData->isEmpty());

--- a/HopsanGUI/Widgets/AnimationWidget.h
+++ b/HopsanGUI/Widgets/AnimationWidget.h
@@ -83,7 +83,7 @@ public:
 
     //Get functions
     QGraphicsScene* getGraphicsScene();
-    LogDataHandler2 *getPlotDataPtr();
+    LogDataHandler2* getPlotDataPtr();
 
     int getIndex(); // returns the current position inside the time vector
     int getLastIndex();

--- a/HopsanGUI/Widgets/HVCWidget.cpp
+++ b/HopsanGUI/Widgets/HVCWidget.cpp
@@ -305,7 +305,7 @@ void HVCWidget::runHvcTest()
 
     // Get Log data handler for model
     int simuGen=-1;
-    LogDataHandler2 *pLogDataHandler = gpModelHandler->getCurrentLogDataHandler();
+    LogDataHandler2 *pLogDataHandler = gpModelHandler->getCurrentLogDataHandler().data();
 
     // Simulate the system
     if (gpModelHandler->getCurrentModel())

--- a/HopsanGUI/Widgets/LibraryWidget.cpp
+++ b/HopsanGUI/Widgets/LibraryWidget.cpp
@@ -55,6 +55,7 @@
 #include "Configuration.h"
 #include "DesktopHandler.h"
 #include "GeneratorUtils.h"
+#include "ModelHandler.h"
 
 //! @todo Ok don't know where I should put this, putting it here for now /Peter
 QString gHopsanCoreVersion = getHopsanCoreVersion();
@@ -782,7 +783,9 @@ void LibraryWidget::handleItemClick(QTreeWidgetItem *item, int column)
                             typeNames.append(mItemToTypeNameMap.find(subItems[s]).value());
                         }
                     }
-                    if(!gpLibraryHandler->isTypeNamesOkToUnload(typeNames))
+                    if(pReply != pRecompileAction &&
+                       pReply != pReloadAction &&
+                       !gpLibraryHandler->isTypeNamesOkToUnload(typeNames))
                     {
                         return;
                     }
@@ -798,7 +801,7 @@ void LibraryWidget::handleItemClick(QTreeWidgetItem *item, int column)
                 // Handle reload
                 else if (pReply == pReloadAction && !typeNames.isEmpty())
                 {
-
+                    gpModelHandler->saveState();
                     ComponentLibraryEntry le = gpLibraryHandler->getEntry(typeNames.first());
                     if (le.pLibrary)
                     {
@@ -812,10 +815,12 @@ void LibraryWidget::handleItemClick(QTreeWidgetItem *item, int column)
                             gpLibraryHandler->loadLibrary(libPath);
                         }
                     }
+                    gpModelHandler->restoreState();
                 }
                 // Handle recompile
                 else if ((pReply == pRecompileAction) && !typeNames.isEmpty())
                 {
+                    gpModelHandler->saveState();
                     ComponentLibraryEntry le = gpLibraryHandler->getEntry(typeNames.first());
                     if (le.pLibrary)
                     {
@@ -839,6 +844,7 @@ void LibraryWidget::handleItemClick(QTreeWidgetItem *item, int column)
                             gpLibraryHandler->loadLibrary(libPath);
                         }
                     }
+                    gpModelHandler->restoreState();
                 }
                 // Handle check consistency
                 else if ((pReply == pCheckConsistenceAction) && !typeNames.isEmpty())

--- a/HopsanGUI/Widgets/ModelWidget.h
+++ b/HopsanGUI/Widgets/ModelWidget.h
@@ -108,7 +108,8 @@ public:
     GraphicsView *getGraphicsView();
     QuickNavigationWidget *getQuickNavigationWidget();
     SimulationThreadHandler *getSimulationThreadHandler();
-    LogDataHandler2 *getLogDataHandler();
+    QSharedPointer<LogDataHandler2> getLogDataHandler();
+    void setLogDataHandler(QSharedPointer<LogDataHandler2> pHandler);
 
     ModelHandler *mpParentModelHandler;
     GraphicsView *mpGraphicsView;
@@ -162,7 +163,7 @@ private:
     QWidget *mpLockedSystemWarningWidget;
 
     SystemContainer *mpToplevelSystem=nullptr;
-    LogDataHandler2 *mpLogDataHandler;
+    QSharedPointer<LogDataHandler2> mpLogDataHandler;
     GUIMessageHandler *mpMessageHandler;
     SimulationThreadHandler *mpSimulationThreadHandler;
 #ifdef USEZMQ


### PR DESCRIPTION
The major change here is to use a shared pointer for the LogDataHandler in ModelWidget. In this way, it can be kept alive when the model is closed and then re-inserted into the model after it is loaded again.