### PR TITLE
Int bool sysparam inputdialog

### DIFF
--- a/HopsanGUI/Utilities/GUIUtilities.cpp
+++ b/HopsanGUI/Utilities/GUIUtilities.cpp
@@ -628,52 +628,15 @@ bool verifyParameterValue(QString &rValue, const QString type, const QStringList
     //Strip trailing and leading spaces
     stripLTSpaces(rValue);
 
-    // Removed checks to allow numhop expressions for doubles /Peter 20151126
+    // Doubles are evaluated numhop expressions
     if (type == "double")
     {
-//        bool onlyNumbers=true;
-//        if ( rValue[0].isNumber() || rValue[0] == '.')
-//        {
-            // Replace incorrect decimal separator
-            rValue.replace(",", ".");
-
-//            if( rValue.count("e") > 1 || rValue.count(".") > 1 || rValue.count("E") > 1 )
-//            {
-//                onlyNumbers=false;
-//            }
-//            else
-//            {
-//                // Since we have already checked the first digit we begin this loop at one to check the rest of them
-//                for(int i=1; i<rValue.size(); ++i)
-//                {
-//                    if(!rValue[i].isDigit() && (rValue[i] != 'e') && (rValue[i] != 'E') && (rValue[i] != '+') && (rValue[i] != '-') && (rValue[i] != '.'))
-//                    {
-//                        onlyNumbers=false;
-//                        break;
-//                    }
-//                    else if( (rValue[i] == '+' || rValue[i] == '-') && !((rValue[i-1] == 'e') || (rValue[i-1] == 'E')) )
-//                    {
-//                        onlyNumbers=false;
-//                        break;
-//                    }
-//                }
-//            }
-//        }
-//        else
-//        {
-//            onlyNumbers = false;
-//        }
-
-//        rValue.prepend(initialSign);
-//        if(!onlyNumbers)
-//        {
-//            rErrorString = QString("Invalid [double] parameter value \"%1\". Only numbers are allowed. Numeric strings like [-]1[eE][+-]5 will work.").arg(rValue);
-//        }
-//        return onlyNumbers;
-            return true;
+        // Replace incorrect decimal separator
+        rValue.replace(",", ".");
+        return true;
     }
 
-    QString initialSign="";
+    QString initialSign;
     // Strip initial +- sign to simplify further checks
     if ( (rValue[0] == '+') || (rValue[0] == '-') )
     {
@@ -702,7 +665,7 @@ bool verifyParameterValue(QString &rValue, const QString type, const QStringList
         rValue.prepend(initialSign);
         if(!onlyNumbers)
         {
-            rErrorString = QString("Invalid [integer] parameter value \"%1\". Only numbers are allowed.").arg(rValue);
+            rErrorString = QString("Invalid [integer] parameter value \"%1\". Only numbers or the name of a system parameter is allowed.").arg(rValue);
         }
 
         return onlyNumbers;
@@ -722,7 +685,7 @@ bool verifyParameterValue(QString &rValue, const QString type, const QStringList
         rValue.prepend(initialSign);
         if(!onlyNumbers)
         {
-            rErrorString = QString("Invalid [integer] parameter value \"%1\". Only numbers are allowed.").arg(rValue);
+            rErrorString = QString("Invalid [integer] parameter value \"%1\". Only numbers or the name of a system parameter is allowed.").arg(rValue);
         }
 
         return onlyNumbers;
@@ -731,7 +694,7 @@ bool verifyParameterValue(QString &rValue, const QString type, const QStringList
     {
         if ((rValue != "true") && (rValue != "false"))
         {
-            rErrorString = QString("Invalid [bool] parameter value \"%1\". Only \"true\" or \"false\" are allowed.").arg(rValue);
+            rErrorString = QString("Invalid [bool] parameter value \"%1\". Only \"true\" or \"false\" or the name of a system parameter is allowed.").arg(rValue);
             return false;
         }
         return true;

--- a/HopsanGUI/Widgets/SystemParametersWidget.cpp
+++ b/HopsanGUI/Widgets/SystemParametersWidget.cpp
@@ -42,6 +42,19 @@
 #include "FindWidget.h"
 #include "Configuration.h"
 
+namespace {
+
+//! @brief Get all  system parameter names for this system, parents and grand parents.
+QStringList getAllAccessibleSystemParameterNames(ContainerObject* pThisSystem) {
+    QStringList parameterNames = pThisSystem->getParameterNames();
+    if ( !pThisSystem->isTopLevelContainer() ) {
+        parameterNames += getAllAccessibleSystemParameterNames(pThisSystem->getParentContainerObject());
+    }
+    return parameterNames;
+}
+
+}
+
 
 QWidget *ParamTypeComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
@@ -246,9 +259,9 @@ bool SysParamTableModel::addOrSetParameter(CoreParameterData &rParameterData)
 
     bool isOk;
     QString errorString;
-    QStringList stringList;
+    QStringList allAccessibleSystemParameterNames = getAllAccessibleSystemParameterNames(mpContainerObject);
 
-    isOk = verifyParameterValue(rParameterData.mValue, rParameterData.mType, stringList, errorString);
+    isOk = verifyParameterValue(rParameterData.mValue, rParameterData.mType, allAccessibleSystemParameterNames, errorString);
     if (!isOk)
     {
         QMessageBox::critical(0, "Error", errorString);


### PR DESCRIPTION
Enable input of system parameter names for int and bool type system parameters, it is supported by the simulator but the GUI faild varification

Also restore functionality for negating integer system parameter values