### PR TITLE
Update indexing csv parser dependency

### DIFF
--- a/HopsanCore/HopsanCore.pro
+++ b/HopsanCore/HopsanCore.pro
@@ -27,7 +27,7 @@ INCLUDEPATH *= $${PWD}/../componentLibraries/defaultLibrary
 #--------------------------------------------------------
 # Set the rappidxml and csv_parser include paths
 INCLUDEPATH *= $${PWD}/dependencies/rapidxml
-INCLUDEPATH *= $${PWD}/dependencies/indexingcsvparser
+INCLUDEPATH *= $${PWD}/dependencies/indexingcsvparser/include
 #--------------------------------------------------------
 
 #--------------------------------------------------------
@@ -139,7 +139,7 @@ SOURCES += \
     src/ComponentUtilities/HopsanPowerUser.cpp \
     src/ComponentUtilities/LookupTable.cpp \
     src/ComponentUtilities/PLOParser.cpp \
-    $${PWD}/dependencies/indexingcsvparser/IndexingCSVParser.cpp \
+    $${PWD}/dependencies/indexingcsvparser/src/indexingcsvparser.cpp \
     src/Quantities.cpp \
     src/CoreUtilities/NumHopHelper.cpp \
     src/CoreUtilities/AliasHandler.cpp \
@@ -193,8 +193,7 @@ HEADERS += \
     include/Components/ModelicaComponent.hpp \
     include/ComponentUtilities/LookupTable.h \
     include/ComponentUtilities/PLOParser.h \
-    $${PWD}/dependencies/indexingcsvparser/IndexingCSVParser.h \
-    $${PWD}/dependencies/indexingcsvparser/IndexingCSVParserImpl.hpp \
+    $${PWD}/dependencies/indexingcsvparser/include/indexingcsvparser/indexingcsvparser.h \
     include/Quantities.h \
     include/NodeRWHelpfuncs.hpp \
     include/HopsanCoreVersion.h \
@@ -204,12 +203,3 @@ HEADERS += \
     include/CoreUtilities/AliasHandler.h \
     include/CoreUtilities/SimulationHandler.h \
     include/CoreUtilities/SaveRestoreSimulationPoint.h
-
-
-
-
-
-
-
-
-

--- a/HopsanCore/src/ComponentUtilities/CSVParser.cpp
+++ b/HopsanCore/src/ComponentUtilities/CSVParser.cpp
@@ -31,7 +31,7 @@
 //$Id$
 
 #define INDCSVP_REPLACEDECIMALCOMMA
-#include "IndexingCSVParser.h"
+#include "indexingcsvparser/indexingcsvparser.h"
 
 #include "ComponentUtilities/CSVParser.h"
 

--- a/HopsanGenerator/src/GeneratorUtilities.cpp
+++ b/HopsanGenerator/src/GeneratorUtilities.cpp
@@ -535,7 +535,7 @@ QStringList getHopsanCoreIncludePaths()
     includePaths << "HopsanCore/include" <<
                     "componentLibraries/defaultLibrary";
     includePaths << "HopsanCore/dependencies/rapidxml" <<
-                    "HopsanCore/dependencies/indexingcsvparser" <<
+                    "HopsanCore/dependencies/indexingcsvparser/include" <<
                     "HopsanCore/dependencies/libnumhop/include";
     return includePaths;
 }
@@ -661,7 +661,7 @@ QStringList listHopsanCoreSourceFiles(const QString &hopsanInstallationPath)
     findAllFilesInFolderAndSubFolders(hopsanInstallationPath+"/Dependencies", "cc", allFiles);
     findAllFilesInFolderAndSubFolders(hopsanInstallationPath+"/Dependencies", "cpp", allFiles);
     findAllFilesInFolderAndSubFolders(hopsanInstallationPath+"/HopsanCore/dependencies/libnumhop/src", "cpp", allFiles);
-    allFiles << hopsanInstallationPath+"/HopsanCore/dependencies/indexingcsvparser/IndexingCSVParser.cpp";
+    allFiles << hopsanInstallationPath+"/HopsanCore/dependencies/indexingcsvparser/src/indexingcsvparser.cpp";
 
     QDir rootDir(hopsanInstallationPath);
 
@@ -683,8 +683,7 @@ QStringList listHopsanCoreIncludeFiles(const QString &hopsanInstallationPath)
     findAllFilesInFolderAndSubFolders(hopsanInstallationPath+"/Dependencies", "hpp", allFiles);
     findAllFilesInFolderAndSubFolders(hopsanInstallationPath+"/HopsanCore/dependencies/rapidxml", "hpp", allFiles);
     findAllFilesInFolderAndSubFolders(hopsanInstallationPath+"/HopsanCore/dependencies/libnumhop/include", "h", allFiles);
-    allFiles << hopsanInstallationPath+"/HopsanCore/dependencies/indexingcsvparser/IndexingCSVParser.h" <<
-                hopsanInstallationPath+"/HopsanCore/dependencies/indexingcsvparser/IndexingCSVParserImpl.hpp";
+    allFiles << hopsanInstallationPath+"/HopsanCore/dependencies/indexingcsvparser/include/indexingcsvparser/indexingcsvparser.h";
 
     QDir rootDir(hopsanInstallationPath);
 


### PR DESCRIPTION
Update indexingcsvparser library

- Now support loading values from white-space padded columns
- Supports header extraction (not used in Hopsan yet)
- Can optionally strip leading and trailing white-spaces when extracting string data (not used in Hopsan yet)