### PR TITLE
Update build scripts to use official Qt 5.12.5 and mingw 7.3 on Windows for 32 and 64 bit

### DIFF
--- a/Dependencies/setHopsanBuildPaths.bat
+++ b/Dependencies/setHopsanBuildPaths.bat
@@ -29,12 +29,12 @@ if not "%hopsan_arch%"=="x86" (
 REM Setup Default compiler and Qt paths
 if "%hopsan_arch%"=="x86" (
 	REM These paths require the official Qt version from Qt.io (for 32-bit)
-	set mingw_path=C:\Qt\Tools\mingw492_32\bin
-	set qmake_path=C:\Qt\5.6.3\mingw49_32\bin
+	set mingw_path=C:\Qt\Tools\mingw730_32\bin
+	set qmake_path=C:\Qt\5.12.5\mingw73_32\bin
 ) else (
 	REM These paths require the custom build Qt library for Hopsan 64-bit
-	set mingw_path=C:\hopsan-dev\x86_64-4.9.4-release-posix-seh-rt_v5-rev0\mingw64\bin
-	set qmake_path=C:\hopsan-dev\qt-5.6.3-x64-mingw494-posix-seh-rt_v5-rev0\bin
+	set mingw_path=C:\Qt\Tools\mingw730_64\bin
+	set qmake_path=C:\Qt\5.12.5\mingw73_64\bin
 )
 
 REM Tool paths

--- a/Dependencies/setupDiscount.bat
+++ b/Dependencies/setupDiscount.bat
@@ -28,8 +28,7 @@ REM Build with mingw patches
 
 REM The first patch was taken from https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-discount
 REM It was however modified to grep for Msys instead of MINGW (from uname -a)
-bash.exe -c "patch -p0 < ../discount-mingw-building.patch; patch -p1 < ../discount-2.1.8-msys.patch; CC=gcc ./configure.sh --shared --prefix=%installdir_bash% --confdir=%installdir_bash%/etc; make -j4; make install"
-REM Note! We use msys make here as mingw32-make is to strict since 4.9.2
+bash.exe -c "patch -p0 < ../discount-mingw-building.patch; patch -p1 < ../discount-2.1.8-msys.patch; CC=gcc ./configure.sh --shared --prefix=%installdir_bash% --confdir=%installdir_bash%/etc; mingw32-make -j4; mingw32-make install"
 
 cd %basedir%
 echo.


### PR DESCRIPTION
While this seem to work fine, the QtWebkit support is missing and I want to try and build that before merging this. 