### PR TITLE
Remove warning when calling SymHop functions with no arguments

### DIFF
--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -1158,7 +1158,9 @@ QString Expression::toString() const
         {
             ret.append(mArguments[i].toString()+",");
         }
-        ret.chop(1);
+        if(!mArguments.isEmpty()) {
+            ret.chop(1);
+        }
         ret.append(")");
     }
     else if(this->isEquation())


### PR DESCRIPTION
SymHop used to print "pi()" as "pi)" when calling `toString` function. This caused harmless but annoying errors in HCOM terminal.