### PR TITLE
Various text editor improvements

### DIFF
--- a/HopsanGUI/MainWindow.cpp
+++ b/HopsanGUI/MainWindow.cpp
@@ -434,6 +434,7 @@ void MainWindow::initializeWorkspace()
     // Create the find widget
     gpFindWidget = new FindWidget(this);
     mpCentralGridLayout->addWidget(gpFindWidget,5,0,1,4);
+    gpFindWidget->setDisabled(true);
     gpFindWidget->hide();
 
     // File association - ignore everything else and open the specified file if there is a hmf file in the argument list
@@ -1445,6 +1446,10 @@ void MainWindow::updateToolBarsToNewTab()
     mpExportToLabviewAction->setEnabled(modelTab);
     mpExportToSimulinkAction->setEnabled(modelTab);
     mpLoadModelParametersAction->setEnabled(modelTab);
+
+    if(gpFindWidget) {
+        gpFindWidget->setEnabled(modelTab || editorTab);
+    }
 }
 
 

--- a/HopsanGUI/ModelHandler.cpp
+++ b/HopsanGUI/ModelHandler.cpp
@@ -50,6 +50,7 @@
 #include "version_gui.h"
 #include "Widgets/DebuggerWidget.h"
 #include "MessageHandler.h"
+#include "Widgets/FindWidget.h"
 #include "Widgets/LibraryWidget.h"
 #include "Widgets/ModelWidget.h"
 #include "Widgets/ProjectTabWidget.h"
@@ -673,10 +674,11 @@ void ModelHandler::refreshMainWindowConnections()
             gpLibraryWidget->setGfxType(pCurrentModel->getTopLevelSystemContainer()->getGfxType());
         }
     }
-    TextEditorWidget *pScriptEditor = qobject_cast<TextEditorWidget*>(gpMainWindow->mpCentralTabs->currentWidget());
-    if(pScriptEditor)
+    TextEditorWidget *pTextEditor = qobject_cast<TextEditorWidget*>(gpMainWindow->mpCentralTabs->currentWidget());
+    if(pTextEditor)
     {
-        connectMainWindowConnections(pScriptEditor);
+        connectMainWindowConnections(pTextEditor);
+        gpFindWidget->setTextEditor(pTextEditor);
     }
 
     emit modelChanged(pCurrentModel);

--- a/HopsanGUI/Utilities/HighlightingUtilities.cpp
+++ b/HopsanGUI/Utilities/HighlightingUtilities.cpp
@@ -350,15 +350,15 @@ CppHighlighter::CppHighlighter(QTextDocument *parent)
                     << "\\bfriend\\b" << "\\binline\\b" << "\\bint\\b"
                     << "\\blong\\b" << "\\bnamespace\\b" << "\\boperator\\b"
                     << "\\bprivate\\b" << "\\bprotected\\b" << "\\bpublic\\b"
-                    << "\\bshort\\b" << "\\bsignals\\b" << "\\bsigned\\b"
-                    << "\\bslots\\b" << "\\bstatic\\b" << "\\bstruct\\b"
-                    << "\\btemplate\\b" << "\\btypedef\\b" << "\\btypename\\b"
-                    << "\\bunion\\b" << "\\bunsigned\\b" << "\\bvirtual\\b"
-                    << "\\bvoid\\b" << "\\bvolatile\\b" << "\\busing\\b"
-                    << "\\bbool\\b" << "\\bif\\b" << "\\belse\\b"
-                    << "\\bfor\\b" << "\\bforeach\\b" << "\\bwhile\\b"
+                    << "\\bshort\\b" << "\\bsigned\\b" << "\\bstatic\\b"
+                    << "\\bstruct\\b" << "\\btemplate\\b" << "\\btypedef\\b"
+                    << "\\btypename\\b" << "\\bunion\\b" << "\\bunsigned\\b"
+                    << "\\bvirtual\\b" << "\\bvoid\\b" << "\\bvolatile\\b"
+                    << "\\busing\\b" << "\\bbool\\b" << "\\bif\\b"
+                    << "\\belse\\b" << "\\bfor\\b" << "\\bwhile\\b"
                     << "\\bswitch\\b" << "\\bcase\\b" << "\\bdefault\\b"
-                    << "\\bbreak\\b" << "\\breturn\\b" << "\\bif\\()";
+                    << "\\bbreak\\b" << "\\breturn\\b" << "\\bif\\()"
+                    << "\\bconstexpr\\b";
     foreach (const QString &pattern, keywordPatterns)
     {
         rule.pattern = QRegExp(pattern);

--- a/HopsanGUI/Utilities/HighlightingUtilities.cpp
+++ b/HopsanGUI/Utilities/HighlightingUtilities.cpp
@@ -371,7 +371,13 @@ CppHighlighter::CppHighlighter(QTextDocument *parent)
     QStringList hopsanKeywordPatterns;
     hopsanKeywordPatterns << "\\bPort\\b" << "\\bFirstOrderTransferFunctionVariable\\b" << "\\bSecondOrderTransferFunctionVariable\\b"
                           << "\\bFirstOrderTransferFunction\\b" << "\\bSecondOrderTransferFunction\\b"
-                          << "\\bFirstOrderFiler\\b" << "\\bSecondOrderFilter\\b";
+                          << "\\bFirstOrderFiler\\b" << "\\bSecondOrderFilter\\b" << "\\bDelay\\b"
+                          << "\\bIntegrator\\b" << "\\bIntegratorLimited\\b" << "\\bTurbulentFlowFunction\\b"
+                          << "\\bValveHysteresis\\b" << "\\bDoubleIntegratorWithDamping\\b" << "\\bDoubleIntegratorWithDampingAndCoulumbFriction\\b"
+                          << "\\bCSVParser\\b" << "\\bCSVParserNG\\b" << "\\bPLOParser\\b"
+                          << "\\bWhiteGaussianNoise\\b" << "\\bEquationSystemSolver\\b" << "\\bNumericalIntegrationSolver\\b"
+                          << "\\bLookupTable1D\\b" << "\\bLookupTable2D\\b" << "\\bLookupTable3D\\b";
+
     foreach (const QString &pattern, hopsanKeywordPatterns)
     {
         rule.pattern = QRegExp(pattern);

--- a/HopsanGUI/Utilities/HighlightingUtilities.cpp
+++ b/HopsanGUI/Utilities/HighlightingUtilities.cpp
@@ -368,19 +368,11 @@ CppHighlighter::CppHighlighter(QTextDocument *parent)
 
     mHopsanKeywordFormat.setForeground(Qt::darkMagenta);
     mHopsanKeywordFormat.setFontWeight(QFont::Normal);
-    QStringList hopsanKeywordPatterns;
-    hopsanKeywordPatterns << "\\bPort\\b" << "\\bFirstOrderTransferFunctionVariable\\b" << "\\bSecondOrderTransferFunctionVariable\\b"
-                          << "\\bFirstOrderTransferFunction\\b" << "\\bSecondOrderTransferFunction\\b"
-                          << "\\bFirstOrderFiler\\b" << "\\bSecondOrderFilter\\b" << "\\bDelay\\b"
-                          << "\\bIntegrator\\b" << "\\bIntegratorLimited\\b" << "\\bTurbulentFlowFunction\\b"
-                          << "\\bValveHysteresis\\b" << "\\bDoubleIntegratorWithDamping\\b" << "\\bDoubleIntegratorWithDampingAndCoulumbFriction\\b"
-                          << "\\bCSVParser\\b" << "\\bCSVParserNG\\b" << "\\bPLOParser\\b"
-                          << "\\bWhiteGaussianNoise\\b" << "\\bEquationSystemSolver\\b" << "\\bNumericalIntegrationSolver\\b"
-                          << "\\bLookupTable1D\\b" << "\\bLookupTable2D\\b" << "\\bLookupTable3D\\b";
-
+    QStringList hopsanKeywordPatterns = getHopsanKeywordPatterns();
     foreach (const QString &pattern, hopsanKeywordPatterns)
     {
-        rule.pattern = QRegExp(pattern);
+        QString actualPattern = "\\b"+pattern+"\\b";
+        rule.pattern = QRegExp(actualPattern);
         rule.format = mHopsanKeywordFormat;
         mHighlightingRules.append(rule);
     }
@@ -455,6 +447,18 @@ void CppHighlighter::highlightBlock(const QString &text)
         setFormat(startIndex, commentLength, mMultiLineCommentFormat);
         startIndex = mCommentStartExpression.indexIn(text, startIndex + commentLength);
     }
+}
+
+QStringList CppHighlighter::getHopsanKeywordPatterns()
+{
+    return QStringList() << "Port" << "FirstOrderTransferFunctionVariable" << "SecondOrderTransferFunctionVariable"
+                         << "FirstOrderTransferFunction" << "SecondOrderTransferFunction"
+                         << "FirstOrderFiler" << "SecondOrderFilter" << "Delay"
+                         << "Integrator" << "IntegratorLimited" << "TurbulentFlowFunction"
+                         << "ValveHysteresis" << "DoubleIntegratorWithDamping" << "DoubleIntegratorWithDampingAndCoulumbFriction"
+                         << "CSVParser" << "CSVParserNG" << "PLOParser"
+                         << "WhiteGaussianNoise" << "EquationSystemSolver" << "NumericalIntegrationSolver"
+                         << "LookupTable1D" << "LookupTable2D" << "LookupTable3D";
 }
 
 

--- a/HopsanGUI/Utilities/HighlightingUtilities.h
+++ b/HopsanGUI/Utilities/HighlightingUtilities.h
@@ -101,6 +101,7 @@ class CppHighlighter : public QSyntaxHighlighter
 
 public:
     CppHighlighter(QTextDocument *parent = 0);
+    static QStringList getHopsanKeywordPatterns();
 
 protected:
     void highlightBlock(const QString &text);

--- a/HopsanGUI/Widgets/FindWidget.cpp
+++ b/HopsanGUI/Widgets/FindWidget.cpp
@@ -31,6 +31,7 @@
 #include "ModelWidget.h"
 #include "GraphicsView.h"
 #include "Utilities/GUIUtilities.h"
+#include "Widgets/TextEditorWidget.h"
 
 #include <QLineEdit>
 #include <QLabel>
@@ -53,6 +54,7 @@ FindWidget::FindWidget(QWidget *parent) :
     QToolButton *pCloseButton = new QToolButton(this);
     mpCaseSensitivityCheckBox = new QCheckBox("Case Sensitive", this);
     mpWildcardCheckBox = new QCheckBox("Match Wildcards (*)", this);
+    mpBackwardsCheckBox = new QCheckBox("Search Backwards", this);
     pCloseButton->setIcon(QIcon(":graphics/uiicons/svg/Hopsan-Discard.svg"));
 
     QVBoxLayout *pMainLayout = new QVBoxLayout(this);
@@ -68,6 +70,7 @@ FindWidget::FindWidget(QWidget *parent) :
     pSubLayout1->setStretch(1,1);
     pSubLayout2->addWidget(mpCaseSensitivityCheckBox);
     pSubLayout2->addWidget(mpWildcardCheckBox);
+    pSubLayout2->addWidget(mpBackwardsCheckBox);
     pSubLayout2->addWidget(new QWidget(this), 1);
     connect(mpFindButton, SIGNAL(clicked()), this, SLOT(find()));
     connect(pCloseButton, SIGNAL(clicked()), this, SLOT(close()));
@@ -79,10 +82,35 @@ FindWidget::FindWidget(QWidget *parent) :
 void FindWidget::setContainer(ContainerObject *pContainer)
 {
     mpContainer = pContainer;
+    mpTextEditor = nullptr;
+    mpFindWhatComboBox->setVisible(true);
+    mpWildcardCheckBox->setVisible(true);
+    mpBackwardsCheckBox->setVisible(false);
+}
+
+void FindWidget::setTextEditor(TextEditorWidget *pEditor)
+{
+    mpTextEditor = pEditor;
+    mpContainer = nullptr;
+    mpFindWhatComboBox->setVisible(false);
+    mpWildcardCheckBox->setVisible(false);
+    mpBackwardsCheckBox->setVisible(true);
 }
 
 void FindWidget::find()
 {
+    if(mpTextEditor) {
+        QTextDocument::FindFlags flags;
+        if(mpCaseSensitivityCheckBox->isChecked()) {
+            flags |= QTextDocument::FindCaseSensitively;
+        }
+        if(mpBackwardsCheckBox->isChecked()) {
+            flags |= QTextDocument::FindBackward;
+        }
+
+        mpTextEditor->find(mpFindLineEdit->text(), flags);
+    }
+
     Qt::CaseSensitivity caseSensitivity = Qt::CaseInsensitive;
     if(mpCaseSensitivityCheckBox->isChecked())
         caseSensitivity = Qt::CaseSensitive;

--- a/HopsanGUI/Widgets/FindWidget.h
+++ b/HopsanGUI/Widgets/FindWidget.h
@@ -37,14 +37,15 @@
 
 // Forward declaration
 class ContainerObject;
+class TextEditorWidget;
 
 class FindWidget : public QWidget
 {
     Q_OBJECT
 public:
     explicit FindWidget(QWidget *parent = 0);
-    void setContainer(ContainerObject *pContainer);
-
+    void setContainer(ContainerObject* pContainer);
+    void setTextEditor(TextEditorWidget* pEditor);
 signals:
 
 public slots:
@@ -66,8 +67,10 @@ private:
     QPushButton* mpFindButton;
     QCheckBox* mpCaseSensitivityCheckBox;
     QCheckBox* mpWildcardCheckBox;
+    QCheckBox* mpBackwardsCheckBox;
 
     QPointer<ContainerObject> mpContainer;
+    QPointer<TextEditorWidget> mpTextEditor;
 
 };
 

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -615,7 +615,7 @@ void TextEditor::updateAutoCompleteList()
     else if(mLanguage == HighlighterTypeEnum::Cpp) {
         QStringList lines = toPlainText().split("\n");
 
-        QStringList dataTypes = QStringList() << "size_t" << "double" << "int" << "SecondOrderTransferFunction" << "FirstOrderTransferFunction" << "Port";
+        QStringList dataTypes = QStringList() << "size_t" << "double" << "int" << CppHighlighter::getHopsanKeywordPatterns();
         QStringList functions = QStringList() << "addInputVariable" << "addOutputVariable" << "addConstant" << "addPowerPort" << "getSafeNodeDataPtr";
 
         int bracketCounter=-1;

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -89,6 +89,15 @@ TextEditorWidget::TextEditorWidget(QFileInfo scriptFileInfo, HighlighterTypeEnum
     connect(mpEditor, SIGNAL(textChanged()), this, SLOT(hasChanged()));
 }
 
+TextEditorWidget::~TextEditorWidget()
+{
+    mpHcomHighlighter->deleteLater();
+    mpCppHighlighter->deleteLater();
+    mpXmlHighlighter->deleteLater();
+    mpModelicaHighlighter->deleteLater();
+    mpPythonXmlHighlighter->deleteLater();
+}
+
 void TextEditorWidget::find(QString text, QTextDocument::FindFlags flags)
 {
     mpEditor->find(text,flags);

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -636,7 +636,7 @@ void TextEditor::updateAutoCompleteList()
 
             if(dataTypes.contains(line.simplified().section(" ",0,0)))
             {
-                variables.append(line.simplified().split(","));
+                variables.append(line.section("//",0,0).simplified().split(","));
             }
         }
         for(int v=0; v<variables.size(); ++v)

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -615,7 +615,7 @@ void TextEditor::updateAutoCompleteList()
     else if(mLanguage == HighlighterTypeEnum::Cpp) {
         QStringList lines = toPlainText().split("\n");
 
-        QStringList dataTypes = QStringList() << "double" << "int" << "SecondOrderTransferFunction" << "FirstOrderTransferFunction" << "Port";
+        QStringList dataTypes = QStringList() << "size_t" << "double" << "int" << "SecondOrderTransferFunction" << "FirstOrderTransferFunction" << "Port";
         QStringList functions = QStringList() << "addInputVariable" << "addOutputVariable" << "addConstant" << "addPowerPort" << "getSafeNodeDataPtr";
 
         int bracketCounter=-1;

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -89,6 +89,12 @@ TextEditorWidget::TextEditorWidget(QFileInfo scriptFileInfo, HighlighterTypeEnum
     connect(mpEditor, SIGNAL(textChanged()), this, SLOT(hasChanged()));
 }
 
+void TextEditorWidget::find(QString text, QTextDocument::FindFlags flags)
+{
+    mpEditor->find(text,flags);
+}
+
+
 void TextEditorWidget::wheelEvent(QWheelEvent* event)
 {
 #if QT_VERSION >= 0x050000  //zoomIn() and zoomOut() not available in Qt4

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -355,15 +355,20 @@ void TextEditor::highlightCurrentLine()
 
 
 //! @brief Update function for line number area
+//! @param rect Rectangle to update
+//! @param dy Amount of pixels viewport is scrolled vertically
 void TextEditor::updateLineNumberArea(const QRect &rect, int dy)
 {
-    if (dy)
+    if(dy != 0) {
         mpLineNumberArea->scroll(0, dy);
-    else
+    }
+    else {
         mpLineNumberArea->update(0, rect.y(), mpLineNumberArea->width(), rect.height());
+    }
 
-    if (rect.contains(viewport()->rect()))
+    if (rect.contains(viewport()->rect())) {
         updateLineNumberAreaWidth(0);
+    }
 }
 
 void TextEditor::keyPressEvent(QKeyEvent* event)

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -641,7 +641,10 @@ void TextEditor::updateAutoCompleteList()
         }
         for(int v=0; v<variables.size(); ++v)
         {
+            variables[v] = variables[v].section("=",0,0);
             variables[v].remove("*");
+            variables[v].remove("&");
+            variables[v].remove("!");
             variables[v].remove(";");
             for(int d=0; d<dataTypes.size(); ++d)
             {

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -648,6 +648,8 @@ void TextEditor::updateAutoCompleteList()
                 variables[v].remove(dataTypes[d]+" ");
             }
             variables[v].remove(" ");
+
+            //Remove index brackets from array variables
             while(variables[v].contains("["))
             {
                 variables[v].remove("["+variables[v].section("[",1,1).section("]",0,0)+"]");

--- a/HopsanGUI/Widgets/TextEditorWidget.h
+++ b/HopsanGUI/Widgets/TextEditorWidget.h
@@ -103,6 +103,7 @@ class TextEditorWidget : public QWidget
     Q_OBJECT
 public:
     explicit TextEditorWidget(QFileInfo file, HighlighterTypeEnum highlighter, QWidget *parent = nullptr);
+    ~TextEditorWidget();
 
     QFileInfo getFileInfo() const { return mFileInfo; }
     bool isSaved() const { return mIsSaved; }

--- a/HopsanGUI/Widgets/TextEditorWidget.h
+++ b/HopsanGUI/Widgets/TextEditorWidget.h
@@ -107,6 +107,9 @@ public:
     QFileInfo getFileInfo() const { return mFileInfo; }
     bool isSaved() const { return mIsSaved; }
 
+public slots:
+    void  find(QString text, QTextDocument::FindFlags flags);
+
 protected:
     void wheelEvent(QWheelEvent* event);
 


### PR DESCRIPTION
Related to #1818.
- Disable find widget when no model or editor is active
- Rename pScriptEditor to pTextEditor
- Support for text editors in find widget
- Remove Qt-specific keywords from C++ highlighter
- Add most component utility classes to C++ highlighter
- Cleanup member pointers in tet editor destructor
- Add C++ autocompleter to text editor