### PR TITLE
Fix Simulink compilation with VS2017

### DIFF
--- a/HopsanCore/include/Component.h
+++ b/HopsanCore/include/Component.h
@@ -40,6 +40,7 @@
 #include "win32dll.h"
 #include <map>
 #include <list>
+#include <algorithm>
 
 namespace hopsan {
 

--- a/HopsanCore/src/ComponentUtilities/IntegratorLimited.cpp
+++ b/HopsanCore/src/ComponentUtilities/IntegratorLimited.cpp
@@ -34,6 +34,7 @@
 //#include <iostream>
 //#include <cassert>
 //#include <math.h>
+#include <algorithm>
 #include "ComponentUtilities/IntegratorLimited.h"
 
 using namespace hopsan;


### PR DESCRIPTION
Added missing include of <algorithm> for compiling with VS2017 and C++11 (required for using std::min and std::max).