### PR TITLE
Issue 1812 realtime animation without generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       compiler: clang
       env:
         - HOPSAN_BUILD_QMAKE_SPEC=macx-clang
+        - HOMEBREW_NO_AUTO_UPDATE=1
       install:
         - brew install qt
         - brew link --force qt

--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -224,7 +224,7 @@ void AnimatedComponent::updateAnimation()
                             data.append(*mpNodeDataPtrs->at(m).at(i));
                             if(!std::isfinite(data.last()))
                             {
-                                mpAnimationWidget->stop();
+                                mpAnimationWidget->stop_reset();
                                 gpMessageHandler->addErrorMessage("Encountered Inf or NaN value. Real-time animation aborted.");
                                 return;
                             }

--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -1168,3 +1168,14 @@ void AnimatedScope::updateAnimation()
     AnimatedComponent::updateAnimation();
     updatePlotwindow();
 }
+
+void AnimatedPlotData::clear()
+{
+#if QT_VERSION >= 0x050000
+    pModelObjectPort.clear();
+#else
+    pModelObjectPort = QPointer<Port>();
+#endif
+    animatedPlotData.clear();
+    logData.clear();
+}

--- a/HopsanGUI/GUIObjects/AnimatedComponent.h
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.h
@@ -100,12 +100,7 @@ struct AnimatedPlotData
     SharedVectorVariableT animatedPlotData;
     SharedVectorVariableT logData;
 
-    void clear()
-    {
-        pModelObjectPort.clear();
-        animatedPlotData.clear();
-        logData.clear();
-    }
+    void clear();
 };
 
 class AnimatedScope : public AnimatedComponent

--- a/HopsanGUI/GUIObjects/AnimatedComponent.h
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.h
@@ -44,12 +44,14 @@
 
 #include "GUIObject.h"
 #include "GUIModelObjectAppearance.h"
+#include "LogVariable.h"
 
 class AnimationWidget;
 class AnimatedIcon;
 class ModelObject;
 class ModelObjectAppearance;
 class PlotWindow;
+class Port;
 
 class AnimatedComponent : public QObject
 {
@@ -61,7 +63,7 @@ public:
     AnimatedComponent(ModelObject* unanimatedComponent, AnimationWidget *parent);
 
     void draw();
-    void updateAnimation();
+    virtual void updateAnimation();
     ModelObjectAnimationData *getAnimationDataPtr();
     int indexOfMovable(AnimatedIcon *pMovable);
     QPointF getPortPos(QString portName);
@@ -71,7 +73,7 @@ public:
 private slots:
     void textEdited();
 
-private:
+protected:
     void setupAnimationBase(QString basePath);
     void setupAnimationMovable(int m);
     void limitMovables();
@@ -90,11 +92,39 @@ private:
 
     bool mIsDisplay;
     bool mIsNumericalInput;
-
-    PlotWindow *mpPlotWindow;
 };
 
+struct AnimatedPlotData
+{
+    QPointer<Port> pModelObjectPort;
+    SharedVectorVariableT animatedPlotData;
+    SharedVectorVariableT logData;
 
+    void clear()
+    {
+        pModelObjectPort.clear();
+        animatedPlotData.clear();
+        logData.clear();
+    }
+};
+
+class AnimatedScope : public AnimatedComponent
+{
+    Q_OBJECT
+    friend class AnimatedIcon;
+public:
+    AnimatedScope(ModelObject* unanimatedScope, AnimationWidget *parent) : AnimatedComponent(unanimatedScope, parent) {}
+    void openPlotwindow();
+    void updatePlotwindow();
+    void updateAnimation() override;
+protected:
+    QPointer<PlotWindow> mpPlotWindow;
+    AnimatedPlotData mTimeData;
+    AnimatedPlotData mBottomData;
+    QVector<AnimatedPlotData> mLeftDatas;
+    QVector<AnimatedPlotData> mRightDatas;
+
+};
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/HopsanGUI/LogVariable.h
+++ b/HopsanGUI/LogVariable.h
@@ -188,6 +188,7 @@ public:
     void elementWiseEq(QVector<double> &rResult, const double value, const double eps) const;
     void elementWiseEq(QVector<double> &rResult, const SharedVectorVariableT pOther, const double eps) const;
     bool compare(SharedVectorVariableT pOther, const double eps) const;
+    int lower_bound(const double value, const bool assumeSorted=false) const;
 
     // Check out and return pointers to data (move to ram if necessary)
     QVector<double> *beginFullVectorOperation();

--- a/HopsanGUI/Widgets/AnimationWidget.cpp
+++ b/HopsanGUI/Widgets/AnimationWidget.cpp
@@ -179,11 +179,8 @@ AnimationWidget::AnimationWidget(QWidget *parent) :
     mHydraulicIntensityMin = mpAnimationData->hydraulicMinPressure;
     mHydraulicSpeed = mpAnimationData->flowSpeed;
 
-    //Collect plot data from container (for non-realtime animations)
-    //mpContainer->collectPlotData();
     mpPlotData = mpContainer->getLogDataHandler().data();
     mpPlayButton->setDisabled(mpPlotData->isEmpty());
-    mpPlayRealTimeButton->setDisabled(mpPlotData->isEmpty());
     mpRewindButton->setDisabled(mpPlotData->isEmpty());
 
     if(!mpPlotData->isEmpty() && !mpPlotData->getTimeVectorVariable(-1).isNull())
@@ -237,9 +234,15 @@ AnimationWidget::AnimationWidget(QWidget *parent) :
     }
 
     //Create animated components from components list
-    for(int g=0;g<mModelObjectsList.size();g++)
+    for(ModelObject* pMO : mModelObjectsList)
     {
-        AnimatedComponent *pAnimatedComponent = new AnimatedComponent(mModelObjectsList.at(g), this);
+        AnimatedComponent *pAnimatedComponent;
+        if (pMO->getTypeName() == HOPSANGUISCOPECOMPONENTTYPENAME) {
+            pAnimatedComponent = new AnimatedScope(pMO, this);
+        }
+        else {
+            pAnimatedComponent = new AnimatedComponent(pMO, this);
+        }
         mAnimatedComponentList.append(pAnimatedComponent);
     }
 

--- a/HopsanGUI/Widgets/AnimationWidget.h
+++ b/HopsanGUI/Widgets/AnimationWidget.h
@@ -111,7 +111,7 @@ public:
     double mHydraulicSpeed;
 
 public slots:
-    void stop();
+    void stop_reset();
 
 private slots:
     void openPreferencesDialog();
@@ -125,6 +125,9 @@ private slots:
     void resetAllAnimationDataToDefault();
 
 private:
+    void adjustFps();
+    void stop();
+
     //Graphics scene
     QGraphicsScene *mpGraphicsScene;
 
@@ -148,9 +151,9 @@ private:
     QLineEdit* mpTimeDisplay;
 
     //Animation timer object
-    QTimer *mpTimer;
-    QTime *mpTime;
-    int mLastTimeCheck;
+    QTimer *mpAnimationStepTrigger;
+    QTime *mpFpsAdjustClock;
+    int mLastFpsAdjustTime;
 
     //Layout
     QGridLayout *mpLayout;


### PR DESCRIPTION
Make it possible to run real-time animation (and plotting) without needing a log data generation. Data will be saved in orphan variables instead.
Also fix "real-time" plotting of play-back data. Now correct data index will be used instead of latest.

While this PR improves the usability of real-time plotting, many issues remain. Will create separate issue for those.

Resolves #1812 