### PR TITLE
Export all ports (ignore logonly) for FinalResults

### DIFF
--- a/HopsanCLI/ModelUtilities.cpp
+++ b/HopsanCLI/ModelUtilities.cpp
@@ -189,9 +189,9 @@ void saveResults(ComponentSystem *pSys, const string &rFileName, const SaveResul
                 {
                     //cout << "port: " << p << " of: " << ports.size() << endl;
                     Port *pPort = ports[p];
-                    if (!pPort->isLoggingEnabled())
+                    // Ignore ports that have logging disabled when saving full data
+                    if ((howMany == SaveResults::Full) && !pPort->isLoggingEnabled())
                     {
-                        // Ignore ports that have logging disabled
                         continue;
                     }
                     const vector<NodeDataDescription> *pVars = pPort->getNodeDataDescriptions();


### PR DESCRIPTION
When only final values are written to file, it wont be very large
so it may as well contain all of the value.
Full results may become VERY large, and only saving the data that
really matters is therefor useful.

#Resolves #1854 