### PR TITLE
Use mkstemp instead of tmpnam to avoid scary security warning

### DIFF
--- a/HopsanCore/include/ComponentUtilities/CSVParser.h
+++ b/HopsanCore/include/ComponentUtilities/CSVParser.h
@@ -35,6 +35,7 @@
 
 #include "win32dll.h"
 #include <vector>
+#include <cstdio>
 #include "HopsanTypes.h"
 
 // Forward declaration
@@ -55,6 +56,7 @@ public:
 
     bool openText(HString text);
     bool openFile(const HString &rFilepath);
+    bool takeOwnershipOfFile(FILE* pFile);
     void closeFile();
 
     void setCommentChar(char commentChar);
@@ -80,7 +82,6 @@ public:
 protected:
     indcsvp::IndexingCSVParser *mpCsvParser;
     HString mErrorString;
-    HString mTmpFileName;
     bool mConvertDecimalSeparator;
 };
 


### PR DESCRIPTION
This is used when opening temporary files with CSV data in lookup table components
tmpnam is not secure, and very scary compiler warnings are generated that look like errors