### PR TITLE
Copy all documentation graphics files to HTML directory

### DIFF
--- a/buildDocumentation.bat
+++ b/buildDocumentation.bat
@@ -10,6 +10,13 @@ set PATH=C:\Program Files\gs\gs9.21\bin;C:\Program Files (x86)\gs\gs9.21\bin;%PA
 set PATH=C:\Program Files\gs\gs9.22\bin;C:\Program Files (x86)\gs\gs9.22\bin;%PATH% 
 set PATH=C:\Program Files (x86)\Graphviz2.38\bin;%PATH%
 
+REM Modify Doxygen scripts to copy all graphics files to HTML directory
+cd doc
+echo Calling PS
+PowerShell.exe ./copyGraphics.ps1
+echo Finished
+cd ..
+
 where /q gswin32c.exe
 if ERRORLEVEL 1 (
   echo Error: gswin32c.exe could not be found

--- a/buildDocumentation.sh
+++ b/buildDocumentation.sh
@@ -6,6 +6,11 @@
 # Date:   2011-11-28
 
 cd doc
+
+files=$(find graphics -type f) && files=$(echo $files)
+sed "s@HTML_EXTRA_FILES       = @HTML_EXTRA_FILES       = ${files}@" -i Doxyfile
+sed "s@HTML_EXTRA_FILES       = @HTML_EXTRA_FILES       = ${files}@" -i Doxyfile_full
+
 if [ "$1" = "full" ]; then
     echo "Building full documentation"
     doxygen Doxyfile_full

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1149,7 +1149,7 @@ HTML_EXTRA_STYLESHEET  = hopsan.css
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       =
+HTML_EXTRA_FILES       = graphics/mainwindow.png graphics/graphics/library.png graphics/graphics/tfanalysis_icon.png graphics/fft_icon.png graphics/sensitivity_icon.png graphics/sensitivity_dialog.png graphics/sensitivity_plot.png graphics/optimization_icon.png graphics/ports.png graphics/node.png graphics/systemparameters_icon.png graphics/configuration_icon.png graphics/simulate_icon.png graphics/plot_icon.png graphics/favoritevariable_icon.png graphics/toggleplotvariables_icon.png graphics/plotresettimevector_icon.png graphics/zoomplot_icon.png graphics/panplot_icon.png graphics/saveplot_icon.png graphics/loadplot_icon.png graphics/exportplot_icon.png graphics/exportplotgfx_icon.png graphics/toggleplotcurvecontrolpanel_icon.png graphics/export_simulink_icon.png graphics/export_fmu_icon.png graphics/import_fmu_icon.png graphics/energylosses_icon.png graphics/energylosses_model1.png graphics/energylosses_barplot1.png graphics/energylosses_model2.png graphics/energylosses_barplot2.png graphics/tlm.png graphics/cq.png graphics/animation_icon.png
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.11
+﻿# Doxyfile 1.8.11
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -1149,7 +1149,7 @@ HTML_EXTRA_STYLESHEET  = hopsan.css
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       = graphics/mainwindow.png graphics/graphics/library.png graphics/graphics/tfanalysis_icon.png graphics/fft_icon.png graphics/sensitivity_icon.png graphics/sensitivity_dialog.png graphics/sensitivity_plot.png graphics/optimization_icon.png graphics/ports.png graphics/node.png graphics/systemparameters_icon.png graphics/configuration_icon.png graphics/simulate_icon.png graphics/plot_icon.png graphics/favoritevariable_icon.png graphics/toggleplotvariables_icon.png graphics/plotresettimevector_icon.png graphics/zoomplot_icon.png graphics/panplot_icon.png graphics/saveplot_icon.png graphics/loadplot_icon.png graphics/exportplot_icon.png graphics/exportplotgfx_icon.png graphics/toggleplotcurvecontrolpanel_icon.png graphics/export_simulink_icon.png graphics/export_fmu_icon.png graphics/import_fmu_icon.png graphics/energylosses_icon.png graphics/energylosses_model1.png graphics/energylosses_barplot1.png graphics/energylosses_model2.png graphics/energylosses_barplot2.png graphics/tlm.png graphics/cq.png graphics/animation_icon.png
+HTML_EXTRA_FILES       = 
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to

--- a/doc/Doxyfile_full
+++ b/doc/Doxyfile_full
@@ -1154,7 +1154,7 @@ HTML_EXTRA_STYLESHEET  = hopsan.css
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       =
+HTML_EXTRA_FILES       = graphics/mainwindow.png graphics/graphics/library.png graphics/graphics/tfanalysis_icon.png graphics/fft_icon.png graphics/sensitivity_icon.png graphics/sensitivity_dialog.png graphics/sensitivity_plot.png graphics/optimization_icon.png graphics/ports.png graphics/node.png graphics/systemparameters_icon.png graphics/configuration_icon.png graphics/simulate_icon.png graphics/plot_icon.png graphics/favoritevariable_icon.png graphics/toggleplotvariables_icon.png graphics/plotresettimevector_icon.png graphics/zoomplot_icon.png graphics/panplot_icon.png graphics/saveplot_icon.png graphics/loadplot_icon.png graphics/exportplot_icon.png graphics/exportplotgfx_icon.png graphics/toggleplotcurvecontrolpanel_icon.png graphics/export_simulink_icon.png graphics/export_fmu_icon.png graphics/import_fmu_icon.png graphics/energylosses_icon.png graphics/energylosses_model1.png graphics/energylosses_barplot1.png graphics/energylosses_model2.png graphics/energylosses_barplot2.png graphics/tlm.png graphics/cq.png graphics/animation_icon.png
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to

--- a/doc/Doxyfile_full
+++ b/doc/Doxyfile_full
@@ -1154,7 +1154,7 @@ HTML_EXTRA_STYLESHEET  = hopsan.css
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       = graphics/mainwindow.png graphics/graphics/library.png graphics/graphics/tfanalysis_icon.png graphics/fft_icon.png graphics/sensitivity_icon.png graphics/sensitivity_dialog.png graphics/sensitivity_plot.png graphics/optimization_icon.png graphics/ports.png graphics/node.png graphics/systemparameters_icon.png graphics/configuration_icon.png graphics/simulate_icon.png graphics/plot_icon.png graphics/favoritevariable_icon.png graphics/toggleplotvariables_icon.png graphics/plotresettimevector_icon.png graphics/zoomplot_icon.png graphics/panplot_icon.png graphics/saveplot_icon.png graphics/loadplot_icon.png graphics/exportplot_icon.png graphics/exportplotgfx_icon.png graphics/toggleplotcurvecontrolpanel_icon.png graphics/export_simulink_icon.png graphics/export_fmu_icon.png graphics/import_fmu_icon.png graphics/energylosses_icon.png graphics/energylosses_model1.png graphics/energylosses_barplot1.png graphics/energylosses_model2.png graphics/energylosses_barplot2.png graphics/tlm.png graphics/cq.png graphics/animation_icon.png
+HTML_EXTRA_FILES       = 
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to

--- a/doc/copyGraphics.ps1
+++ b/doc/copyGraphics.ps1
@@ -1,0 +1,19 @@
+#Get list of all png files in grahpics folder
+$names = Get-ChildItem graphics -Filter "*.png" -Name | Out-String
+
+#Remove space at end of string
+$names = $names.trim()
+
+#Replace line breaks with spaces and prepend path to each filename
+$names = $names.replace("`r`n"," graphics/")
+
+#Prepend path to first filename
+$names = "graphics/$names"
+
+#Replace string in user doxyfile
+cat Doxyfile | %{$_ -replace "HTML_EXTRA_FILES       = ","HTML_EXTRA_FILES       = $names"} | Out-File -Encoding "UTF8" Doxyfile_tmp
+mv -Force Doxyfile_tmp Doxyfile
+
+#Replace string in full doxyfile
+cat Doxyfile_full | %{$_ -replace "HTML_EXTRA_FILES       = ","HTML_EXTRA_FILES       = $names"} | Out-File -Encoding "UTF8" Doxyfile_tmp
+mv -Force Doxyfile_tmp Doxyfile_full

--- a/doc/userAnimation.dox
+++ b/doc/userAnimation.dox
@@ -3,7 +3,7 @@
 
 Hopsan models can be animated, either in real-time or as replays. Animation is accessed through the Animate icon in the simulation toolbar, or from the menus.
 
-\htmlimagerightcaption{../graphics/animation_icon.png, Animate}
+\htmlimagerightcaption{animation_icon.png, Animate}
 \image latex "animation_icon.png" "Animate"
 
 This opens the model in animation mode. There is a toolbar where it is possible to replay, rewind, stop or play in real-time. Animation speed can also be adjusted. Some animation parameters can be adjusted by the parameters icon, or by double-clicking on movable icons in the workspace.

--- a/doc/userEnergyLosses.dox
+++ b/doc/userEnergyLosses.dox
@@ -4,7 +4,7 @@
 
 Hopsan has a built-in tool for estimating energy efficiency and identifying power losses in a model. To use this, first simulate the model and then click the "Calculate Losses" icon:
 
-\htmlimagerightcaption{../graphics/energylosses_icon.png, Calculate Losses}
+\htmlimagerightcaption{energylosses_icon.png, Calculate Losses}
 \image latex "energylosses_icon.png" "Calculate Losses"
 
 Added or consumed energy in each component is calculated by summing up the added or removed energy in each port. It does not separate useful energy from losses automatically, simply because this depends on how "useful" is defined. The total energy in a model is thus always conserved.
@@ -15,22 +15,22 @@ The energy efficiency tool will open a bar plot with total added or consumed ene
 
 As an example, let's use the "Position Servo" model (found under Help-Examples Models). This uses a constant pressure system with a fixed pump and a pressure relief valve. This is a common, but very energy inefficient solution. The pump will always supply flow to the system, and pressure will be maintained by the pressure drop over the relief valve.
 
-\htmllinkimage{../graphics/energylosses_model1.png, 400}
+\htmllinkimage{energylosses_model1.png, 400}
 \image latex "energylosses_model1.png" "Energy losses model1"
 
 When simulating this model and clicking the energy losses icon, the following graph appears. As we can see, approximately 860 kJ is added to the pump, and most of it is lost (converted to heat and noise) at the relief valve.
 
-\htmllinkimage{../graphics/energylosses_barplot1.png, 400}
+\htmllinkimage{energylosses_barplot1.png, 400}
 \image latex "energylosses_barplot1.png" "Energy losses barplot1"
 
 Now we will try to improve efficiency. A much better approach is to use a pressure controlled pump, so that the system pressure is adjusted from the displacement setting in the pump. A relief valve is still needed to reduce pressure peaks. Adjust the settings so that the system pressure and the step response is similar as in the previous model.
 
-\htmllinkimage{../graphics/energylosses_model2.png, 400}
+\htmllinkimage{energylosses_model2.png, 400}
 \image latex "energylosses_model2.png" "Energy losses model2"
 
 Now click the energy icon again. As we can see, the pump now only consumes about 15 kJ of energy, whereof 11 kJ is lost in the relief valve. This system thus require 57 times less energy to perform the same work!
 
-\htmllinkimage{../graphics/energylosses_barplot2.png, 400}
+\htmllinkimage{energylosses_barplot2.png, 400}
 \image latex "energylosses_barplot2.png" "Energy losses barplot2"
 
 */

--- a/doc/userFrequencyAnalysis.dox
+++ b/doc/userFrequencyAnalysis.dox
@@ -7,7 +7,7 @@ Hopsan has built-in tools for Nyquist diagrams, Bode plots and frequency spectru
 
 Transfer function analysis will generate Nyquist diagrams and bode plots. It is accessed from the toolbar in the plot window. To use this you need to define two curves, representing the input and the output signal. Add these curves to the same plot tab and then press the Transfer Function Analysis button.
 
-\htmlimagerightcaption{../graphics/tfanalysis_icon.png, Transfer Function Analysis}
+\htmlimagerightcaption{tfanalysis_icon.png, Transfer Function Analysis}
 \image latex "tfanalysis_icon.png" "Transfer Function Analysis"
 
 
@@ -25,7 +25,7 @@ A dialog will appear, where input signal and output signal can be selected. It i
 
 It is possible to generate a frequency spectrum for a curve in the plot window. This is accessed by clicking the Frequency Spectrum button in the curve control panel (below the plot area).
 
-\htmlimagerightcaption{../graphics/fft_icon.png, Frequency Analysis}
+\htmlimagerightcaption{fft_icon.png, Frequency Analysis}
 \image latex "fft_icon.png" "Frequency Analysis"
 
 A dialog will appear, where it is possible to choose whether to use logarithmic scaling or power spectrum The latter means that the square of the frequencies are used, to give a better picture of the energy contents. After clicking "Go," a new plot tab with the frequency spectrum will appear.

--- a/doc/userGettingStarted.dox
+++ b/doc/userGettingStarted.dox
@@ -12,7 +12,7 @@
 \page overview Overview
 The first thing you will see when you open Hopsan is a welcome dialog. From here you can choose to create a new model, load an existing model or open the models from last session. You also have the option to always open the last session, without showing the welcome dialog. When you have made your selection, the main window will appear. It will look like the screenshot bellow (with some cosmetic differences depending on your operating system). It consists of a tool bar at the top, a workspace area in the middle, a component library to the left and a message widget at the bottom. More windows and widgets can be opened later.
 
-\htmllinkimage{../graphics/mainwindow.png, 500}
+\htmllinkimage{mainwindow.png, 500}
 \image latex mainwindow.png "The Hopsan main window" width=1.0\linewidth
 
 \section toolbar Toolbar
@@ -41,7 +41,7 @@ Models are displayed in the workspace area. More than one model can be opened at
 
 \section library Library
 Components are added to the workspace by dragging them from the library widget to the left. Standard libraries exist with hydraulic, mechanic and signal components. Each of these categories have a number of subcategories, which makes it easier to find a certain component. External libraries can be loaded either from the File menu, or by right clicking in the library and selecting "Add External Library". Unloading an external library is done in the same way. 
-\htmllinkimage{../graphics/library.png, 180}
+\htmllinkimage{library.png, 180}
 \image latex "library.png"
 
 
@@ -66,7 +66,7 @@ Components in HOPSAN are connected by creating a \a node between two or more \a 
 
 The connection is created by clicking on one of the ports, drawing the connector the way you want it and finally clicking on the end port. Most ports, but not all, must be connected before simulating the model. Note that the TLM method results in that C-type components, such as volumes, can only be connected to Q-type components, such as valves or orifices. This can feel a little tricky, but is on the other hand always physically motivated. Signal components are simulated sequentially and do not obey these rules.
 \htmlonly
-<br><img src="../graphics/ports.png" width=250 border=0><img src="../graphics/node.png" width=250 border=0><br>
+<br><img src="ports.png" width=250 border=0><img src="node.png" width=250 border=0><br>
 \endhtmlonly
 \image latex "ports.png" "Ports" width=0.45\linewidth
 \image latex "node.png" "Nodes" width=0.45\linewidth
@@ -78,7 +78,7 @@ To change parameters of a component, you can double-click on it to open its para
 \section using-global-parameters Using Global Parameters
 Global system parameters can be used to quickly change a parameter value in several components at once. To do this, open the \a System \a Parameters widget by clicking on the little earth globe icon in the toolbar or by pressing Ctrl+Alt+Y. 
 
-\htmlimagerightcaption{../graphics/systemparameters_icon.png,System Parameters}
+\htmlimagerightcaption{systemparameters_icon.png,System Parameters}
 \image latex "systemparameters_icon.png" "System Parameters"
 
 From here new system parameters can be added or removed by clicking on the "Set" and "Unset" buttons. Values can be changed directly by double-clicking on their values in the list. They can then be used as parameters in components by clicking on the icon to the right of the parameter value box in the component's parameter dialog. When a system parameter is changed, it is changed for all components that use it. Should a system parameter be removed, the components that use it will change to simply using the last numerical value of the parameter instead.
@@ -110,63 +110,63 @@ After the simulation there is a finalize phase, where components has the opportu
 \section setting-up-simulation-parameters Setting up simulation parameters
 Start value, time step and stop time can be changed directly in the toolbar at the top of the main window. Choosing the time step is always a trade-off; smaller time steps will give more accurate results, but will also slow down the simulation. Apart from these settings, it is also possible to change how many data samples that will be logged for plotting. This is done in the Model Preferences dialog, which is accessed from the monkey wrench icon in the simulation toolbar. This is also a trade-off; too few data samples will result in less good looking plots, while too much logging will slow down the simulation. 
 
-\htmlimagerightcaption{../graphics/configuration_icon.png, Model Properties}
+\htmlimagerightcaption{configuration_icon.png, Model Properties}
 \image latex "configuration_icon.png" "Model Properties"
 
 When all setup is finished, the simulation is executed by clicking on the green "play" button in the simulation toolbar. If the progress bar is enabled (can be disabled from Options Dialog for performance reasons), it is possible to abort the simulation by clicking "Abort". 
 
-\htmlimagerightcaption{../graphics/simulate_icon.png, Simulate}
+\htmlimagerightcaption{simulate_icon.png, Simulate}
 \image latex "simulate_icon.png" "Simulate"
 
 \page plotting Plotting
 Plot curves are shown in plot windows. There are two methods to open a new plot window. The easiest way is to right click on a port in the workspace and choose "Plot <variable>" from the menu. This will create a new plot window with the selected plot variable. The more advanced way is to open the plot widget, by clicking on the plot icon in the simulation toolbar or by pressing Ctrl+Shift+P. A list with all components in the current model will then appear. This list can be expanded so that it shows all ports in each component. From here a plot window can be created by double clicking on a port name or by dragging it to the workspace.
 
-\htmlimagerightcaption{../graphics/plot_icon.png, Open Plot Widget}
+\htmlimagerightcaption{plot_icon.png, Open Plot Widget}
 \image latex "plot_icon.png" "Open Plot Widget"
 
 Because this list can be long and time consuming to search, it is possible to mark those variables that are especially interesting as \a favorite \a variables. This is done by right clicking on them and choosing this in the drop-down menu. Favorite parameters gets a yellow star in front of their names, and they always appear at the top in the widget to make them easily accessible. 
 
-\htmlimagerightcaption{../graphics/favoritevariable_icon.png, Favorite Variable}
+\htmlimagerightcaption{favoritevariable_icon.png, Favorite Variable}
 \image latex "favoritevariable_icon.png" "Favorite Variables"
 
 Once a plot window has been opened, it is possible to add more plot curves to it by dragging items from the variable list to the window. The variable list is also accessible from inside the plot window, on the right side of the plot. On small monitors the list will be automatically hidden, but can be opened with the Toggle Plot Variables icon.
 
-\htmlimagerightcaption{../graphics/toggleplotvariables_icon.png, Toggle Plot Variables}
+\htmlimagerightcaption{toggleplotvariables_icon.png, Toggle Plot Variables}
 \image latex "toggleplotvariables_icon.png" "Toggle Plot Variables"
 
 New curves can be added either to the left y-axis, to the right y-axis or to the x-axis. The latter will replace the time vector and result in an XY-plot. The x-axis can be reset to the time vector by using the Reset Time Vector button.
 
-\htmlimagerightcaption{../graphics/plotresettimevector_icon.png, Reset Time Vector}
+\htmlimagerightcaption{plotresettimevector_icon.png, Reset Time Vector}
 \image latex "plotresettimevector_icon.png" "Reset Time Vector"
 
 Adding curves with different physical units to the same y-axis is generally not recommended, because they will use the same scale. The plot window contains several useful tools. First of all it is possible to zoom or pan the graphs by using the two leftmost icons. To return to the original position, simply right click anywhere in the plot area. 
 
-\htmlimagerightcaption{../graphics/zoomplot_icon.png, Zoom}
+\htmlimagerightcaption{zoomplot_icon.png, Zoom}
 \image latex "zoomplot_icon.png" "Zoom"
 
-\htmlimagerightcaption{../graphics/panplot_icon.png, Pan}
+\htmlimagerightcaption{panplot_icon.png, Pan}
 \image latex "panplot_icon.png" "Pan"
 
 The third button is used to save plot windows, so that they can be opened at a later time. Plot windows are saved in the XML-based .hmpf (Hopsan Model Plot File) format. These can be opened from the plot widget by using the "Load Plot Window From XML" button. 
 
-\htmlimagerightcaption{../graphics/saveplot_icon.png, Save To Plot Window Description File}
+\htmlimagerightcaption{saveplot_icon.png, Save To Plot Window Description File}
 \image latex "saveplot_icon.png" "Save To Plot Window Description File"
 
-\htmlimagerightcaption{../graphics/loadplot_icon.png, Load Plot Window Description File}
+\htmlimagerightcaption{loadplot_icon.png, Load Plot Window Description File}
 \image latex "loadplot_icon.png" "Load Plot Window Description File"
 
 Plot data can be exported to .xml (Extensible Markup Language), .csv (Comma-Separated Values), .m (Matlab script file) or .dat (gnuplot data file) formats. It is also possible to export plots graphically to .pdf or .png format.
-\htmlimagerightcaption{../graphics/exportplot_icon.png, Export Plot Data}
+\htmlimagerightcaption{exportplot_icon.png, Export Plot Data}
 \image latex "exportplot_icon.png" "Export Plot Data"
 
-\htmlimagerightcaption{../graphics/exportplotgfx_icon.png, Export Plot To Graphics File}
+\htmlimagerightcaption{exportplotgfx_icon.png, Export Plot To Graphics File}
 \image latex "exportplotgfx_icon.png" "Export Plot To Graphics File"
 
 The next two buttons are used to modify the plot window cosmetically. It is possible to show or hide the grid and to change the background color. 
 
 Each curve has its own set of icons below the plot. On small monitors these are hidden by default, they can be shown by clicking the Toggle Plot Curve Control Panel button.
 
-\htmlimagerightcaption{../graphics/toggleplotcurvecontrolpanel_icon.png, Toggle Plot Curve Control Panel}
+\htmlimagerightcaption{toggleplotcurvecontrolpanel_icon.png, Toggle Plot Curve Control Panel}
 \image latex "toggleplotcurvecontrolpanel_icon.png" "Toggle Plot Curve Control Panel"
 
 From here it is possible to control \a plot \a generations. If the same model are simulated several times, a new generation is added to the plot window as long as the "Auto Update" check box is checked. To move between different generations, press the left arrow or right arrow icons. It is also possible to modify the curve cosmetically, to perform frequency analysis, and to remove the curve from the plot.

--- a/doc/userModelExport.dox
+++ b/doc/userModelExport.dox
@@ -29,7 +29,7 @@ First of all we must have a model to export. In this example, we want to export 
 
 Next step is to export the files. Click the "Export" button and select Simulink Source Files.
 
-\htmlimagerightcaption{../graphics/export_simulink_icon.png, Export to S-function}
+\htmlimagerightcaption{export_simulink_icon.png, Export to S-function}
 \image latex "export_simulink_icon.png" "Export to S-function"
 
 A dialog appears, where you can choose version of Visual C++ and if you want 32-bit or 64-bit architecture. These settings should be chosen so that they match your version of Matlab. It is also possible to disable port graphics, for portability with older versions of Simulink. Use this setting only if Matlab gives an error message ending with "called mdlSetNumInputPorts more than once". 
@@ -59,7 +59,7 @@ The Functional Mock-up Interface is an open interface for communication between 
 \section export-fmu Exporting a Functional Mock-up Unit
 Hopsan models can be exported to FMUs by clicking on the Export to FMU button. Then choose an empty folder. All required files will be exported, compiled and compressed. Model inputs and outputs can be specified by using interface components.
 
-\htmlimagerightcaption{../graphics/export_fmu_icon.png, Export to FMU}
+\htmlimagerightcaption{export_fmu_icon.png, Export to FMU}
 \image latex "export_fmu_icon.png" "Export to FMU"
 
 \subsection export-fmu-prerequisites Prerequisites
@@ -68,7 +68,7 @@ Hopsan models can be exported to FMUs by clicking on the Export to FMU button. T
 \section import-fmu Importing a Functional Mock-up Unit
 FMUs from other programs (or from Hopsan itself) can be imported by clicking on the import from FMU icon. If all goes well they will appear as components in the component library. 
 
-\htmlimagerightcaption{../graphics/import_fmu_icon.png, Import from FMU}
+\htmlimagerightcaption{import_fmu_icon.png, Import from FMU}
 \image latex "import_fmu_icon.png" "Import from FMU"
 
 \subsection export-fmu-prerequisites Prerequisites

--- a/doc/userOptimization.dox
+++ b/doc/userOptimization.dox
@@ -78,7 +78,7 @@ Sixth International Symposium on Micromachine and Human Science, Nagoya, Japan. 
 
 2.	Click the 'Optimization' icon. It is found in the simulation toolbar, next to the simulate button. It can also be reached from the menus.
 
-\htmlimagerightcaption{../graphics/optimization_icon.png, Open Optimization Dialog}
+\htmlimagerightcaption{optimization_icon.png, Open Optimization Dialog}
 \image latex "optimization_icon.png" "Open Optimization Dialog"
 
 3.	Select general settings. Specify number of iterations, number of search points, reflection coefficient, randomization and forgetting factor and tolerances for convergence. Also choose whether to plot each iteration (will slow down optimization). In the example we choose 100 iterations, 4 search points, reflection coefficient of 1.3, randomization factor of 0.3, and a forgetting factor of 0. For tolerance values we use default settings.

--- a/doc/userSensitivityAnalysis.dox
+++ b/doc/userSensitivityAnalysis.dox
@@ -10,7 +10,7 @@ Hopsan can perform Monte Carlo-based sensitivity analysis. This means many simul
 
 2.	Click the 'Sensitivity Analysis' icon. It is found in the simulation tool bar. It can also be accessed from the menus.
 
-\htmlimagerightcaption{../graphics/sensitivity_icon.png, Open Sensitivity Analysis Dialog}
+\htmlimagerightcaption{sensitivity_icon.png, Open Sensitivity Analysis Dialog}
 \image latex "sensitivity_icon.png" "Open Sensitivity Analysis Dialog"
 
 
@@ -18,12 +18,12 @@ Hopsan can perform Monte Carlo-based sensitivity analysis. This means many simul
 
 4.  Choose which output variables. In this example, we want to know how the step response of the position servo is affected when damping is uncertain. The dialog should now look similar to this:
 
-\htmllinkimage{../graphics/sensitivity_dialog.png, 500}
+\htmllinkimage{sensitivity_dialog.png, 500}
 \image latex "sensitivity_dialog.png" "Sensitivity Analysis settings dialog"
 
 5.  Now press the "Start Analysis" button. The model will be simulated 99 times with randomized damping parameters. When done, the results from all simulations will be plotted in one graph:
 
-\htmllinkimage{../graphics/sensitivity_plot.png, 500}
+\htmllinkimage{sensitivity_plot.png, 500}
 \image latex "sensitivity_plot.png" "Sensitivity Analysis results"
 
 

--- a/doc/userTransmissionLineElementMethod.dox
+++ b/doc/userTransmissionLineElementMethod.dox
@@ -9,13 +9,13 @@ Power-transmitting components are divided into two types. The first type is capa
 \endhtmlonly
 
 \htmlonly
-<br><img src="../graphics/tlm.png" width=500><br><br>
+<br><img src="tlm.png" width=500><br><br>
 \endhtmlonly
 
 The second type is restrictive components, called "Q-type" (because they write the flow). In hydraulics, these are components that somehow limits the flow, such as valves and orifices. These work in the opposite way to C-type components, by taking c and Zc as input variables and returning pressure and flow. For this to work is it necessary that a C-type component only is connected to Q-type components and vice versa. 
 
 \htmlonly
-<br><img src="../graphics/cq.png" width=500><br><br>
+<br><img src="cq.png" width=500><br><br>
 \endhtmlonly
 
 */


### PR DESCRIPTION
This is needed for building documentation to the new `documentation` repository.

All graphics files for the documentation will now be copied into the `/html`directory. In this way we avoid relative paths (`../graphics/image.png`), which does not work in the new repository.