### PR TITLE
Fix not being able to import FMU, due to new 0.3 Library XML format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin/
 HopsanNG_bd/
 output64/
 output/
+output_deb/
 *.pro.user*
 *~
 *.o

--- a/HopsanGenerator/include/generators/HopsanGeneratorBase.h
+++ b/HopsanGenerator/include/generators/HopsanGeneratorBase.h
@@ -83,7 +83,7 @@ public:
     void printErrorMessage(const QString &msg) const;
 
     void compileFromComponentSpecification(const QString &outputFile, const ComponentSpecification &comp, const bool overwriteStartValues=false, const QString customSourceFile="");
-    bool generateNewLibrary(QString dstPath, QStringList hppFiles, QStringList cflags=QStringList(), QStringList lflags=QStringList(), QStringList includePaths=QStringList(), QStringList linkPaths=QStringList(), QStringList linkLibraries=QStringList());
+    bool generateNewLibrary(QString dstPath, QString libName, QStringList hppFiles, QStringList cafFiles=QStringList(), QStringList cflags=QStringList(), QStringList lflags=QStringList(), QStringList includePaths=QStringList(), QStringList linkPaths=QStringList(), QStringList linkLibraries=QStringList());
     bool generateCafFile(QString &rPath, ComponentAppearanceSpecification &rCafSpec);
     bool generateComponentSourceFile(QString &path, ComponentSpecification &comp, TargetLanguageT target=Cpp);
     bool generateLibrarySourceFile(const ComponentLibrary &lib);

--- a/HopsanGenerator/include/hopsangenerator.h
+++ b/HopsanGenerator/include/hopsangenerator.h
@@ -33,7 +33,7 @@ extern "C" {
 
     HOPSANGENERATOR_DLLAPI bool callAddExistingComponentToLibrary(const char* libraryXMLPath, const char* cafPath, messagehandler_t messageHandler=0, void* pMessageObject=0);
 
-    HOPSANGENERATOR_DLLAPI bool callRemoveComponentFromLibrary(const char* libraryXmlPath, const char* cafPath, const char *hppPath, bool deleteFiles, messagehandler_t messageHandler, void *pMessageObject);
+    HOPSANGENERATOR_DLLAPI bool callRemoveComponentFromLibrary(const char* libraryXmlPath, const char* cafPath, const char *sourceCodePath, bool deleteFiles, messagehandler_t messageHandler, void *pMessageObject);
 }
 
 #endif // HOPSANGENERATOR_H

--- a/HopsanGenerator/src/HopsanGeneratorLib.cpp
+++ b/HopsanGenerator/src/HopsanGeneratorLib.cpp
@@ -64,7 +64,9 @@ bool callModelicaGenerator(const char* moFilePath, const char* compilerPath, mes
         QString dir = mofile.absolutePath()+"/";
         QString typeName = mofile.baseName();
         QStringList hppFiles {typeName+".hpp"};
-        bool genLibraryOK = pGenerator->generateNewLibrary(dir, hppFiles);
+        QString libName = QDir(dir).dirName();
+        //! @todo Is my use of {libName+".xml"} correct here for modelica generator usage ?
+        bool genLibraryOK = pGenerator->generateNewLibrary(dir, libName, hppFiles, {libName+".xml"});
         if (!genLibraryOK) {
             return false;
         }
@@ -87,7 +89,10 @@ bool callLibraryGenerator(const char*  outputPath, const char* const hppFiles[],
     {
         tempList.append(hppFiles[i]);
     }
-    return pGenerator->generateNewLibrary(outputPath, tempList);
+    QString libName = QDir(outputPath).dirName();
+    //! @todo what about caf files? It seems that this code is only called from HopsanGUI to generate a new empty library right now, it is also in a block of EXPERIMENTAL code in the component properties dialog
+    //! @todo The for now this works since its only called to create a new empty library, but the callLibraryGenerator should take the caf files as input also
+    return pGenerator->generateNewLibrary(outputPath, libName, tempList);
 }
 
 
@@ -156,7 +161,10 @@ bool callCppGenerator(const char* hppPath, const char* compilerPath, bool compil
         QString dir = hp.absolutePath()+"/";
         QString typeName = hp.baseName();
         QStringList hppFiles {typeName+".hpp"};
-        bool genLibraryOK = pGenerator->generateNewLibrary(dir, hppFiles);
+        QString libName = QDir(dir).dirName();
+        //! @todo what about caf files, this code seems to be called ONLY from EXPERIMENTAL code in LibraryHandler (create new component) and Component Properties dialog.
+        //! @todo This code is not used unless EXPERIMENTAL is defined, maybe it can be removed
+        bool genLibraryOK = pGenerator->generateNewLibrary(dir, libName, hppFiles);
         if (!genLibraryOK) {
             return false;
         }
@@ -201,7 +209,8 @@ bool callFmuImportGenerator(const char* fmuFilePath, const char* targetPath, con
 
     // Generate the component library files
     QStringList hppFiles {hppFileInfo.filePath()};
-    bool genOK = pGenerator->generateNewLibrary(fmuImportRoot.canonicalFilePath(), hppFiles , cflags, lflags);
+    QString libName = QDir(fmuImportRoot.canonicalFilePath()).dirName();
+    bool genOK = pGenerator->generateNewLibrary(fmuImportRoot.canonicalFilePath(), libName, hppFiles, {libName+".xml"}, cflags, lflags);
     if (!genOK) {
         pGenerator->printErrorMessage("Failed to generate FMU import library");
         return false;

--- a/HopsanGenerator/src/generators/HopsanGeneratorBase.cpp
+++ b/HopsanGenerator/src/generators/HopsanGeneratorBase.cpp
@@ -872,7 +872,7 @@ void HopsanGeneratorBase::compileFromComponentSpecification(const QString &outpu
 //! @param[in] hppFiles Relative path to hpp files
 //! @param[in] cflags Compiler flags required for building the library
 //! @param[in] lflags Linker flags required for building the library
-bool HopsanGeneratorBase::generateNewLibrary(QString dstPath, QStringList hppFiles, QStringList cflags, QStringList lflags, QStringList includePaths, QStringList linkPaths, QStringList linkLibraries)
+bool HopsanGeneratorBase::generateNewLibrary(QString dstPath, QString libName, QStringList hppFiles, QStringList cafFiles, QStringList cflags, QStringList lflags, QStringList includePaths, QStringList linkPaths, QStringList linkLibraries)
 {
     printMessage("Creating new component library...");
 
@@ -882,7 +882,6 @@ bool HopsanGeneratorBase::generateNewLibrary(QString dstPath, QStringList hppFil
         dstPath.append("/");
     }
 
-    QString libName = QDir(dstPath).dirName();
     const QString libID = QUuid::createUuid().toString().remove('{').remove('}');
 
     QStringList typeNames;
@@ -940,6 +939,7 @@ bool HopsanGeneratorBase::generateNewLibrary(QString dstPath, QStringList hppFil
     lib.mIncludePaths = includePaths;
     lib.mLinkPaths = linkPaths;
     lib.mLinkLibraries = linkLibraries;
+    lib.mComponentXMLFiles = cafFiles;
 
     const QString libFilePath = dstPath+libName+"_lib.xml";
     bool saveOK = lib.saveToXML(libFilePath);

--- a/HopsanGenerator/src/generators/HopsanGeneratorBase.cpp
+++ b/HopsanGenerator/src/generators/HopsanGeneratorBase.cpp
@@ -1088,7 +1088,7 @@ bool HopsanGeneratorBase::generateLibrarySourceFile(const ComponentLibrary &lib)
     QString output;
     output.append(QString("#include <iostream>\n"));
     output.append(QString("#include \"ComponentEssentials.h\"\n"));
-    for(const QString srcFile : lib.mComponentCodeFiles) {
+    for(const QString& srcFile : lib.mComponentCodeFiles) {
         output.append("#include \""+srcFile+"\"\n");
     }
     output.append("\n");
@@ -1097,7 +1097,7 @@ bool HopsanGeneratorBase::generateLibrarySourceFile(const ComponentLibrary &lib)
     output.append("extern \"C\" DLLEXPORT void register_contents(ComponentFactory* pComponentFactory, NodeFactory* pNodeFactory)\n");
     output.append("{\n");
     output.append("    //Register Components\n");
-    for(const QString srcFile : lib.mComponentCodeFiles) {
+    for(const QString& srcFile : lib.mComponentCodeFiles) {
         QString typeName = QFileInfo(srcFile).baseName();
         output.append("    pComponentFactory->registerCreatorFunction(\""+typeName+"\", "+typeName+"::Creator);\n");
     }


### PR DESCRIPTION
Exported FMUs cant be imported after the change to 0.3 library xml format. The reason is that the CAF files are not included in the import generated library xml. This may also be a problem with other import generators. 