### PR TITLE
Prevent generating header guards starting with digits

### DIFF
--- a/HoLC/Dialogs/CreateComponentWizard.cpp
+++ b/HoLC/Dialogs/CreateComponentWizard.cpp
@@ -541,7 +541,7 @@ void CreateComponentWizard::generate()
     compTemplateFile.close();
 
 
-    QString headerGuard = typeName.toUpper()+"_HPP_INCLUDED";
+    QString headerGuard = "HEADER_"+typeName.toUpper()+"_INCLUDED";
     QString memberVariableCode;
     QString localVariableCode;
     QString addConstantsCode;

--- a/HopsanGenerator/src/generators/HopsanFMIGenerator.cpp
+++ b/HopsanGenerator/src/generators/HopsanFMIGenerator.cpp
@@ -356,7 +356,7 @@ bool HopsanFMIGenerator::generateFromFmu1(const QString &rFmuPath, const QString
         return false;
     }
 
-    QString headerGuard = fmuName.toUpper()+"_HPP_INCLUDED";
+    QString headerGuard = "FMU_"+fmuName.toUpper()+"_HPP_INCLUDED";
     QString className = "FMU_"+fmuName;
     // Lets default FMUs to signal components unless a HopsanTLM port specification xml is present
     QString classParent = "ComponentSignal";
@@ -793,7 +793,7 @@ bool HopsanFMIGenerator::generateFromFmu2(const QString &rFmuPath, const QString
         return false;
     }
 
-    QString headerGuard = fmuName.toUpper()+"_HPP_INCLUDED";
+    QString headerGuard = "FMU_"+fmuName.toUpper()+"_HPP_INCLUDED";
     QString className = "FMU_"+fmuName;
     // Lets default FMUs to signal components unless a HopsanTLM port specification xml is present
     QString classParent = "ComponentSignal";


### PR DESCRIPTION
They are invalid and will not compile