### PR TITLE
Remove mode from bind mounts as automatic review in the snap store fails

### DIFF
--- a/snap/snapcraft.yaml.in
+++ b/snap/snapcraft.yaml.in
@@ -15,13 +15,10 @@ passthrough:
   layout:
     /usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libmvec_nonshared.a:
       bind-file: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libmvec_nonshared.a
-      mode: 755
     /usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libc_nonshared.a:
       bind-file: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libc_nonshared.a
-      mode: 755
     /usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libpthread_nonshared.a:
       bind-file: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libpthread_nonshared.a
-      mode: 755
   license: (Apache-2.0 AND GPL-3.0)
 
 apps:


### PR DESCRIPTION
The correct permissions rw-r-r seems to be given anyway