### PR TITLE
Fix potential double free of markdown document

### DIFF
--- a/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
+++ b/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
@@ -508,10 +508,13 @@ QWidget *ComponentPropertiesDialog3::createHelpWidget()
                 {
                     // Generate html from markdown
                     MMIOT *doc = mkd_in(inFile, 0);
-                    markdown(doc, outFile, MKD_TABSTOP);
-                    fclose(outFile);
+                    int rc = markdown(doc, outFile, MKD_TABSTOP);
+                    if (rc == -1) {
+                        // If rc == 0 then mkd_cleanup has already ben run on doc
+                        mkd_cleanup(doc);
+                    }
                     fclose(inFile);
-                    mkd_cleanup(doc);
+                    fclose(outFile);
 
                     // Now parse the html file for equations and images
                     QFile htmlFile(htmlFilePath);


### PR DESCRIPTION
This bug will crash HopsanGUI if you enter component properties dialog for LaminarOrifice, the only component that have markdown documentation. 

The problem was actually reported several years ago, occurring on Suse, but I have never been able to reproduce it until now, on Windows, after upgrading to the MinGW 5.4.0 compiler. I have never seen the bug occur on Ubuntu with any compiler.