### PR TITLE
Issue 1694 separate local and system parameters

### DIFF
--- a/HopsanCore/include/Component.h
+++ b/HopsanCore/include/Component.h
@@ -163,7 +163,6 @@ public:
     bool checkParameters(HString &errParName);
     void evaluateParameters();
     bool evaluateParameter(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
-    double evaluateDoubleParameter(const HString &rName, bool &rEvalOK);
 
     // Start values
     void setDefaultStartValue(Port* pPort, const size_t idx, const double value);

--- a/HopsanCore/include/ComponentSystem.h
+++ b/HopsanCore/include/ComponentSystem.h
@@ -123,6 +123,7 @@ namespace hopsan {
         bool evaluateNumHopScriptRecursively();
         bool runNumHopScript(const HString &rScript, bool printOutput, HString &rOutput);
         void setNumHopScript(const HString &rScript);
+        HString getNumHopScript() const;
 
         // Initialize and simulate
         bool checkModelBeforeSimulation();

--- a/HopsanCore/include/CoreUtilities/HmfLoader.h
+++ b/HopsanCore/include/CoreUtilities/HmfLoader.h
@@ -54,6 +54,7 @@ bool HOPSANCORE_DLLAPI isVersionAGreaterThanB(const HString& versionA, const HSt
 int HOPSANCORE_DLLAPI compareHopsanVersions(const HString& versionA, const HString& versionB);
 
 void HOPSANCORE_DLLAPI autoPrependSelfToParameterExpressions(Component* pComponent);
+HVector<HString> HOPSANCORE_DLLAPI findValuesNeedingPrependSelfInEmbeddedInitScript(ComponentSystem* pSystem);
 void HOPSANCORE_DLLAPI autoPrependSelfToEmbeddedInitScript(ComponentSystem* pSystem);
 
 ComponentSystem* loadHopsanModelFile(const HString &rFilePath, HopsanEssentials* pHopsanEssentials, double &rStartTime, double &rStopTime);

--- a/HopsanCore/include/CoreUtilities/HmfLoader.h
+++ b/HopsanCore/include/CoreUtilities/HmfLoader.h
@@ -53,6 +53,8 @@ int HOPSANCORE_DLLAPI getMinorVersion(const HString& version);
 bool HOPSANCORE_DLLAPI isVersionAGreaterThanB(const HString& versionA, const HString& versionB);
 int HOPSANCORE_DLLAPI compareHopsanVersions(const HString& versionA, const HString& versionB);
 
+void HOPSANCORE_DLLAPI autoPrependSelfToParameterExpressions(Component* pComponent);
+
 ComponentSystem* loadHopsanModelFile(const HString &rFilePath, HopsanEssentials* pHopsanEssentials, double &rStartTime, double &rStopTime);
 ComponentSystem* loadHopsanModel(const std::vector<unsigned char> xmlVector, HopsanEssentials* pHopsanEssentials);
 ComponentSystem* loadHopsanModel(const char* xmlStr, HopsanEssentials* pHopsanEssentials, double &rStartTime, double &rStopTime);

--- a/HopsanCore/include/CoreUtilities/HmfLoader.h
+++ b/HopsanCore/include/CoreUtilities/HmfLoader.h
@@ -54,6 +54,7 @@ bool HOPSANCORE_DLLAPI isVersionAGreaterThanB(const HString& versionA, const HSt
 int HOPSANCORE_DLLAPI compareHopsanVersions(const HString& versionA, const HString& versionB);
 
 void HOPSANCORE_DLLAPI autoPrependSelfToParameterExpressions(Component* pComponent);
+void HOPSANCORE_DLLAPI autoPrependSelfToEmbeddedInitScript(ComponentSystem* pSystem);
 
 ComponentSystem* loadHopsanModelFile(const HString &rFilePath, HopsanEssentials* pHopsanEssentials, double &rStartTime, double &rStopTime);
 ComponentSystem* loadHopsanModel(const std::vector<unsigned char> xmlVector, HopsanEssentials* pHopsanEssentials);

--- a/HopsanCore/include/CoreUtilities/NumHopHelper.h
+++ b/HopsanCore/include/CoreUtilities/NumHopHelper.h
@@ -52,6 +52,8 @@ public:
     bool eval(double &rValue, bool doPrintOutput, HString &rOutput);
 
     HVector<HString> extractVariableNames(const HString &expression) const;
+    static HVector<HString> extractNamedValues(const HString &expression);
+    static HString replaceNamedValue(const HString& expression, const HString &oldName, const HString& newName);
 
 private:
     ComponentSystem *mpSystem;

--- a/HopsanCore/include/HopsanTypes.h
+++ b/HopsanCore/include/HopsanTypes.h
@@ -69,6 +69,7 @@ public:
     bool empty() const;
     bool compare(const char* other) const;
     bool compare(const HString &rOther) const;
+    bool startsWith(const HString& rOther) const;
     bool isNummeric() const;
     bool isBool() const;
     double toDouble(bool *isOK) const;

--- a/HopsanCore/include/HopsanTypes.h
+++ b/HopsanCore/include/HopsanTypes.h
@@ -49,6 +49,7 @@ public:
     ~HString();
     HString(const char* str);
     HString(const char* str, const size_t len);
+    HString(char c);
     HString(const int value);
     HString(const HString &rOther);
     HString(const HString &rOther, size_t pos, size_t len=npos);

--- a/HopsanCore/include/Parameters.h
+++ b/HopsanCore/include/Parameters.h
@@ -111,7 +111,7 @@ public:
 
     bool evaluateParameters();
     bool evaluateInComponent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
-    bool evaluateInSystemParent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
+    bool evaluateRecursivelyInSystemParents(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
     bool evaluateParameterExpression(const HString &rExpression, HString &rEvaluatedParameterValue);
 
     bool hasParameter(const HString &rName) const;

--- a/HopsanCore/include/Parameters.h
+++ b/HopsanCore/include/Parameters.h
@@ -50,7 +50,7 @@ public:
     ParameterEvaluator(const HString &rName, const HString &rValue, const HString &rDescription, const HString &rQuantity, const HString &rUnit,
                        const HString &rType, void* pDataPtr=0, ParameterEvaluatorHandler* parentParameters=0);
 
-    bool setParameterValue(const HString &rValue, ParameterEvaluator **ppNeedEvaluation=0);
+    bool setParameterValue(const HString &rValue, ParameterEvaluator **ppNeedEvaluation=0, bool force=false);
     bool setParameter(const HString &rValue, const HString &rDescription, const HString &rQuantity, const HString &rUnit,
                       const HString &rType, ParameterEvaluator **pNeedEvaluation=0, bool force=false);
 

--- a/HopsanCore/include/Parameters.h
+++ b/HopsanCore/include/Parameters.h
@@ -88,7 +88,7 @@ protected:
 class HOPSANCORE_DLLAPI ParameterEvaluatorHandler
 {
 public:
-    ParameterEvaluatorHandler(Component* parentComponent);
+    ParameterEvaluatorHandler(Component* pComponent);
     ~ParameterEvaluatorHandler();
 
     bool addParameter(const HString &rName, const HString &rValue, const HString &rDescription,
@@ -117,10 +117,10 @@ public:
     bool hasParameter(const HString &rName) const;
     bool checkParameters(HString &rErrParName);
 
-    Component *getParentComponent() const;
+    Component *getComponent() const;
 
 protected:
-    Component* mParentComponent;
+    Component* mComponent;
     std::vector<ParameterEvaluator*> mParameters;
     std::vector<ParameterEvaluator*> mParametersNeedEvaluation; //! @todo Use this vector to ensure parameters are valid at simulation time e.g. if a used system parameter is deleted before simulation
 };

--- a/HopsanCore/include/Parameters.h
+++ b/HopsanCore/include/Parameters.h
@@ -107,7 +107,7 @@ public:
     bool setParameterValue(const HString &rName, const HString &rValue, bool force=false);
     void* getParameterDataPtr(const HString &rName);
 
-    bool evaluateParameter(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
+    bool evaluateInLocalComponent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
     bool evaluateParameters();
     bool refreshParameterValueText(const HString &rParameterName);
 

--- a/HopsanCore/include/Parameters.h
+++ b/HopsanCore/include/Parameters.h
@@ -48,7 +48,7 @@ class HOPSANCORE_DLLAPI ParameterEvaluator
     friend class ParameterEvaluatorHandler;
 public:
     ParameterEvaluator(const HString &rName, const HString &rValue, const HString &rDescription, const HString &rQuantity, const HString &rUnit,
-                       const HString &rType, void* pDataPtr=0, ParameterEvaluatorHandler* parentParameters=0);
+                       const HString &rType, void* pDataPtr=0, ParameterEvaluatorHandler* pParameterEvalHandler=0);
 
     bool setParameterValue(const HString &rValue, ParameterEvaluator **ppNeedEvaluation=0, bool force=false);
     bool setParameter(const HString &rValue, const HString &rDescription, const HString &rQuantity, const HString &rUnit,
@@ -80,7 +80,7 @@ protected:
     HString mType;
     void* mpData;
     size_t mDepthCounter;
-    ParameterEvaluatorHandler* mpParentParameters;
+    ParameterEvaluatorHandler* mpParameterEvaluatorHandler;
     std::vector<HString> mConditions;
 };
 
@@ -107,10 +107,10 @@ public:
     bool setParameterValue(const HString &rName, const HString &rValue, bool force=false);
     void* getParameterDataPtr(const HString &rName);
 
-    bool evaluateInLocalComponent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
-    bool evaluateParameters();
     bool refreshParameterValueText(const HString &rParameterName);
 
+    bool evaluateParameters();
+    bool evaluateInComponent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
     bool evaluateInSystemParent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType);
     bool evaluateParameterExpression(const HString &rExpression, HString &rEvaluatedParameterValue);
 

--- a/HopsanCore/src/Component.cpp
+++ b/HopsanCore/src/Component.cpp
@@ -145,7 +145,7 @@ void Component::evaluateParameters()
 
 bool Component::evaluateParameter(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType)
 {
-    return mpParameters->evaluateInLocalComponent(rName, rEvaluatedParameterValue, rType);
+    return mpParameters->evaluateInComponent(rName, rEvaluatedParameterValue, rType);
 }
 
 

--- a/HopsanCore/src/Component.cpp
+++ b/HopsanCore/src/Component.cpp
@@ -125,24 +125,6 @@ void Component::getParameterValue(const HString &rName, HString &rValue)
     mpParameters->getParameterValue(rName, rValue);
 }
 
-double Component::evaluateDoubleParameter(const HString &rName, bool &rEvalOK)
-{
-    HString val;
-    bool rc = false;
-    if(rName.startsWith("self#"))
-    {
-        HString name =rName.substr(5,rName.size()-5);
-        rc = mpParameters->evaluateInLocalComponent(name, val, "double");
-    }
-    else
-    {
-        rc = mpParameters->evaluateInSystemParent(rName, val, "double");
-    }
-    double v = val.toDouble(&rEvalOK);
-    rEvalOK = (rEvalOK && rc);
-    return v;
-}
-
 //! @brief Returns a pointer directly to the parameter data variable
 //! @warning Don't use this function unless YOU REALLY KNOW WHAT YOU ARE DOING
 void* Component::getParameterDataPtr(const HString &rName)

--- a/HopsanCore/src/Component.cpp
+++ b/HopsanCore/src/Component.cpp
@@ -128,7 +128,16 @@ void Component::getParameterValue(const HString &rName, HString &rValue)
 double Component::evaluateDoubleParameter(const HString &rName, bool &rEvalOK)
 {
     HString val;
-    bool rc = mpParameters->evaluateParameter(rName, val, "double");
+    bool rc = false;
+    if(rName.startsWith("self#"))
+    {
+        HString name =rName.substr(5,rName.size()-5);
+        rc = mpParameters->evaluateInLocalComponent(name, val, "double");
+    }
+    else
+    {
+        rc = mpParameters->evaluateInSystemParent(rName, val, "double");
+    }
     double v = val.toDouble(&rEvalOK);
     rEvalOK = (rEvalOK && rc);
     return v;
@@ -154,7 +163,7 @@ void Component::evaluateParameters()
 
 bool Component::evaluateParameter(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType)
 {
-    return mpParameters->evaluateParameter(rName, rEvaluatedParameterValue, rType);
+    return mpParameters->evaluateInLocalComponent(rName, rEvaluatedParameterValue, rType);
 }
 
 

--- a/HopsanCore/src/ComponentSystem.cpp
+++ b/HopsanCore/src/ComponentSystem.cpp
@@ -2160,6 +2160,11 @@ void ComponentSystem::setNumHopScript(const HString &rScript)
     mNumHopScript = rScript;
 }
 
+HString ComponentSystem::getNumHopScript() const
+{
+    return mNumHopScript;
+}
+
 
 //! @brief Initializes a system and all its contained components before a simulation.
 //! Also allocates log data memory.

--- a/HopsanCore/src/CoreUtilities/HmfLoader.cpp
+++ b/HopsanCore/src/CoreUtilities/HmfLoader.cpp
@@ -478,8 +478,10 @@ size_t loadValuesFromHopsanParameterFile(rapidxml::xml_node<> *pSystemNode, Comp
     return numUpdated;
 }
 
+}
+
 //! @brief Go through all parameter values an prepend self# to parameter names in expressions if they point to a local parameter
-void autoPrependSelfToParameterExpressions(Component* pComponent) {
+void hopsan::autoPrependSelfToParameterExpressions(Component* pComponent) {
 
     std::vector<HString> localParameterNames;
     pComponent->getParameterNames(localParameterNames);
@@ -508,8 +510,6 @@ void autoPrependSelfToParameterExpressions(Component* pComponent) {
             }
         }
     }
-}
-
 }
 
 

--- a/HopsanCore/src/CoreUtilities/NumHopHelper.cpp
+++ b/HopsanCore/src/CoreUtilities/NumHopHelper.cpp
@@ -444,3 +444,23 @@ HVector<HString> NumHopHelper::extractVariableNames(const HString &expression) c
     }
     return names;
 }
+
+HVector<HString> NumHopHelper::extractNamedValues(const HString &expression)
+{
+    numhop::Expression e(expression.c_str(), numhop::UndefinedT);
+    std::set<std::string> namedValues;
+    e.extractNamedValues(namedValues);
+    std::set<std::string>::iterator it;
+    HVector<HString> output;
+    for (it= namedValues.begin(); it != namedValues.end(); ++it) {
+        output.append(it->c_str());
+    }
+    return output;
+}
+
+HString NumHopHelper::replaceNamedValue(const HString& expression, const HString &oldName, const HString &newName)
+{
+    numhop::Expression e(expression.c_str(), numhop::UndefinedT);
+    e.replaceNamedValue(oldName.c_str(), newName.c_str());
+    return e.print().c_str();
+}

--- a/HopsanCore/src/CoreUtilities/NumHopHelper.cpp
+++ b/HopsanCore/src/CoreUtilities/NumHopHelper.cpp
@@ -145,6 +145,17 @@ public:
                     return value;
                 }
             }
+            // This seems to be a system parameter, recurse upwards in the model hierarcy until we find the parameter (or not)
+            else if(parts.size() == 1) {
+                ComponentSystem* pSystemParent = mpSystem->getSystemParent();
+                while (pSystemParent) {
+                    value = evaluateDoubleParameter(pSystemParent, parts[0], rFound);
+                    if (rFound) {
+                        break;
+                    }
+                    pSystemParent = pSystemParent->getSystemParent();
+                }
+            }
         }
         rFound = false;
         return -1;
@@ -258,11 +269,16 @@ public:
         {
             value = evaluateDoubleParameter(mpComponent, parts[1]+"#"+parts[2], evalOK);
         }
-        // This seems to be a system parameter
+        // This seems to be a system parameter, recurse upwards in the model hierarcy until we find the parameter (or not)
         else if(parts.size() == 1) {
             mpComponent->getParameterValue(parts[0], valstring);
-            if (mpComponent->getSystemParent()) {
-                value = evaluateDoubleParameter(mpComponent->getSystemParent(), parts[0], evalOK);
+            ComponentSystem* pSystemParent = mpComponent->getSystemParent();
+            while (pSystemParent) {
+                value = evaluateDoubleParameter(pSystemParent, parts[0], evalOK);
+                if (evalOK) {
+                    break;
+                }
+                pSystemParent = pSystemParent->getSystemParent();
             }
         }
 

--- a/HopsanCore/src/CoreUtilities/NumHopHelper.cpp
+++ b/HopsanCore/src/CoreUtilities/NumHopHelper.cpp
@@ -500,20 +500,39 @@ HVector<HString> NumHopHelper::extractVariableNames(const HString &expression) c
 
 HVector<HString> NumHopHelper::extractNamedValues(const HString &expression)
 {
-    numhop::Expression e(expression.c_str(), numhop::UndefinedT);
-    std::set<std::string> namedValues;
-    e.extractNamedValues(namedValues);
-    std::set<std::string>::iterator it;
+    list<string> expressions;
+    numhop::extractExpressionRows(expression.c_str(), '#', expressions);
+
     HVector<HString> output;
-    for (it= namedValues.begin(); it != namedValues.end(); ++it) {
-        output.append(it->c_str());
+    list<string>::iterator eit;
+    for (eit = expressions.begin(); eit != expressions.end(); ++eit) {
+        numhop::Expression e(eit->c_str(), numhop::UndefinedT);
+        std::set<std::string> namedValues;
+        e.extractNamedValues(namedValues);
+        std::set<std::string>::iterator it;
+        for (it= namedValues.begin(); it != namedValues.end(); ++it) {
+            output.append(it->c_str());
+        }
     }
     return output;
 }
 
 HString NumHopHelper::replaceNamedValue(const HString& expression, const HString &oldName, const HString &newName)
 {
-    numhop::Expression e(expression.c_str(), numhop::UndefinedT);
-    e.replaceNamedValue(oldName.c_str(), newName.c_str());
-    return e.print().c_str();
+    list<string> expressions;
+    numhop::extractExpressionRows(expression.c_str(), '#', expressions);
+
+    HString output;
+    list<string>::iterator eit;
+
+    for (eit = expressions.begin(); eit != expressions.end(); ++eit) {
+        numhop::Expression e(eit->c_str(), numhop::UndefinedT);
+        e.replaceNamedValue(oldName.c_str(), newName.c_str());
+        output.append(e.print().c_str());
+        // For multi-line scripts, append line breaks
+        if (expressions.size() > 1) {
+            output.append("\n");
+        }
+    }
+    return output;
 }

--- a/HopsanCore/src/HopsanTypes.cpp
+++ b/HopsanCore/src/HopsanTypes.cpp
@@ -59,6 +59,14 @@ HString::HString(const char *str, const size_t len)
     setString(str, len);
 }
 
+HString::HString(char c)
+{
+    mpDataBuffer=0;
+    mSize=0;
+    append(c);
+
+}
+
 //! @brief This constructor is used to catch mistakes made by Hospan component developers
 HString::HString(const int value)
 {

--- a/HopsanCore/src/HopsanTypes.cpp
+++ b/HopsanCore/src/HopsanTypes.cpp
@@ -234,6 +234,19 @@ bool HString::compare(const HString &rOther) const
     return false;
 }
 
+bool HString::startsWith(const HString &rOther) const
+{
+    if (mSize < rOther.size()) {
+        return false;
+    }
+    else if (empty() && rOther.empty()) {
+        return true;
+    }
+    else {
+        return (strncmp(mpDataBuffer, rOther.c_str(), rOther.size()) == 0);
+    }
+}
+
 //! @brief Check if the string can be interpreted as a number
 bool HString::isNummeric() const
 {

--- a/HopsanCore/src/Parameters.cpp
+++ b/HopsanCore/src/Parameters.cpp
@@ -742,10 +742,7 @@ bool ParameterEvaluatorHandler::refreshParameterValueText(const HString &rParame
 bool ParameterEvaluatorHandler::evaluateInSystemParent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType)
 {
     // Try one of our system parent component parameters
-    if(mComponent && mComponent->isComponentSystem()) {
-        return mComponent->evaluateParameter(rName, rEvaluatedParameterValue, rType);
-    }
-    else if(mComponent && mComponent->getSystemParent())
+    if(mComponent && mComponent->getSystemParent())
     {
         return mComponent->getSystemParent()->evaluateParameter(rName, rEvaluatedParameterValue , rType);
     }

--- a/HopsanCore/src/Parameters.cpp
+++ b/HopsanCore/src/Parameters.cpp
@@ -699,21 +699,15 @@ bool ParameterEvaluatorHandler::setParameterValue(const HString &rName, const HS
 //! @param [out] rEvaluatedParameterValue The result of the evaluation
 //! @param [in] rType The type of how the parameter should be interpreted
 //! @return true if success, otherwise false
-bool ParameterEvaluatorHandler::evaluateParameter(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType)
+bool ParameterEvaluatorHandler::evaluateInLocalComponent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType)
 {
     bool success = false;
-    // Try our own parameters
     for(size_t i = 0; i < mParameters.size(); ++i)
     {
         if ( (mParameters[i]->getName() == rName) && (mParameters[i]->getType() == rType) )
         {
             success = mParameters[i]->evaluate(rEvaluatedParameterValue);
         }
-    }
-    if(!success)
-    {
-        // Try one of our system parent component parameters
-        success = evaluateInSystemParent(rName, rEvaluatedParameterValue, rType);
     }
     return success;
 }
@@ -746,7 +740,10 @@ bool ParameterEvaluatorHandler::refreshParameterValueText(const HString &rParame
 bool ParameterEvaluatorHandler::evaluateInSystemParent(const HString &rName, HString &rEvaluatedParameterValue, const HString &rType)
 {
     // Try one of our system parent component parameters
-    if(mParentComponent && mParentComponent->getSystemParent())
+    if(mParentComponent && mParentComponent->isComponentSystem()) {
+        return mParentComponent->evaluateParameter(rName, rEvaluatedParameterValue, rType);
+    }
+    else if(mParentComponent && mParentComponent->getSystemParent())
     {
         return mParentComponent->getSystemParent()->evaluateParameter(rName, rEvaluatedParameterValue , rType);
     }

--- a/HopsanCore/src/Parameters.cpp
+++ b/HopsanCore/src/Parameters.cpp
@@ -132,7 +132,7 @@ bool ParameterEvaluator::setParameter(const HString &rValue, const HString &rDes
 //! @return true if success, otherwise false
 //!
 //! This function is used by Parameters
-bool ParameterEvaluator::setParameterValue(const HString &rValue, ParameterEvaluator **ppNeedEvaluation)
+bool ParameterEvaluator::setParameterValue(const HString &rValue, ParameterEvaluator **ppNeedEvaluation, bool force)
 {
     bool success=false;
 
@@ -140,17 +140,18 @@ bool ParameterEvaluator::setParameterValue(const HString &rValue, ParameterEvalu
     mParameterValue = rValue;
     HString evalResult = rValue;
     success = evaluate(evalResult);
-    if(!success)
+    if(!success && !force)
     {
         mParameterValue = oldValue;
     }
-    if(rValue != evalResult)
-    {
-        *ppNeedEvaluation = this;
-    }
-    else
-    {
-        *ppNeedEvaluation = 0;
+
+    if (ppNeedEvaluation) {
+        if(rValue != evalResult) {
+            *ppNeedEvaluation = this;
+        }
+        else {
+            *ppNeedEvaluation = 0;
+        }
     }
 
     return success;

--- a/HopsanGUI/CoreAccess.h
+++ b/HopsanGUI/CoreAccess.h
@@ -99,6 +99,8 @@ double evalWithNumHop(const QString &rExpression);
 
 QStringList getEmbeddedSriptVariableNames(const QString& expression, CoreSystemAccess* pCoreSystem);
 
+void prependSelfToParameterExpresions(CoreSystemAccess* pCoreSystem);
+
 
 class CoreParameterData
 {

--- a/HopsanGUI/CoreAccess.h
+++ b/HopsanGUI/CoreAccess.h
@@ -42,6 +42,7 @@
 //Forward declarations of HopsanGUI classes
 class LibraryWidget;
 class SystemContainer;
+class ContainerObject;
 class CoreSystemAccess;
 
 //Forward declaration of HopsanCore classes
@@ -99,7 +100,8 @@ double evalWithNumHop(const QString &rExpression);
 
 QStringList getEmbeddedSriptVariableNames(const QString& expression, CoreSystemAccess* pCoreSystem);
 
-void prependSelfToParameterExpresions(CoreSystemAccess* pCoreSystem);
+void prependSelfToParameterExpressions(ContainerObject* pTopLevelGUISystem);
+QString checkPrependSelfToEmbeddedScripts(ContainerObject *pTopLevelGUISystem);
 
 
 class CoreParameterData

--- a/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
+++ b/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
@@ -204,10 +204,11 @@ bool VariableTableWidget::cleanAndVerifyParameterValue(QString &rValue, const QS
 {
     //! @todo I think CORE should handle all of this stuff
     QString tempVal = rValue;
-    QStringList sysParamNames = mpModelObject->getParentContainerObject()->getParameterNames();
+    QStringList selfParameterNames = mpModelObject->getParameterNames();
+    QStringList allAccessibleParentSystemParamNames = getAllAccessibleSystemParameterNames(mpModelObject->getParentContainerObject());
     QString error;
 
-    if(verifyParameterValue(tempVal, type, sysParamNames, error))
+    if(verifyParameterValue(tempVal, type, selfParameterNames, allAccessibleParentSystemParamNames, error))
     {
         // Set corrected text
         rValue = tempVal;

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -7784,6 +7784,11 @@ QString HcomHandler::getParameterValue(QString parameterName, QString &rParamete
             CoreParameterData par;
             pMO->getParameter(parName, par);
             rParameterType = par.mType;
+            if(par.mValue.startsWith("self."))
+            {
+                QString otherPar = par.mValue.remove(0,5);
+                return getParameterValue(compName+"."+otherPar);
+            }
             return par.mValue;
         }
 
@@ -8143,7 +8148,7 @@ bool HcomHandler::evaluateArithmeticExpression(QString cmd)
         evaluateExpression(right);
 
         QStringList pars;
-        if (mAnsType==Scalar)
+        if (mAnsType==Scalar || mAnsType==Wildcard)
         {
             getParameters(left, pars);
             SharedVectorVariableT data = getLogVariable(left);
@@ -8173,7 +8178,12 @@ bool HcomHandler::evaluateArithmeticExpression(QString cmd)
             return false;
         }
 
-        if(mAnsType==Scalar)
+        if(mAnsType == Wildcard && !pars.isEmpty())
+        {
+            executeCommand("chpa "+left+" "+mAnsWildcard);
+            return true;
+        }
+        else if(mAnsType==Scalar)
         {
             if(!pars.isEmpty())
             {

--- a/HopsanGUI/Utilities/GUIUtilities.h
+++ b/HopsanGUI/Utilities/GUIUtilities.h
@@ -47,6 +47,7 @@
 #include <functional>
 
 class GUIMessageHandler;
+class ContainerObject;
 
 QString readName(QTextStream &rTextStream);
 QString readName(QString namestring);
@@ -73,7 +74,10 @@ void copyDir(const QString fromPath, QString toPath);
 void copyIncludeFilesToDir(QString path);
 double normalDistribution(double average, double sigma);
 double uniformDistribution(double min, double max);
-bool verifyParameterValue(QString &rValue, const QString type, const QStringList &rSysParNames, QString &rErrorString);
+
+bool verifyParameterValue(QString &rValue, const QString type, const QStringList &rSelfParameterNames, const QStringList &rSysParNames, QString &rErrorString);
+QStringList getAllAccessibleSystemParameterNames(ContainerObject* pSystem);
+
 double findSmallestValueGreaterThanZero(QVector<double> data);
 void splitWithRespectToQuotations(const QString str, const QChar c, QStringList &split);
 void splitRespectingQuotationsAndParanthesis(const QString str, const QChar c, QStringList &rSplit);

--- a/HopsanGUI/Widgets/ModelWidget.cpp
+++ b/HopsanGUI/Widgets/ModelWidget.cpp
@@ -1742,6 +1742,12 @@ bool ModelWidget::loadModel(QFile &rModelFile)
             compLib = compLib.nextSiblingElement("componentlibrary");
         }
 
+        // Upconvert adding self. to parameter names
+        if (hmfRoot.attribute(HMF_HOPSANGUIVERSIONTAG, "0") < "2.14.0") {
+            prependSelfToParameterExpresions(mpToplevelSystem->getCoreSystemAccessPtr());
+        }
+
+
         setSaved(true);
         mpToplevelSystem->setUndoEnabled(true, true);
         return true;

--- a/HopsanGUI/Widgets/ModelWidget.cpp
+++ b/HopsanGUI/Widgets/ModelWidget.cpp
@@ -39,6 +39,7 @@
 #include <QLabel>
 #include <QHBoxLayout>
 #include <QInputDialog>
+#include <QMessageBox>
 
 
 //Hopsan includes
@@ -1744,7 +1745,15 @@ bool ModelWidget::loadModel(QFile &rModelFile)
 
         // Upconvert adding self. to parameter names
         if (hmfRoot.attribute(HMF_HOPSANGUIVERSIONTAG, "0") < "2.14.0") {
-            prependSelfToParameterExpresions(mpToplevelSystem->getCoreSystemAccessPtr());
+            prependSelfToParameterExpressions(mpToplevelSystem);
+            QString neededChanges = checkPrependSelfToEmbeddedScripts(mpToplevelSystem);
+            if (!neededChanges.isEmpty()) {
+                mpMessageHandler->addWarningMessage(neededChanges);
+                QMessageBox msgBox;
+                msgBox.setWindowTitle("Model updates needed");
+                msgBox.setText(neededChanges);
+                msgBox.exec();
+            }
         }
 
 

--- a/HopsanGUI/Widgets/SystemParametersWidget.cpp
+++ b/HopsanGUI/Widgets/SystemParametersWidget.cpp
@@ -44,13 +44,12 @@
 
 namespace {
 
-//! @brief Get all  system parameter names for this system, parents and grand parents.
-QStringList getAllAccessibleSystemParameterNames(ContainerObject* pThisSystem) {
-    QStringList parameterNames = pThisSystem->getParameterNames();
-    if ( !pThisSystem->isTopLevelContainer() ) {
-        parameterNames += getAllAccessibleSystemParameterNames(pThisSystem->getParentContainerObject());
+QStringList getAllAccesibleParentAndGrandparentSystemParameterNames(ContainerObject* pThisSystem) {
+    QStringList output;
+    if (!pThisSystem->isTopLevelContainer()) {
+        output = getAllAccessibleSystemParameterNames(pThisSystem->getParentContainerObject());
     }
-    return parameterNames;
+    return output;
 }
 
 }
@@ -259,9 +258,10 @@ bool SysParamTableModel::addOrSetParameter(CoreParameterData &rParameterData)
 
     bool isOk;
     QString errorString;
-    QStringList allAccessibleSystemParameterNames = getAllAccessibleSystemParameterNames(mpContainerObject);
+    QStringList thisSystemParameterNames = mpContainerObject->getParameterNames();
+    QStringList allAccessibleParentSystemParameterNames = getAllAccesibleParentAndGrandparentSystemParameterNames(mpContainerObject);
 
-    isOk = verifyParameterValue(rParameterData.mValue, rParameterData.mType, allAccessibleSystemParameterNames, errorString);
+    isOk = verifyParameterValue(rParameterData.mValue, rParameterData.mType, thisSystemParameterNames, allAccessibleParentSystemParameterNames, errorString);
     if (!isOk)
     {
         QMessageBox::critical(0, "Error", errorString);

--- a/HopsanGUI/loadFunctions.cpp
+++ b/HopsanGUI/loadFunctions.cpp
@@ -230,6 +230,26 @@ void loadParameterValue(QDomElement &rDomElement, ModelObject* pObject, UndoStat
         return;
     }
 
+    if(existingNames.contains(parameterValue) &&
+       !pObject->getParentContainerObject()->hasParameter(parameterValue))
+    {
+        gpMessageHandler->addWarningMessage(QString("%1: Updating parameter value from \"%2\" to \"self.%2\"")
+                                            .arg(pObject->getName())
+                                            .arg(parameterValue));
+        pObject->setParameterValue(parameterName, "self."+parameterValue, true);
+        return;
+    }
+
+    if(existingNames.contains(parameterValue) &&
+       !pObject->getParentContainerObject()->hasParameter(parameterValue))
+    {
+        gpMessageHandler->addWarningMessage(QString("%1: Updating parameter value from \"%2\" to \"self.%2\"")
+                                            .arg(pObject->getName())
+                                            .arg(parameterValue));
+        pObject->setParameterValue(parameterName, "self."+parameterValue, true);
+        return;
+    }
+
     if(!(pObject->getTypeName() == MODELICATYPENAME &&
        (parameterName == "ports" || parameterName == "parameters" || parameterName == "defaults")))
     {

--- a/HopsanGUI/loadFunctions.cpp
+++ b/HopsanGUI/loadFunctions.cpp
@@ -230,26 +230,6 @@ void loadParameterValue(QDomElement &rDomElement, ModelObject* pObject, UndoStat
         return;
     }
 
-    if(existingNames.contains(parameterValue) &&
-       !pObject->getParentContainerObject()->hasParameter(parameterValue))
-    {
-        gpMessageHandler->addWarningMessage(QString("%1: Updating parameter value from \"%2\" to \"self.%2\"")
-                                            .arg(pObject->getName())
-                                            .arg(parameterValue));
-        pObject->setParameterValue(parameterName, "self."+parameterValue, true);
-        return;
-    }
-
-    if(existingNames.contains(parameterValue) &&
-       !pObject->getParentContainerObject()->hasParameter(parameterValue))
-    {
-        gpMessageHandler->addWarningMessage(QString("%1: Updating parameter value from \"%2\" to \"self.%2\"")
-                                            .arg(pObject->getName())
-                                            .arg(parameterValue));
-        pObject->setParameterValue(parameterName, "self."+parameterValue, true);
-        return;
-    }
-
     if(!(pObject->getTypeName() == MODELICATYPENAME &&
        (parameterName == "ports" || parameterName == "parameters" || parameterName == "defaults")))
     {

--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -365,7 +365,7 @@ void Expression::commonConstructorCode(QStringList symbols, bool &ok, const Expr
         int start=0;        //Start index of each symbol
         for(int i=0; i<str.size(); ++i)
         {
-            if(!var && parBal==0 && (str.at(i).isLetterOrNumber() || str.at(i) == '_' || str.at(i) == '-' || str.at(i) == '.' || str.at(i) == ':')) //New variable or function string
+            if(!var && parBal==0 && (str.at(i).isLetterOrNumber() || str.at(i) == '_' || str.at(i) == '-' || str.at(i) == '.' || str.at(i) == ':' || str.at(i) == '"')) //New variable or function string
             {
                 var = true;
                 start = i;
@@ -388,7 +388,7 @@ void Expression::commonConstructorCode(QStringList symbols, bool &ok, const Expr
                     symbols.append(str.mid(start, i-start+1));
                 }
             }
-            else if(var && !(str.at(i).isLetterOrNumber() || str.at(i) == '|' || str.at(i) == '_' || str.at(i) == '.' || str.at(i) == ':'  || str.at(i) == '@' ||
+            else if(var && !(str.at(i).isLetterOrNumber() || str.at(i) == '|' || str.at(i) == '_' || str.at(i) == '.' || str.at(i) == ':'  || str.at(i) == '@' || str.at(i) == '"' ||
                              (i>1 && str.size() > i+2 && str.at(i) == '+' && str.at(i+1) == '-' && str.at(i-1) == 'e' && str.at(i+2).isNumber()) ||
                              (i>0 && str.size() > i+1 && str.at(i) == '-' && str.at(i-1) == '+' && str.at(i-2) == 'e' && str.at(i+1).isNumber()) ||
                              (i>0 && str.size() > i+1 && str.at(i) == '+' && str.at(i-1) == 'e' && str.at(i+1).isNumber())))     //End of variable, append it to symbols (last two checks makes sure that Xe+Y and Xe-Y are treated as one symbol)

--- a/UnitTests/HopsanCoreTests/HStringTest/tst_hstringtest.cpp
+++ b/UnitTests/HopsanCoreTests/HStringTest/tst_hstringtest.cpp
@@ -448,6 +448,26 @@ private Q_SLOTS:
         QTest::newRow("5") << HString("alpha") << HString(" ") << false;
     }
 
+    void HString_StartsWith()
+    {
+        QFETCH(HString, String);
+        QFETCH(HString, testString);
+        QFETCH(bool, Result);
+        HString failmsg("Failure! startsWith produced wrong result for "+String+", "+testString);
+        QVERIFY2(String.startsWith(testString) == Result, failmsg.c_str());
+
+    }
+    void HString_StartsWith_data()
+    {
+        QTest::addColumn<HString>("String");
+        QTest::addColumn<HString>("testString");
+        QTest::addColumn<bool>("Result");
+        QTest::newRow("hopsan,hop") << HString("hopsan") << HString("hop") << true;
+        QTest::newRow("hopsan,san") << HString("hopsan") << HString("san") << false;
+        QTest::newRow("empty,empty") << HString("") << HString("") << true;
+        QTest::newRow("hopsan,empty") << HString("hopsan") << HString("") << true;
+        QTest::newRow("empty,hopsan") << HString("") << HString("hopsan") << false;
+    }
 };
 
 QTEST_APPLESS_MAIN(HStringTests)

--- a/UnitTests/HopsanCoreTests/SimulationTest/tst_simulationtest.cpp
+++ b/UnitTests/HopsanCoreTests/SimulationTest/tst_simulationtest.cpp
@@ -996,6 +996,7 @@ private slots:
     void System_Simulate()
     {
         QFETCH(ComponentSystem*, system);
+        QVERIFY(system->initialize(0, 10.0));
         system->simulate(10.0);
         QVERIFY2(system->getLogTimeVector()->size() == 1024, "Failed to simulate system!");
         QVERIFY2(system->getNumActuallyLoggedSamples() == 1024, "Failed to simulate system!");
@@ -1011,6 +1012,7 @@ private slots:
     void System_Simulate_Multicore()
     {
         QFETCH(ComponentSystem*, system);
+        QVERIFY(system->initialize(0, 10.0));
         system->simulateMultiThreaded(0, 10.0);
         QVERIFY2(system->getLogTimeVector()->size() == 1024, "Failed to simulate system!");
         QVERIFY2(system->getNumActuallyLoggedSamples() == 1024, "Failed to simulate system!");

--- a/UnitTests/HopsanCoreTests/SimulationTest/tst_simulationtest.cpp
+++ b/UnitTests/HopsanCoreTests/SimulationTest/tst_simulationtest.cpp
@@ -1163,6 +1163,17 @@ private slots:
         QTest::newRow("12") << HString("Subsystem$Subsubsystem$1DLookupTable") << HString("inid") << HString("integer") << HString("subsub_lookup_inid") << HString("0");
         QTest::newRow("13") << HString("Subsystem$Subsubsystem$1DLookupTable") << HString("comment") << HString("string") << HString("subsub_lookup_comment") << HString("#");
         QTest::newRow("14") << HString("Subsystem$Subsubsystem$1DLookupTable") << HString("reload") << HString("bool") << HString("subsub_lookup_reload") << HString("true");
+
+        // Test that int,bool,string,textblock system parameter can be recursively evaluated
+        QTest::newRow("15") << HString("Subsystem$Subsubsystem$1DLookupTable_2") << HString("text") << HString("textblock") << HString("main_lookup_textblock") << HString("1, 1\n2, 2");
+        QTest::newRow("16") << HString("Subsystem$Subsubsystem$1DLookupTable_2") << HString("inid") << HString("integer") << HString("main_lookup_inid") << HString("1");
+        QTest::newRow("17") << HString("Subsystem$Subsubsystem$1DLookupTable_2") << HString("comment") << HString("string") << HString("main_lookup_comment") << HString("#");
+        QTest::newRow("18") << HString("Subsystem$Subsubsystem$1DLookupTable_2") << HString("reload") << HString("bool") << HString("main_lookup_reload") << HString("true");
+
+        // Test that int and string parameter can be self. evaluated
+        //! @todo need test for textblock and bool as well, but hav no componetns with two of those (may need to write a test component)
+        QTest::newRow("19") << HString("Subsystem$Subsubsystem$1DLookupTable_1") << HString("outid") << HString("integer") << HString("self.numlineskip") << HString("1");
+        QTest::newRow("20") << HString("Subsystem$Subsubsystem$1DLookupTable_1") << HString("comment") << HString("string") << HString("self.filename") << HString("K");
     }
 
     void Component_Get_CQS()

--- a/UnitTests/HopsanCoreTests/SimulationTest/unittestmodel.hmf
+++ b/UnitTests/HopsanCoreTests/SimulationTest/unittestmodel.hmf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hopsanmodelfile hmfversion="0.4" hopsancoreversion="2.12.0.20170101.0001" hopsanguiversion="2.12.0.20200211.1013">
+<hopsanmodelfile hopsanguiversion="2.12.0.20200222.2002" hopsancoreversion="2.12.0.20170101.0001" hmfversion="0.4">
   <requirements>
     <componentlibrary>
       <id>59c07d33-554f-49d3-a163-a928823d4380</id>
@@ -10,9 +10,9 @@
       <name>HopsanInternals</name>
     </componentlibrary>
   </requirements>
-  <system locked="false" cqstype="UndefinedCQSType" subtypename="" disabled="false" typename="Subsystem" name="unittestmodel">
-    <simulationtime stop="10" timestep="0.001" start="0" inherit_timestep="true"/>
-    <simulationlogsettings numsamples="2048" starttime="0"/>
+  <system cqstype="UndefinedCQSType" name="unittestmodel" disabled="false" typename="Subsystem" locked="false" subtypename="">
+    <simulationtime start="0" inherit_timestep="true" stop="10" timestep="0.001"/>
+    <simulationlogsettings starttime="0" numsamples="2048"/>
     <parameters>
       <parameter type="double" name="apa" value="7"/>
       <parameter type="double" name="main_a" value="1"/>
@@ -29,10 +29,10 @@
     </parameters>
     <aliases/>
     <hopsangui>
-      <pose y="0" flipped="false" a="0" x="0"/>
+      <pose x="0" flipped="false" a="0" y="0"/>
       <nametext visible="0" position="0"/>
-      <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100" disabled="false"/>
-      <viewport y="2391.5" zoom="1" x="2273"/>
+      <animation disabled="false" hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+      <viewport x="2277.5" zoom="1" y="2369.5"/>
       <ports hidden="1"/>
       <names hidden="0"/>
       <graphics type="user"/>
@@ -43,7 +43,7 @@
             <icon type="defaultmissing" path="subsystemDefault.svg"/>
           </icons>
           <ports/>
-          <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+          <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
         </modelobject>
       </hopsanobjectappearance>
       <optimization>
@@ -72,20 +72,20 @@
       </senstivitityanalysis>
     </hopsangui>
     <objects>
-      <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGain" name="TestGain">
+      <component cqstype="S" name="TestGain" disabled="false" typename="SignalGain" locked="false" subtypename="">
         <parameters>
-          <parameter type="double" unit="" name="in#Value" value="0"/>
-          <parameter type="double" unit="" name="k#Value" value="1"/>
+          <parameter type="double" name="in#Value" value="0" unit=""/>
+          <parameter type="double" name="k#Value" value="1" unit=""/>
         </parameters>
         <ports>
-          <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-          <port nodetype="NodeSignal" name="k"/>
-          <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
+          <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+          <port name="k" nodetype="NodeSignal"/>
+          <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
         </ports>
         <hopsangui>
-          <pose y="2494" flipped="false" a="0" x="2408"/>
+          <pose x="2408" flipped="false" a="0" y="2494"/>
           <nametext visible="0" position="0"/>
-          <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+          <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
           <hopsanobjectappearance version="0.3">
             <modelobject displayname="TestGain" typename="SignalGain">
               <ports/>
@@ -93,10 +93,32 @@
           </hopsanobjectappearance>
         </hopsangui>
       </component>
-      <system locked="false" cqstype="S" subtypename="" disabled="false" typename="Subsystem" name="Subsystem">
-        <simulationtime stop="10" timestep="0.001" start="0" inherit_timestep="true"/>
-        <simulationlogsettings numsamples="2048" starttime="0"/>
-        <numhopscript>NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
+      <component cqstype="S" name="TestConstant" disabled="false" typename="SignalConstant" locked="false" subtypename="">
+        <parameters>
+          <parameter type="double" name="y#Value" value="1" unit=""/>
+        </parameters>
+        <ports>
+          <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
+        </ports>
+        <hopsangui>
+          <pose x="2160" flipped="false" a="0" y="2310"/>
+          <nametext visible="0" position="0"/>
+          <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+          <hopsanobjectappearance version="0.3">
+            <modelobject displayname="TestConstant" typename="SignalConstant">
+              <ports/>
+            </modelobject>
+          </hopsanobjectappearance>
+        </hopsangui>
+      </component>
+      <system cqstype="S" name="Subsystem" disabled="false" typename="Subsystem" locked="false" subtypename="">
+        <simulationtime start="0" inherit_timestep="true" stop="10" timestep="0.001"/>
+        <simulationlogsettings starttime="0" numsamples="2048"/>
+        <numhopscript># Comment line
+NumhopSetValue.y = sub_a;  NumhopSetValue.y = sub_b
+
+# Actual test expression
+NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
         <parameters>
           <parameter type="double" name="sub_a" value="main_a"/>
           <parameter type="double" name="sub_b" value="2"/>
@@ -113,10 +135,10 @@
         </parameters>
         <aliases/>
         <hopsangui>
-          <pose y="2310" flipped="false" a="0" x="2378"/>
+          <pose x="2378" flipped="false" a="0" y="2310"/>
           <nametext visible="0" position="0"/>
-          <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100" disabled="false"/>
-          <viewport y="2034" zoom="1" x="2312"/>
+          <animation disabled="false" hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+          <viewport x="2324.5" zoom="1" y="2002.5"/>
           <ports hidden="1"/>
           <names hidden="0"/>
           <graphics type="user"/>
@@ -127,10 +149,10 @@
                 <icon type="defaultmissing" path="subsystemDefault.svg"/>
               </icons>
               <ports>
-                <port enabled="true" y="0.5" a="180" autoplaced="true" name="SubPortIn" x="0"/>
-                <port enabled="true" y="0.5" a="0" autoplaced="true" name="SubPortOut" x="1"/>
+                <port x="1" enabled="true" name="SubPortOut" autoplaced="true" a="0" y="0.5"/>
+                <port x="0" enabled="true" name="SubPortIn" autoplaced="true" a="180" y="0.5"/>
               </ports>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
             </modelobject>
           </hopsanobjectappearance>
           <optimization>
@@ -159,55 +181,100 @@
           </senstivitityanalysis>
         </hopsangui>
         <objects>
-          <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalAdd" name="Add">
+          <component cqstype="S" name="NumhopSetValue" disabled="false" typename="SignalConstant" locked="false" subtypename="">
             <parameters>
-              <parameter type="double" unit="" name="in1#Value" value="0"/>
-              <parameter type="double" unit="" name="in2#Value" value="in1.Value"/>
+              <parameter type="double" name="y#Value" value="0" unit=""/>
             </parameters>
             <ports>
-              <port nodetype="NodeSignal" porttype="ReadPortType" name="in1"/>
-              <port nodetype="NodeSignal" porttype="ReadPortType" name="in2"/>
-              <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
+              <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
             </ports>
             <hopsangui>
-              <pose y="2029" flipped="false" a="0" x="2274"/>
+              <pose x="2106" flipped="false" a="0" y="2157"/>
               <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
               <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Add" typename="SignalAdd">
+                <modelobject displayname="NumhopSetValue" typename="SignalConstant">
                   <ports/>
                 </modelobject>
               </hopsanobjectappearance>
             </hopsangui>
           </component>
-          <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalStopSimulation" name="Stop_simulation">
+          <component cqstype="S" name="Gain_1" disabled="false" typename="SignalGain" locked="false" subtypename="">
             <parameters>
-              <parameter type="double" unit="" name="in#Value" value="0"/>
-              <parameter type="string" unit="" name="message" value=""/>
+              <parameter type="double" name="in#Value" value="0" unit=""/>
+              <parameter type="double" name="k#Value" value="sub_b+main_a" unit=""/>
             </parameters>
             <ports>
-              <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
+              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="k" nodetype="NodeSignal"/>
+              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
             </ports>
             <hopsangui>
-              <pose y="2029" flipped="false" a="0" x="2438"/>
+              <pose x="2427" flipped="false" a="0" y="2203.5"/>
               <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
               <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Stop_simulation" typename="SignalStopSimulation">
+                <modelobject displayname="Gain_1" typename="SignalGain">
                   <ports/>
                 </modelobject>
               </hopsanobjectappearance>
             </hopsangui>
           </component>
-          <system locked="false" cqstype="S" subtypename="" disabled="false" typename="Subsystem" name="Subsubsystem">
-            <simulationtime stop="10" timestep="0.001" start="0" inherit_timestep="true"/>
-            <simulationlogsettings numsamples="2048" starttime="0"/>
+          <systemport cqstype="hasNoCqsType" name="SubPortOut" disabled="false" typename="HopsanGUIContainerPort" locked="false" subtypename="">
+            <hopsangui>
+              <pose x="2820" flipped="false" a="0" y="2298"/>
+              <nametext visible="0" position="0"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+            </hopsangui>
+          </systemport>
+          <component cqstype="S" name="TestConstant" disabled="false" typename="SignalConstant" locked="false" subtypename="">
+            <parameters>
+              <parameter type="double" name="y#Value" value="1" unit=""/>
+            </parameters>
+            <ports>
+              <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2340" flipped="false" a="0" y="2154"/>
+              <nametext visible="0" position="0"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="TestConstant" typename="SignalConstant">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component cqstype="S" name="Gain" disabled="false" typename="SignalGain" locked="false" subtypename="">
+            <parameters>
+              <parameter type="double" name="in#Value" value="0" unit=""/>
+              <parameter type="double" name="k#Value" value="sub_b+sub_a" unit=""/>
+            </parameters>
+            <ports>
+              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="k" nodetype="NodeSignal"/>
+              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2427" flipped="false" a="0" y="2154"/>
+              <nametext visible="0" position="0"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="Gain" typename="SignalGain">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <system cqstype="S" name="Subsubsystem" disabled="false" typename="Subsystem" locked="false" subtypename="">
+            <simulationtime start="0" inherit_timestep="true" stop="10" timestep="0.001"/>
+            <simulationlogsettings starttime="0" numsamples="2048"/>
             <parameters>
               <parameter type="double" name="subsub_a" value="sub_a"/>
               <parameter type="double" name="subsub_b" value="sub_b"/>
               <parameter type="double" name="subsub_c" value="sub_a+sub_b"/>
-              <parameter type="double" name="subsub_d" value="subsub_a+subsub_b"/>
-              <parameter type="double" name="subsub_e" value="main_a+subsub_b"/>
+              <parameter type="double" name="subsub_d" value="self.subsub_a+self.subsub_b"/>
+              <parameter type="double" name="subsub_e" value="main_a+self.subsub_b"/>
               <parameter type="integer" name="subsub_int_a" value="sub_int_a"/>
               <parameter type="integer" name="subsub_int_b" value="sub_int_b"/>
               <parameter type="bool" name="subsub_bool_a" value="sub_bool_a"/>
@@ -223,10 +290,10 @@
             </parameters>
             <aliases/>
             <hopsangui>
-              <pose y="2298" flipped="false" a="0" x="2380"/>
+              <pose x="2380" flipped="false" a="0" y="2298"/>
               <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100" disabled="false"/>
-              <viewport y="2245" zoom="1" x="2183"/>
+              <animation disabled="false" hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <viewport x="2183" zoom="1" y="2245"/>
               <ports hidden="1"/>
               <names hidden="1"/>
               <graphics type="user"/>
@@ -237,10 +304,10 @@
                     <icon type="defaultmissing" path="subsystemDefault.svg"/>
                   </icons>
                   <ports>
-                    <port enabled="true" y="0.5" a="0" autoplaced="true" name="SubsubPortOut" x="1"/>
-                    <port enabled="true" y="0.5" a="180" autoplaced="true" name="SubsubPortIn" x="0"/>
+                    <port x="0" enabled="true" name="SubsubPortIn" autoplaced="true" a="180" y="0.5"/>
+                    <port x="1" enabled="true" name="SubsubPortOut" autoplaced="true" a="0" y="0.5"/>
                   </ports>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
                 </modelobject>
               </hopsanobjectappearance>
               <optimization>
@@ -269,48 +336,20 @@
               </senstivitityanalysis>
             </hopsangui>
             <objects>
-              <systemport locked="false" cqstype="hasNoCqsType" subtypename="" disabled="false" typename="HopsanGUIContainerPort" name="SubsubPortOut">
-                <hopsangui>
-                  <pose y="2395" flipped="false" a="0" x="2329"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-                </hopsangui>
-              </systemport>
-              <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalAdd" name="Add">
+              <component cqstype="S" name="Gain_2" disabled="false" typename="SignalGain" locked="false" subtypename="">
                 <parameters>
-                  <parameter type="double" unit="" name="in1#Value" value="subsub_a"/>
-                  <parameter type="double" unit="" name="in2#Value" value="in1.Value+1"/>
+                  <parameter type="double" name="in#Value" value="0" unit=""/>
+                  <parameter type="double" name="k#Value" value="subsub_d" unit=""/>
                 </parameters>
                 <ports>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in1"/>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in2"/>
-                  <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
+                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="k" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose y="2395" flipped="false" a="0" x="2088"/>
+                  <pose x="2039.333333" flipped="false" a="0" y="2198"/>
                   <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Add" typename="SignalAdd">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGain" name="Gain_2">
-                <parameters>
-                  <parameter type="double" unit="" name="in#Value" value="0"/>
-                  <parameter type="double" unit="" name="k#Value" value="subsub_d"/>
-                </parameters>
-                <ports>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-                  <port nodetype="NodeSignal" name="k"/>
-                  <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
-                </ports>
-                <hopsangui>
-                  <pose y="2198" flipped="false" a="0" x="2039.333333"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
                     <modelobject displayname="Gain_2" typename="SignalGain">
                       <ports/>
@@ -318,41 +357,27 @@
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalAdd" name="Add_1">
-                <parameters>
-                  <parameter type="double" unit="" name="in1#Value" value="subsub_a"/>
-                  <parameter type="double" unit="" name="in2#Value" value="1"/>
-                </parameters>
-                <ports>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in1"/>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in2"/>
-                  <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
-                </ports>
+              <systemport cqstype="hasNoCqsType" name="SubsubPortIn" disabled="false" typename="HopsanGUIContainerPort" locked="false" subtypename="">
                 <hopsangui>
-                  <pose y="2395" flipped="false" a="0" x="2182"/>
+                  <pose x="2000" flipped="false" a="0" y="2347"/>
                   <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Add_1" typename="SignalAdd">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
                 </hopsangui>
-              </component>
-              <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGain" name="Gain_3">
+              </systemport>
+              <component cqstype="S" name="Gain_3" disabled="false" typename="SignalGain" locked="false" subtypename="">
                 <parameters>
-                  <parameter type="double" unit="" name="in#Value" value="0"/>
-                  <parameter type="double" unit="" name="k#Value" value="subsub_e"/>
+                  <parameter type="double" name="in#Value" value="0" unit=""/>
+                  <parameter type="double" name="k#Value" value="subsub_e" unit=""/>
                 </parameters>
                 <ports>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-                  <port nodetype="NodeSignal" name="k"/>
-                  <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
+                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="k" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose y="2198" flipped="false" a="0" x="2097"/>
+                  <pose x="2097" flipped="false" a="0" y="2198"/>
                   <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
                     <modelobject displayname="Gain_3" typename="SignalGain">
                       <ports/>
@@ -360,66 +385,20 @@
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGain" name="Gain">
+              <component cqstype="S" name="Gain_1" disabled="false" typename="SignalGain" locked="false" subtypename="">
                 <parameters>
-                  <parameter type="double" unit="" name="in#Value" value="0"/>
-                  <parameter type="double" unit="" name="k#Value" value="subsub_c"/>
+                  <parameter type="double" name="in#Value" value="0" unit=""/>
+                  <parameter type="double" name="k#Value" value="subsub_c" unit=""/>
                 </parameters>
                 <ports>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-                  <port nodetype="NodeSignal" name="k"/>
-                  <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
+                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="k" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose y="2395" flipped="false" a="0" x="2136"/>
+                  <pose x="1981.666667" flipped="false" a="0" y="2198"/>
                   <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Gain" typename="SignalGain">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <systemport locked="false" cqstype="hasNoCqsType" subtypename="" disabled="false" typename="HopsanGUIContainerPort" name="SubsubPortIn">
-                <hopsangui>
-                  <pose y="2347" flipped="false" a="0" x="2000"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-                </hopsangui>
-              </systemport>
-              <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalConstant" name="TestConstant">
-                <parameters>
-                  <parameter type="double" unit="" name="y#Value" value="1"/>
-                </parameters>
-                <ports>
-                  <port nodetype="NodeSignal" porttype="WritePortType" name="y"/>
-                </ports>
-                <hopsangui>
-                  <pose y="2198" flipped="false" a="0" x="1924"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="TestConstant" typename="SignalConstant">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGain" name="Gain_1">
-                <parameters>
-                  <parameter type="double" unit="" name="in#Value" value="0"/>
-                  <parameter type="double" unit="" name="k#Value" value="subsub_c"/>
-                </parameters>
-                <ports>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-                  <port nodetype="NodeSignal" name="k"/>
-                  <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
-                </ports>
-                <hopsangui>
-                  <pose y="2198" flipped="false" a="0" x="1981.666667"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
                     <modelobject displayname="Gain_1" typename="SignalGain">
                       <ports/>
@@ -427,26 +406,86 @@
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component locked="false" cqstype="S" subtypename="" disabled="false" typename="Signal1DLookupTable" name="1DLookupTable">
+              <component cqstype="S" name="TestConstant" disabled="false" typename="SignalConstant" locked="false" subtypename="">
                 <parameters>
-                  <parameter type="double" unit="" name="in#Value" value="0"/>
-                  <parameter type="string" unit="" name="filename" value="FilePath"/>
-                  <parameter type="textblock" unit="" name="text" value="subsub_lookup_textblock"/>
-                  <parameter type="string" unit="" name="csvsep" value=","/>
-                  <parameter type="integer" unit="" name="inid" value="subsub_lookup_inid"/>
-                  <parameter type="integer" unit="" name="outid" value="1"/>
-                  <parameter type="integer" unit="" name="numlineskip" value="0"/>
-                  <parameter type="string" unit="" name="comment" value="subsub_lookup_comment"/>
-                  <parameter type="bool" unit="" name="reload" value="subsub_lookup_reload"/>
+                  <parameter type="double" name="y#Value" value="1" unit=""/>
                 </parameters>
                 <ports>
-                  <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-                  <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
+                  <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose y="2245" flipped="false" a="0" x="2288"/>
+                  <pose x="1924" flipped="false" a="0" y="2198"/>
                   <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="TestConstant" typename="SignalConstant">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component cqstype="S" name="Gain" disabled="false" typename="SignalGain" locked="false" subtypename="">
+                <parameters>
+                  <parameter type="double" name="in#Value" value="0" unit=""/>
+                  <parameter type="double" name="k#Value" value="subsub_c" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="k" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2136" flipped="false" a="0" y="2395"/>
+                  <nametext visible="0" position="0"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="Gain" typename="SignalGain">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component cqstype="S" name="Add" disabled="false" typename="SignalAdd" locked="false" subtypename="">
+                <parameters>
+                  <parameter type="double" name="in1#Value" value="subsub_a" unit=""/>
+                  <parameter type="double" name="in2#Value" value="self.in1.Value+1" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="in2" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2088" flipped="false" a="0" y="2395"/>
+                  <nametext visible="0" position="0"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="Add" typename="SignalAdd">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component cqstype="S" name="1DLookupTable" disabled="false" typename="Signal1DLookupTable" locked="false" subtypename="">
+                <parameters>
+                  <parameter type="double" name="in#Value" value="0" unit=""/>
+                  <parameter type="string" name="filename" value="FilePath" unit=""/>
+                  <parameter type="textblock" name="text" value="subsub_lookup_textblock" unit=""/>
+                  <parameter type="string" name="csvsep" value="," unit=""/>
+                  <parameter type="integer" name="inid" value="subsub_lookup_inid" unit=""/>
+                  <parameter type="integer" name="outid" value="1" unit=""/>
+                  <parameter type="integer" name="numlineskip" value="0" unit=""/>
+                  <parameter type="string" name="comment" value="subsub_lookup_comment" unit=""/>
+                  <parameter type="bool" name="reload" value="subsub_lookup_reload" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2288" flipped="false" a="0" y="2245"/>
+                  <nametext visible="0" position="0"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
                     <modelobject displayname="1DLookupTable" typename="Signal1DLookupTable">
                       <ports/>
@@ -454,15 +493,43 @@
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
+              <component cqstype="S" name="Add_1" disabled="false" typename="SignalAdd" locked="false" subtypename="">
+                <parameters>
+                  <parameter type="double" name="in1#Value" value="subsub_a" unit=""/>
+                  <parameter type="double" name="in2#Value" value="1" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="in2" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2182" flipped="false" a="0" y="2395"/>
+                  <nametext visible="0" position="0"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="Add_1" typename="SignalAdd">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <systemport cqstype="hasNoCqsType" name="SubsubPortOut" disabled="false" typename="HopsanGUIContainerPort" locked="false" subtypename="">
+                <hopsangui>
+                  <pose x="2329" flipped="false" a="0" y="2395"/>
+                  <nametext visible="0" position="0"/>
+                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                </hopsangui>
+              </systemport>
             </objects>
             <connections>
-              <connect endport="in" startport="out" endcomponent="Gain" startcomponent="Add">
+              <connect endcomponent="Gain" startport="out" endport="in" startcomponent="Add">
                 <hopsangui>
                   <coordinates>
-                    <coordinate y="2395.00000000000000000000" x="2100.50000000000000000000"/>
-                    <coordinate y="2395.00000000000000000000" x="2105.45491502499999114661"/>
-                    <coordinate y="2395.00000000000000000000" x="2105.45491502499999114661"/>
-                    <coordinate y="2395.00000000000000000000" x="2123.50000000000000000000"/>
+                    <coordinate x="2100.50000000000000000000" y="2395.00000000000000000000"/>
+                    <coordinate x="2105.45491502499999114661" y="2395.00000000000000000000"/>
+                    <coordinate x="2105.45491502499999114661" y="2395.00000000000000000000"/>
+                    <coordinate x="2123.50000000000000000000" y="2395.00000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -472,13 +539,13 @@
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endport="in1" startport="out" endcomponent="Add_1" startcomponent="Gain">
+              <connect endcomponent="Add_1" startport="out" endport="in1" startcomponent="Gain">
                 <hopsangui>
                   <coordinates>
-                    <coordinate y="2395.00000000000000000000" x="2148.50000000000000000000"/>
-                    <coordinate y="2395.00000000000000000000" x="2152.45491502499999114661"/>
-                    <coordinate y="2395.00000000000000000000" x="2152.45491502499999114661"/>
-                    <coordinate y="2395.00000000000000000000" x="2169.50000000000000000000"/>
+                    <coordinate x="2148.50000000000000000000" y="2395.00000000000000000000"/>
+                    <coordinate x="2152.45491502499999114661" y="2395.00000000000000000000"/>
+                    <coordinate x="2152.45491502499999114661" y="2395.00000000000000000000"/>
+                    <coordinate x="2169.50000000000000000000" y="2395.00000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -488,12 +555,12 @@
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endport="in2" startport="SubsubPortIn" endcomponent="Add_1" startcomponent="SubsubPortIn">
+              <connect endcomponent="Add_1" startport="SubsubPortIn" endport="in2" startcomponent="SubsubPortIn">
                 <hopsangui>
                   <coordinates>
-                    <coordinate y="2347.00000000000000000000" x="2000.00000000000000000000"/>
-                    <coordinate y="2347.00000000000000000000" x="2182.00000000000000000000"/>
-                    <coordinate y="2382.50000000000000000000" x="2182.00000000000000000000"/>
+                    <coordinate x="2000.00000000000000000000" y="2347.00000000000000000000"/>
+                    <coordinate x="2182.00000000000000000000" y="2347.00000000000000000000"/>
+                    <coordinate x="2182.00000000000000000000" y="2382.50000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -502,29 +569,13 @@
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endport="SubsubPortOut" startport="out" endcomponent="SubsubPortOut" startcomponent="Add_1">
+              <connect endcomponent="SubsubPortOut" startport="out" endport="SubsubPortOut" startcomponent="Add_1">
                 <hopsangui>
                   <coordinates>
-                    <coordinate y="2395.00000000000000000000" x="2194.50000000000000000000"/>
-                    <coordinate y="2395.00000000000000000000" x="2309.00000000000000000000"/>
-                    <coordinate y="2395.00000000000000000000" x="2309.00000000000000000000"/>
-                    <coordinate y="2395.00000000000000000000" x="2329.00000000000000000000"/>
-                  </coordinates>
-                  <geometries>
-                    <geometry>vertical</geometry>
-                    <geometry>horizontal</geometry>
-                    <geometry>vertical</geometry>
-                  </geometries>
-                  <style>solid</style>
-                </hopsangui>
-              </connect>
-              <connect endport="in" startport="y" endcomponent="Gain_1" startcomponent="TestConstant">
-                <hopsangui>
-                  <coordinates>
-                    <coordinate y="2198.00000000000000000000" x="1936.50000000000000000000"/>
-                    <coordinate y="2198.00000000000000000000" x="1948.50000000000000000000"/>
-                    <coordinate y="2198.00000000000000000000" x="1948.50000000000000000000"/>
-                    <coordinate y="2198.00000000000000000000" x="1969.16666699999996126280"/>
+                    <coordinate x="2194.50000000000000000000" y="2395.00000000000000000000"/>
+                    <coordinate x="2309.00000000000000000000" y="2395.00000000000000000000"/>
+                    <coordinate x="2309.00000000000000000000" y="2395.00000000000000000000"/>
+                    <coordinate x="2329.00000000000000000000" y="2395.00000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -534,13 +585,13 @@
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endport="in" startport="out" endcomponent="Gain_2" startcomponent="Gain_1">
+              <connect endcomponent="Gain_1" startport="y" endport="in" startcomponent="TestConstant">
                 <hopsangui>
                   <coordinates>
-                    <coordinate y="2198.00000000000000000000" x="1994.16666699999996126280"/>
-                    <coordinate y="2198.00000000000000000000" x="2028.16666666666651508422"/>
-                    <coordinate y="2198.00000000000000000000" x="2028.16666666666651508422"/>
-                    <coordinate y="2198.00000000000000000000" x="2026.83333300000003873720"/>
+                    <coordinate x="1936.50000000000000000000" y="2198.00000000000000000000"/>
+                    <coordinate x="1948.50000000000000000000" y="2198.00000000000000000000"/>
+                    <coordinate x="1948.50000000000000000000" y="2198.00000000000000000000"/>
+                    <coordinate x="1969.16666699999996126280" y="2198.00000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -550,13 +601,29 @@
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endport="in" startport="out" endcomponent="Gain_3" startcomponent="Gain_2">
+              <connect endcomponent="Gain_2" startport="out" endport="in" startcomponent="Gain_1">
                 <hopsangui>
                   <coordinates>
-                    <coordinate y="2198.00000000000000000000" x="2051.83333300000003873720"/>
-                    <coordinate y="2198.00000000000000000000" x="2051.28824835833302131505"/>
-                    <coordinate y="2198.00000000000000000000" x="2051.28824835833302131505"/>
-                    <coordinate y="2198.00000000000000000000" x="2084.50000000000000000000"/>
+                    <coordinate x="1994.16666699999996126280" y="2198.00000000000000000000"/>
+                    <coordinate x="2028.16666666666651508422" y="2198.00000000000000000000"/>
+                    <coordinate x="2028.16666666666651508422" y="2198.00000000000000000000"/>
+                    <coordinate x="2026.83333300000003873720" y="2198.00000000000000000000"/>
+                  </coordinates>
+                  <geometries>
+                    <geometry>vertical</geometry>
+                    <geometry>horizontal</geometry>
+                    <geometry>vertical</geometry>
+                  </geometries>
+                  <style>solid</style>
+                </hopsangui>
+              </connect>
+              <connect endcomponent="Gain_3" startport="out" endport="in" startcomponent="Gain_2">
+                <hopsangui>
+                  <coordinates>
+                    <coordinate x="2051.83333300000003873720" y="2198.00000000000000000000"/>
+                    <coordinate x="2051.28824835833302131505" y="2198.00000000000000000000"/>
+                    <coordinate x="2051.28824835833302131505" y="2198.00000000000000000000"/>
+                    <coordinate x="2084.50000000000000000000" y="2198.00000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -568,133 +635,48 @@
               </connect>
             </connections>
           </system>
-          <systemport locked="false" cqstype="hasNoCqsType" subtypename="" disabled="false" typename="HopsanGUIContainerPort" name="SubPortIn">
+          <component cqstype="S" name="Add" disabled="false" typename="SignalAdd" locked="false" subtypename="">
+            <parameters>
+              <parameter type="double" name="in1#Value" value="0" unit=""/>
+              <parameter type="double" name="in2#Value" value="self.in1.Value" unit=""/>
+            </parameters>
+            <ports>
+              <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="in2" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+            </ports>
             <hopsangui>
-              <pose y="2298" flipped="false" a="0" x="1925"/>
+              <pose x="2274" flipped="false" a="0" y="2029"/>
               <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="Add" typename="SignalAdd">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <systemport cqstype="hasNoCqsType" name="SubPortIn" disabled="false" typename="HopsanGUIContainerPort" locked="false" subtypename="">
+            <hopsangui>
+              <pose x="1925" flipped="false" a="0" y="2298"/>
+              <nametext visible="0" position="0"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
             </hopsangui>
           </systemport>
-          <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGain" name="Gain">
+          <component cqstype="S" name="ShadowParamGain" disabled="false" typename="SignalGain" locked="false" subtypename="">
             <parameters>
-              <parameter type="double" unit="" name="in#Value" value="0"/>
-              <parameter type="double" unit="" name="k#Value" value="sub_b+sub_a"/>
+              <parameter type="double" name="in#Value" value="0" unit=""/>
+              <parameter type="double" name="k#Value" value="shadow_param" unit=""/>
             </parameters>
             <ports>
-              <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-              <port nodetype="NodeSignal" name="k"/>
-              <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
+              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="k" nodetype="NodeSignal"/>
+              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
             </ports>
             <hopsangui>
-              <pose y="2154" flipped="false" a="0" x="2427"/>
+              <pose x="2583" flipped="false" a="0" y="2170"/>
               <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Gain" typename="SignalGain">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalConstant" name="NumhopSetValue">
-            <parameters>
-              <parameter type="double" unit="" name="y#Value" value="0"/>
-            </parameters>
-            <ports>
-              <port nodetype="NodeSignal" porttype="WritePortType" name="y"/>
-            </ports>
-            <hopsangui>
-              <pose y="2157" flipped="false" a="0" x="2106"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="NumhopSetValue" typename="SignalConstant">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <systemport locked="false" cqstype="hasNoCqsType" subtypename="" disabled="false" typename="HopsanGUIContainerPort" name="SubPortOut">
-            <hopsangui>
-              <pose y="2298" flipped="false" a="0" x="2820"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-            </hopsangui>
-          </systemport>
-          <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGreaterThan" name="Greater_Than_Comparer">
-            <parameters>
-              <parameter type="double" unit="" name="in#Value" value="0"/>
-              <parameter type="double" unit="" name="x_limit#Value" value="0.5"/>
-            </parameters>
-            <ports>
-              <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-              <port nodetype="NodeSignal" name="x_limit"/>
-              <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
-            </ports>
-            <hopsangui>
-              <pose y="2029" flipped="false" a="0" x="2342"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Greater_Than_Comparer" typename="SignalGreaterThan">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalConstant" name="TestConstant">
-            <parameters>
-              <parameter type="double" unit="" name="y#Value" value="1"/>
-            </parameters>
-            <ports>
-              <port nodetype="NodeSignal" porttype="WritePortType" name="y"/>
-            </ports>
-            <hopsangui>
-              <pose y="2154" flipped="false" a="0" x="2340"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="TestConstant" typename="SignalConstant">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGain" name="Gain_1">
-            <parameters>
-              <parameter type="double" unit="" name="in#Value" value="0"/>
-              <parameter type="double" unit="" name="k#Value" value="sub_b+main_a"/>
-            </parameters>
-            <ports>
-              <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-              <port nodetype="NodeSignal" name="k"/>
-              <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
-            </ports>
-            <hopsangui>
-              <pose y="2203.5" flipped="false" a="0" x="2427"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Gain_1" typename="SignalGain">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalGain" name="ShadowParamGain">
-            <parameters>
-              <parameter type="double" unit="" name="in#Value" value="0"/>
-              <parameter type="double" unit="" name="k#Value" value="shadow_param"/>
-            </parameters>
-            <ports>
-              <port nodetype="NodeSignal" porttype="ReadPortType" name="in"/>
-              <port nodetype="NodeSignal" name="k"/>
-              <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
-            </ports>
-            <hopsangui>
-              <pose y="2170" flipped="false" a="0" x="2583"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
               <hopsanobjectappearance version="0.3">
                 <modelobject displayname="ShadowParamGain" typename="SignalGain">
                   <ports/>
@@ -702,23 +684,63 @@
               </hopsanobjectappearance>
             </hopsangui>
           </component>
+          <component cqstype="S" name="Greater_Than_Comparer" disabled="false" typename="SignalGreaterThan" locked="false" subtypename="">
+            <parameters>
+              <parameter type="double" name="in#Value" value="0" unit=""/>
+              <parameter type="double" name="x_limit#Value" value="0.5" unit=""/>
+            </parameters>
+            <ports>
+              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="x_limit" nodetype="NodeSignal"/>
+              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2342" flipped="false" a="0" y="2029"/>
+              <nametext visible="0" position="0"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="Greater_Than_Comparer" typename="SignalGreaterThan">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component cqstype="S" name="Stop_simulation" disabled="false" typename="SignalStopSimulation" locked="false" subtypename="">
+            <parameters>
+              <parameter type="double" name="in#Value" value="0" unit=""/>
+              <parameter type="string" name="message" value="" unit=""/>
+            </parameters>
+            <ports>
+              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2438" flipped="false" a="0" y="2029"/>
+              <nametext visible="0" position="0"/>
+              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="Stop_simulation" typename="SignalStopSimulation">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
           <textboxwidget>
             <hopsangui>
-              <pose y="1934.000000" x="2103.000000"/>
-              <textobject fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" text="Test when local variable and system variable with same name exists&#xa;In this case in1.value and in1#value" reflow="1"/>
-              <size height="130.000000" width="561.000000"/>
-              <line visible="1" style="solidline" width="2" color="#556b2f"/>
+              <pose x="2103.000000" y="1934.000000"/>
+              <textobject text="Test when local variable and system variable with same name exists&#xa;In this case in1.value and in1#value" reflow="1" fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular"/>
+              <size height="130.000000" width="565.000000"/>
+              <line visible="1" color="#556b2f" width="2" style="solidline"/>
             </hopsangui>
           </textboxwidget>
         </objects>
         <connections>
-          <connect endport="SubsubPortIn" startport="SubPortIn" endcomponent="Subsubsystem" startcomponent="SubPortIn">
+          <connect endcomponent="Subsubsystem" startport="SubPortIn" endport="SubsubPortIn" startcomponent="SubPortIn">
             <hopsangui>
               <coordinates>
-                <coordinate y="2298.00000000000000000000" x="1925.00000000000000000000"/>
-                <coordinate y="2298.00000000000000000000" x="2315.00000000000000000000"/>
-                <coordinate y="2298.00000000000000000000" x="2315.00000000000000000000"/>
-                <coordinate y="2298.00000000000000000000" x="2335.00000000000000000000"/>
+                <coordinate x="1925.00000000000000000000" y="2298.00000000000000000000"/>
+                <coordinate x="2315.00000000000000000000" y="2298.00000000000000000000"/>
+                <coordinate x="2315.00000000000000000000" y="2298.00000000000000000000"/>
+                <coordinate x="2335.00000000000000000000" y="2298.00000000000000000000"/>
               </coordinates>
               <geometries>
                 <geometry>vertical</geometry>
@@ -728,13 +750,13 @@
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endport="SubPortOut" startport="SubsubPortOut" endcomponent="SubPortOut" startcomponent="Subsubsystem">
+          <connect endcomponent="SubPortOut" startport="SubsubPortOut" endport="SubPortOut" startcomponent="Subsubsystem">
             <hopsangui>
               <coordinates>
-                <coordinate y="2298.00000000000000000000" x="2425.00000000000000000000"/>
-                <coordinate y="2298.00000000000000000000" x="2545.00000000000000000000"/>
-                <coordinate y="2298.00000000000000000000" x="2545.00000000000000000000"/>
-                <coordinate y="2298.00000000000000000000" x="2820.00000000000000000000"/>
+                <coordinate x="2425.00000000000000000000" y="2298.00000000000000000000"/>
+                <coordinate x="2545.00000000000000000000" y="2298.00000000000000000000"/>
+                <coordinate x="2545.00000000000000000000" y="2298.00000000000000000000"/>
+                <coordinate x="2820.00000000000000000000" y="2298.00000000000000000000"/>
               </coordinates>
               <geometries>
                 <geometry>vertical</geometry>
@@ -744,13 +766,13 @@
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endport="y" startport="in" endcomponent="TestConstant" startcomponent="Gain">
+          <connect endcomponent="TestConstant" startport="in" endport="y" startcomponent="Gain">
             <hopsangui>
               <coordinates>
-                <coordinate y="2154.00000000000000000000" x="2414.50000000000000000000"/>
-                <coordinate y="2154.00000000000000000000" x="2372.50000000000000000000"/>
-                <coordinate y="2154.00000000000000000000" x="2372.50000000000000000000"/>
-                <coordinate y="2154.00000000000000000000" x="2352.50000000000000000000"/>
+                <coordinate x="2414.50000000000000000000" y="2154.00000000000000000000"/>
+                <coordinate x="2372.50000000000000000000" y="2154.00000000000000000000"/>
+                <coordinate x="2372.50000000000000000000" y="2154.00000000000000000000"/>
+                <coordinate x="2352.50000000000000000000" y="2154.00000000000000000000"/>
               </coordinates>
               <geometries>
                 <geometry>vertical</geometry>
@@ -760,13 +782,13 @@
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endport="y" startport="in" endcomponent="TestConstant" startcomponent="Gain_1">
+          <connect endcomponent="TestConstant" startport="in" endport="y" startcomponent="Gain_1">
             <hopsangui>
               <coordinates>
-                <coordinate y="2203.50000000000000000000" x="2414.50000000000000000000"/>
-                <coordinate y="2203.50000000000000000000" x="2372.00000000000000000000"/>
-                <coordinate y="2154.00000000000000000000" x="2372.00000000000000000000"/>
-                <coordinate y="2154.00000000000000000000" x="2352.50000000000000000000"/>
+                <coordinate x="2414.50000000000000000000" y="2203.50000000000000000000"/>
+                <coordinate x="2372.00000000000000000000" y="2203.50000000000000000000"/>
+                <coordinate x="2372.00000000000000000000" y="2154.00000000000000000000"/>
+                <coordinate x="2352.50000000000000000000" y="2154.00000000000000000000"/>
               </coordinates>
               <geometries>
                 <geometry>vertical</geometry>
@@ -776,13 +798,13 @@
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endport="out" startport="in" endcomponent="Add" startcomponent="Greater_Than_Comparer">
+          <connect endcomponent="Add" startport="in" endport="out" startcomponent="Greater_Than_Comparer">
             <hopsangui>
               <coordinates>
-                <coordinate y="2029.00000000000000000000" x="2329.50000000000000000000"/>
-                <coordinate y="2029.00000000000000000000" x="2306.50000000000000000000"/>
-                <coordinate y="2029.00000000000000000000" x="2306.50000000000000000000"/>
-                <coordinate y="2029.00000000000000000000" x="2286.50000000000000000000"/>
+                <coordinate x="2329.50000000000000000000" y="2029.00000000000000000000"/>
+                <coordinate x="2306.50000000000000000000" y="2029.00000000000000000000"/>
+                <coordinate x="2306.50000000000000000000" y="2029.00000000000000000000"/>
+                <coordinate x="2286.50000000000000000000" y="2029.00000000000000000000"/>
               </coordinates>
               <geometries>
                 <geometry>vertical</geometry>
@@ -792,13 +814,13 @@
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endport="in" startport="out" endcomponent="Stop_simulation" startcomponent="Greater_Than_Comparer">
+          <connect endcomponent="Stop_simulation" startport="out" endport="in" startcomponent="Greater_Than_Comparer">
             <hopsangui>
               <coordinates>
-                <coordinate y="2029.00000000000000000000" x="2354.50000000000000000000"/>
-                <coordinate y="2029.00000000000000000000" x="2398.00000000000000000000"/>
-                <coordinate y="2029.00000000000000000000" x="2398.00000000000000000000"/>
-                <coordinate y="2029.00000000000000000000" x="2418.00000000000000000000"/>
+                <coordinate x="2354.50000000000000000000" y="2029.00000000000000000000"/>
+                <coordinate x="2398.00000000000000000000" y="2029.00000000000000000000"/>
+                <coordinate x="2398.00000000000000000000" y="2029.00000000000000000000"/>
+                <coordinate x="2418.00000000000000000000" y="2029.00000000000000000000"/>
               </coordinates>
               <geometries>
                 <geometry>vertical</geometry>
@@ -810,22 +832,22 @@
           </connect>
         </connections>
       </system>
-      <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalStep" name="TestStep">
+      <component cqstype="S" name="TestStep" disabled="false" typename="SignalStep" locked="false" subtypename="">
         <parameters>
-          <parameter type="double" unit="" name="y_0#Value" value="-5"/>
-          <parameter type="double" unit="" name="y_A#Value" value="5"/>
-          <parameter type="double" unit="s" name="t_step#Value" value="apa"/>
+          <parameter type="double" name="y_0#Value" value="-5" unit=""/>
+          <parameter type="double" name="y_A#Value" value="5" unit=""/>
+          <parameter type="double" name="t_step#Value" value="apa" unit="s"/>
         </parameters>
         <ports>
-          <port nodetype="NodeSignal" porttype="WritePortType" name="out"/>
-          <port nodetype="NodeSignal" name="y_0"/>
-          <port nodetype="NodeSignal" name="y_A"/>
-          <port nodetype="NodeSignal" name="t_step"/>
+          <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+          <port name="y_0" nodetype="NodeSignal"/>
+          <port name="y_A" nodetype="NodeSignal"/>
+          <port name="t_step" nodetype="NodeSignal"/>
         </ports>
         <hopsangui>
-          <pose y="2494" flipped="false" a="0" x="2320"/>
+          <pose x="2320" flipped="false" a="0" y="2494"/>
           <nametext visible="0" position="0"/>
-          <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
+          <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
           <hopsanobjectappearance version="0.3">
             <modelobject displayname="TestStep" typename="SignalStep">
               <ports/>
@@ -833,31 +855,13 @@
           </hopsanobjectappearance>
         </hopsangui>
       </component>
-      <component locked="false" cqstype="S" subtypename="" disabled="false" typename="SignalConstant" name="TestConstant">
-        <parameters>
-          <parameter type="double" unit="" name="y#Value" value="1"/>
-        </parameters>
-        <ports>
-          <port nodetype="NodeSignal" porttype="WritePortType" name="y"/>
-        </ports>
-        <hopsangui>
-          <pose y="2310" flipped="false" a="0" x="2160"/>
-          <nametext visible="0" position="0"/>
-          <animation hydraulicmaxpressure="20000000" hydraulicminpressure="0" flowspeed="100"/>
-          <hopsanobjectappearance version="0.3">
-            <modelobject displayname="TestConstant" typename="SignalConstant">
-              <ports/>
-            </modelobject>
-          </hopsanobjectappearance>
-        </hopsangui>
-      </component>
     </objects>
     <connections>
-      <connect endport="in" startport="out" endcomponent="TestGain" startcomponent="TestStep">
+      <connect endcomponent="TestGain" startport="out" endport="in" startcomponent="TestStep">
         <hopsangui>
           <coordinates>
-            <coordinate y="2494.00000000000000000000" x="2332.50000000000000000000"/>
-            <coordinate y="2494.00000000000000000000" x="2395.50000000000000000000"/>
+            <coordinate x="2332.50000000000000000000" y="2494.00000000000000000000"/>
+            <coordinate x="2395.50000000000000000000" y="2494.00000000000000000000"/>
           </coordinates>
           <geometries>
             <geometry>diagonal</geometry>
@@ -865,13 +869,13 @@
           <style>solid</style>
         </hopsangui>
       </connect>
-      <connect endport="SubPortIn" startport="y" endcomponent="Subsystem" startcomponent="TestConstant">
+      <connect endcomponent="Subsystem" startport="y" endport="SubPortIn" startcomponent="TestConstant">
         <hopsangui>
           <coordinates>
-            <coordinate y="2310.00000000000000000000" x="2172.50000000000000000000"/>
-            <coordinate y="2310.00000000000000000000" x="2284.00000000000000000000"/>
-            <coordinate y="2310.00000000000000000000" x="2284.00000000000000000000"/>
-            <coordinate y="2310.00000000000000000000" x="2333.00000000000000000000"/>
+            <coordinate x="2172.50000000000000000000" y="2310.00000000000000000000"/>
+            <coordinate x="2284.00000000000000000000" y="2310.00000000000000000000"/>
+            <coordinate x="2284.00000000000000000000" y="2310.00000000000000000000"/>
+            <coordinate x="2333.00000000000000000000" y="2310.00000000000000000000"/>
           </coordinates>
           <geometries>
             <geometry>vertical</geometry>

--- a/UnitTests/HopsanCoreTests/SimulationTest/unittestmodel.hmf
+++ b/UnitTests/HopsanCoreTests/SimulationTest/unittestmodel.hmf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hopsanmodelfile hmfversion="0.4" hopsancoreversion="2.12.0.20170101.0001" hopsanguiversion="2.12.0.20200222.1953">
+<hopsanmodelfile hopsanguiversion="2.12.0.20200222.1953" hmfversion="0.4" hopsancoreversion="2.12.0.20170101.0001">
   <requirements>
     <componentlibrary>
       <id>59c07d33-554f-49d3-a163-a928823d4380</id>
@@ -10,40 +10,44 @@
       <name>HopsanInternals</name>
     </componentlibrary>
   </requirements>
-  <system name="unittestmodel" typename="Subsystem" subtypename="" cqstype="UndefinedCQSType" disabled="false" locked="false">
-    <simulationtime inherit_timestep="true" stop="10" timestep="0.001" start="0"/>
+  <system name="unittestmodel" locked="false" disabled="false" cqstype="UndefinedCQSType" subtypename="" typename="Subsystem">
+    <simulationtime timestep="0.001" inherit_timestep="true" start="0" stop="10"/>
     <simulationlogsettings starttime="0" numsamples="2048"/>
     <parameters>
-      <parameter name="apa" value="7" type="double"/>
-      <parameter name="main_a" value="1" type="double"/>
-      <parameter name="shadow_param" value="-1" type="double"/>
-      <parameter name="main_int_a" value="1" type="integer"/>
-      <parameter name="main_bool_a" value="true" type="bool"/>
-      <parameter name="main_string_a" value="string_a" type="string"/>
-      <parameter name="main_textblock_a" value="textblock_a" type="textblock"/>
-      <parameter name="main_textblock_b" value="INVALID" type="textblock"/>
-      <parameter name="main_string_b" value="INVALID" type="string"/>
-      <parameter name="main_int_b" value="-1" type="integer"/>
-      <parameter name="main_bool_b" value="true" type="bool"/>
-      <parameter name="main_b" value="-1" type="double"/>
+      <parameter name="apa" type="double" value="7"/>
+      <parameter name="main_a" type="double" value="1"/>
+      <parameter name="shadow_param" type="double" value="-1"/>
+      <parameter name="main_int_a" type="integer" value="1"/>
+      <parameter name="main_bool_a" type="bool" value="true"/>
+      <parameter name="main_string_a" type="string" value="string_a"/>
+      <parameter name="main_textblock_a" type="textblock" value="textblock_a"/>
+      <parameter name="main_textblock_b" type="textblock" value="INVALID"/>
+      <parameter name="main_string_b" type="string" value="INVALID"/>
+      <parameter name="main_int_b" type="integer" value="-1"/>
+      <parameter name="main_bool_b" type="bool" value="true"/>
+      <parameter name="main_b" type="double" value="-1"/>
+      <parameter name="main_lookup_textblock" type="textblock" value="1, 1&#xa;2, 2"/>
+      <parameter name="main_lookup_inid" type="integer" value="1"/>
+      <parameter name="main_lookup_comment" type="string" value="#"/>
+      <parameter name="main_lookup_reload" type="bool" value="true"/>
     </parameters>
     <aliases/>
     <hopsangui>
-      <pose x="0" a="0" flipped="false" y="0"/>
-      <nametext position="0" visible="0"/>
-      <animation hydraulicminpressure="0" disabled="false" hydraulicmaxpressure="20000000" flowspeed="100"/>
-      <viewport x="2283.5" zoom="1" y="2336.5"/>
+      <pose x="0" y="0" a="0" flipped="false"/>
+      <nametext visible="0" position="0"/>
+      <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0" disabled="false"/>
+      <viewport x="2326" y="2405.5" zoom="1"/>
       <ports hidden="1"/>
       <names hidden="0"/>
       <graphics type="user"/>
       <scriptfile path=""/>
       <hopsanobjectappearance version="0.3">
-        <modelobject typename="Subsystem" displayname="unittestmodel">
+        <modelobject displayname="unittestmodel" typename="Subsystem">
           <icons>
             <icon type="defaultmissing" path="subsystemDefault.svg"/>
           </icons>
           <ports/>
-          <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+          <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
         </modelobject>
       </hopsanobjectappearance>
       <optimization>
@@ -72,70 +76,70 @@
       </senstivitityanalysis>
     </hopsangui>
     <objects>
-      <component name="TestGain" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
+      <component name="TestConstant" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalConstant">
         <parameters>
-          <parameter name="in#Value" value="0" unit="" type="double"/>
-          <parameter name="k#Value" value="1" unit="" type="double"/>
+          <parameter name="y#Value" type="double" value="1" unit=""/>
         </parameters>
         <ports>
-          <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+          <port name="y" nodetype="NodeSignal" porttype="WritePortType"/>
+        </ports>
+        <hopsangui>
+          <pose x="2160" y="2310" a="0" flipped="false"/>
+          <nametext visible="0" position="0"/>
+          <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+          <hopsanobjectappearance version="0.3">
+            <modelobject displayname="TestConstant" typename="SignalConstant">
+              <ports/>
+            </modelobject>
+          </hopsanobjectappearance>
+        </hopsangui>
+      </component>
+      <component name="TestGain" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGain">
+        <parameters>
+          <parameter name="in#Value" type="double" value="0" unit=""/>
+          <parameter name="k#Value" type="double" value="1" unit=""/>
+        </parameters>
+        <ports>
+          <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
           <port name="k" nodetype="NodeSignal"/>
-          <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+          <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
         </ports>
         <hopsangui>
-          <pose x="2408" a="0" flipped="false" y="2494"/>
-          <nametext position="0" visible="0"/>
-          <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+          <pose x="2408" y="2494" a="0" flipped="false"/>
+          <nametext visible="0" position="0"/>
+          <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
           <hopsanobjectappearance version="0.3">
-            <modelobject typename="SignalGain" displayname="TestGain">
+            <modelobject displayname="TestGain" typename="SignalGain">
               <ports/>
             </modelobject>
           </hopsanobjectappearance>
         </hopsangui>
       </component>
-      <component name="TestConstant" typename="SignalConstant" subtypename="" cqstype="S" disabled="false" locked="false">
+      <component name="TestStep" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalStep">
         <parameters>
-          <parameter name="y#Value" value="1" unit="" type="double"/>
+          <parameter name="y_0#Value" type="double" value="-5" unit=""/>
+          <parameter name="y_A#Value" type="double" value="5" unit=""/>
+          <parameter name="t_step#Value" type="double" value="apa" unit="s"/>
         </parameters>
         <ports>
-          <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
-        </ports>
-        <hopsangui>
-          <pose x="2160" a="0" flipped="false" y="2310"/>
-          <nametext position="0" visible="0"/>
-          <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-          <hopsanobjectappearance version="0.3">
-            <modelobject typename="SignalConstant" displayname="TestConstant">
-              <ports/>
-            </modelobject>
-          </hopsanobjectappearance>
-        </hopsangui>
-      </component>
-      <component name="TestStep" typename="SignalStep" subtypename="" cqstype="S" disabled="false" locked="false">
-        <parameters>
-          <parameter name="y_0#Value" value="-5" unit="" type="double"/>
-          <parameter name="y_A#Value" value="5" unit="" type="double"/>
-          <parameter name="t_step#Value" value="apa" unit="s" type="double"/>
-        </parameters>
-        <ports>
-          <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+          <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
           <port name="y_0" nodetype="NodeSignal"/>
           <port name="y_A" nodetype="NodeSignal"/>
           <port name="t_step" nodetype="NodeSignal"/>
         </ports>
         <hopsangui>
-          <pose x="2320" a="0" flipped="false" y="2494"/>
-          <nametext position="0" visible="0"/>
-          <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+          <pose x="2320" y="2494" a="0" flipped="false"/>
+          <nametext visible="0" position="0"/>
+          <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
           <hopsanobjectappearance version="0.3">
-            <modelobject typename="SignalStep" displayname="TestStep">
+            <modelobject displayname="TestStep" typename="SignalStep">
               <ports/>
             </modelobject>
           </hopsanobjectappearance>
         </hopsangui>
       </component>
-      <system name="Subsystem" typename="Subsystem" subtypename="" cqstype="S" disabled="false" locked="false">
-        <simulationtime inherit_timestep="true" stop="10" timestep="0.001" start="0"/>
+      <system name="Subsystem" locked="false" disabled="false" cqstype="S" subtypename="" typename="Subsystem">
+        <simulationtime timestep="0.001" inherit_timestep="true" start="0" stop="10"/>
         <simulationlogsettings starttime="0" numsamples="2048"/>
         <numhopscript># Comment line
 NumhopSetValue.y = sub_a;  NumhopSetValue.y = sub_b
@@ -143,39 +147,39 @@ NumhopSetValue.y = sub_a;  NumhopSetValue.y = sub_b
 # Actual test expression
 NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
         <parameters>
-          <parameter name="sub_a" value="main_a" type="double"/>
-          <parameter name="sub_b" value="2" type="double"/>
-          <parameter name="in1#Value" value="1" description="This is a deliberate complication, adding in1#Value as the name of a system parameter" type="double"/>
-          <parameter name="shadow_param" value="2" type="double"/>
-          <parameter name="sub_int_a" value="main_int_a" type="integer"/>
-          <parameter name="sub_int_b" value="2" type="integer"/>
-          <parameter name="sub_bool_a" value="main_bool_a" type="bool"/>
-          <parameter name="sub_bool_b" value="false" type="bool"/>
-          <parameter name="sub_string_a" value="main_string_a" type="string"/>
-          <parameter name="sub_textblock_a" value="main_textblock_a" type="textblock"/>
-          <parameter name="sub_string_b" value="string_b" type="string"/>
-          <parameter name="sub_textblock_b" value="textblock_b" type="textblock"/>
+          <parameter name="sub_a" type="double" value="main_a"/>
+          <parameter name="sub_b" type="double" value="2"/>
+          <parameter name="in1#Value" type="double" description="This is a deliberate complication, adding in1#Value as the name of a system parameter" value="1"/>
+          <parameter name="shadow_param" type="double" value="2"/>
+          <parameter name="sub_int_a" type="integer" value="main_int_a"/>
+          <parameter name="sub_int_b" type="integer" value="2"/>
+          <parameter name="sub_bool_a" type="bool" value="main_bool_a"/>
+          <parameter name="sub_bool_b" type="bool" value="false"/>
+          <parameter name="sub_string_a" type="string" value="main_string_a"/>
+          <parameter name="sub_textblock_a" type="textblock" value="main_textblock_a"/>
+          <parameter name="sub_string_b" type="string" value="string_b"/>
+          <parameter name="sub_textblock_b" type="textblock" value="textblock_b"/>
         </parameters>
         <aliases/>
         <hopsangui>
-          <pose x="2378" a="0" flipped="false" y="2310"/>
-          <nametext position="0" visible="0"/>
-          <animation hydraulicminpressure="0" disabled="false" hydraulicmaxpressure="20000000" flowspeed="100"/>
-          <viewport x="2348.5" zoom="1" y="2058.5"/>
+          <pose x="2378" y="2310" a="0" flipped="false"/>
+          <nametext visible="0" position="0"/>
+          <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0" disabled="false"/>
+          <viewport x="2427" y="1970.5" zoom="1"/>
           <ports hidden="1"/>
           <names hidden="0"/>
           <graphics type="user"/>
           <scriptfile path=""/>
           <hopsanobjectappearance version="0.3">
-            <modelobject typename="Subsystem" displayname="Subsystem">
+            <modelobject displayname="Subsystem" typename="Subsystem">
               <icons>
                 <icon type="defaultmissing" path="subsystemDefault.svg"/>
               </icons>
               <ports>
-                <port autoplaced="true" name="SubPortOut" x="1" a="0" enabled="true" y="0.5"/>
-                <port autoplaced="true" name="SubPortIn" x="0" a="180" enabled="true" y="0.5"/>
+                <port name="SubPortOut" autoplaced="true" x="1" y="0.5" a="0" enabled="true"/>
+                <port name="SubPortIn" autoplaced="true" x="0" y="0.5" a="180" enabled="true"/>
               </ports>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
             </modelobject>
           </hopsanobjectappearance>
           <optimization>
@@ -204,183 +208,94 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
           </senstivitityanalysis>
         </hopsangui>
         <objects>
-          <systemport name="SubPortOut" typename="HopsanGUIContainerPort" subtypename="" cqstype="hasNoCqsType" disabled="false" locked="false">
+          <component name="TestConstant" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalConstant">
+            <parameters>
+              <parameter name="y#Value" type="double" value="1" unit=""/>
+            </parameters>
+            <ports>
+              <port name="y" nodetype="NodeSignal" porttype="WritePortType"/>
+            </ports>
             <hopsangui>
-              <pose x="2820" a="0" flipped="false" y="2298"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <pose x="2340" y="2154" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="TestConstant" typename="SignalConstant">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component name="Gain" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGain">
+            <parameters>
+              <parameter name="in#Value" type="double" value="0" unit=""/>
+              <parameter name="k#Value" type="double" value="sub_b+sub_a" unit=""/>
+            </parameters>
+            <ports>
+              <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
+              <port name="k" nodetype="NodeSignal"/>
+              <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+            </ports>
+            <hopsangui>
+              <pose x="2427" y="2154" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="Gain" typename="SignalGain">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <systemport name="SubPortOut" locked="false" disabled="false" cqstype="hasNoCqsType" subtypename="" typename="HopsanGUIContainerPort">
+            <hopsangui>
+              <pose x="2820" y="2298" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
             </hopsangui>
           </systemport>
-          <component name="ShadowParamGain" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
-            <parameters>
-              <parameter name="in#Value" value="0" unit="" type="double"/>
-              <parameter name="k#Value" value="shadow_param" unit="" type="double"/>
-            </parameters>
-            <ports>
-              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="k" nodetype="NodeSignal"/>
-              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2583" a="0" flipped="false" y="2170"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject typename="SignalGain" displayname="ShadowParamGain">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component name="TestConstant" typename="SignalConstant" subtypename="" cqstype="S" disabled="false" locked="false">
-            <parameters>
-              <parameter name="y#Value" value="1" unit="" type="double"/>
-            </parameters>
-            <ports>
-              <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2340" a="0" flipped="false" y="2154"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject typename="SignalConstant" displayname="TestConstant">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component name="Gain" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
-            <parameters>
-              <parameter name="in#Value" value="0" unit="" type="double"/>
-              <parameter name="k#Value" value="sub_b+sub_a" unit="" type="double"/>
-            </parameters>
-            <ports>
-              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="k" nodetype="NodeSignal"/>
-              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2427" a="0" flipped="false" y="2154"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject typename="SignalGain" displayname="Gain">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <systemport name="SubPortIn" typename="HopsanGUIContainerPort" subtypename="" cqstype="hasNoCqsType" disabled="false" locked="false">
-            <hopsangui>
-              <pose x="1925" a="0" flipped="false" y="2298"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-            </hopsangui>
-          </systemport>
-          <component name="Stop_simulation" typename="SignalStopSimulation" subtypename="" cqstype="S" disabled="false" locked="false">
-            <parameters>
-              <parameter name="in#Value" value="0" unit="" type="double"/>
-              <parameter name="message" value="" unit="" type="string"/>
-            </parameters>
-            <ports>
-              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2438" a="0" flipped="false" y="2029"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject typename="SignalStopSimulation" displayname="Stop_simulation">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component name="Add" typename="SignalAdd" subtypename="" cqstype="S" disabled="false" locked="false">
-            <parameters>
-              <parameter name="in1#Value" value="0" unit="" type="double"/>
-              <parameter name="in2#Value" value="self.in1.Value" unit="" type="double"/>
-            </parameters>
-            <ports>
-              <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="in2" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2274" a="0" flipped="false" y="2029"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject typename="SignalAdd" displayname="Add">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component name="Greater_Than_Comparer" typename="SignalGreaterThan" subtypename="" cqstype="S" disabled="false" locked="false">
-            <parameters>
-              <parameter name="in#Value" value="0" unit="" type="double"/>
-              <parameter name="x_limit#Value" value="0.5" unit="" type="double"/>
-            </parameters>
-            <ports>
-              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="x_limit" nodetype="NodeSignal"/>
-              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2342" a="0" flipped="false" y="2029"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject typename="SignalGreaterThan" displayname="Greater_Than_Comparer">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <system name="Subsubsystem" typename="Subsystem" subtypename="" cqstype="S" disabled="false" locked="false">
-            <simulationtime inherit_timestep="true" stop="10" timestep="0.001" start="0"/>
+          <system name="Subsubsystem" locked="false" disabled="false" cqstype="S" subtypename="" typename="Subsystem">
+            <simulationtime timestep="0.001" inherit_timestep="true" start="0" stop="10"/>
             <simulationlogsettings starttime="0" numsamples="2048"/>
             <parameters>
-              <parameter name="subsub_a" value="sub_a" type="double"/>
-              <parameter name="subsub_b" value="sub_b" type="double"/>
-              <parameter name="subsub_c" value="sub_a+sub_b" type="double"/>
-              <parameter name="subsub_d" value="self.subsub_a+self.subsub_b" type="double"/>
-              <parameter name="subsub_e" value="main_a+self.subsub_b" type="double"/>
-              <parameter name="subsub_int_a" value="sub_int_a" type="integer"/>
-              <parameter name="subsub_int_b" value="sub_int_b" type="integer"/>
-              <parameter name="subsub_bool_a" value="sub_bool_a" type="bool"/>
-              <parameter name="subsub_bool_b" value="sub_bool_b" type="bool"/>
-              <parameter name="subsub_string_a" value="sub_string_a" type="string"/>
-              <parameter name="subsub_string_b" value="sub_string_b" type="string"/>
-              <parameter name="subsub_textblock_a" value="sub_textblock_a" type="textblock"/>
-              <parameter name="subsub_textblock_b" value="sub_textblock_b" type="textblock"/>
-              <parameter name="subsub_lookup_textblock" value="1, 1&#xa;2, 2" type="textblock"/>
-              <parameter name="subsub_lookup_inid" value="0" type="integer"/>
-              <parameter name="subsub_lookup_comment" value="#" type="string"/>
-              <parameter name="subsub_lookup_reload" value="true" type="bool"/>
+              <parameter name="subsub_a" type="double" value="sub_a"/>
+              <parameter name="subsub_b" type="double" value="sub_b"/>
+              <parameter name="subsub_c" type="double" value="sub_a+sub_b"/>
+              <parameter name="subsub_d" type="double" value="self.subsub_a+self.subsub_b"/>
+              <parameter name="subsub_e" type="double" value="main_a+self.subsub_b"/>
+              <parameter name="subsub_int_a" type="integer" value="sub_int_a"/>
+              <parameter name="subsub_int_b" type="integer" value="sub_int_b"/>
+              <parameter name="subsub_bool_a" type="bool" value="sub_bool_a"/>
+              <parameter name="subsub_bool_b" type="bool" value="sub_bool_b"/>
+              <parameter name="subsub_string_a" type="string" value="sub_string_a"/>
+              <parameter name="subsub_string_b" type="string" value="sub_string_b"/>
+              <parameter name="subsub_textblock_a" type="textblock" value="sub_textblock_a"/>
+              <parameter name="subsub_textblock_b" type="textblock" value="sub_textblock_b"/>
+              <parameter name="subsub_lookup_textblock" type="textblock" value="1, 1&#xa;2, 2"/>
+              <parameter name="subsub_lookup_inid" type="integer" value="0"/>
+              <parameter name="subsub_lookup_comment" type="string" value="#"/>
+              <parameter name="subsub_lookup_reload" type="bool" value="true"/>
             </parameters>
             <aliases/>
             <hopsangui>
-              <pose x="2380" a="0" flipped="false" y="2298"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" disabled="false" hydraulicmaxpressure="20000000" flowspeed="100"/>
-              <viewport x="2207.5" zoom="1" y="2181.5"/>
+              <pose x="2380" y="2298" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0" disabled="false"/>
+              <viewport x="2037" y="2189.5" zoom="1"/>
               <ports hidden="1"/>
               <names hidden="1"/>
               <graphics type="user"/>
               <scriptfile path=""/>
               <hopsanobjectappearance version="0.3">
-                <modelobject typename="Subsystem" displayname="Subsubsystem">
+                <modelobject displayname="Subsubsystem" typename="Subsystem">
                   <icons>
                     <icon type="defaultmissing" path="subsystemDefault.svg"/>
                   </icons>
                   <ports>
-                    <port autoplaced="true" name="SubsubPortOut" x="1" a="0" enabled="true" y="0.5"/>
-                    <port autoplaced="true" name="SubsubPortIn" x="0" a="180" enabled="true" y="0.5"/>
+                    <port name="SubsubPortOut" autoplaced="true" x="1" y="0.5" a="0" enabled="true"/>
+                    <port name="SubsubPortIn" autoplaced="true" x="0" y="0.5" a="180" enabled="true"/>
                   </ports>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                 </modelobject>
               </hopsanobjectappearance>
               <optimization>
@@ -409,245 +324,288 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               </senstivitityanalysis>
             </hopsangui>
             <objects>
-              <component name="1DLookupTable_1" typename="Signal1DLookupTable" subtypename="" cqstype="S" disabled="false" locked="false">
+              <component name="TestConstant" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalConstant">
                 <parameters>
-                  <parameter name="in#Value" value="0" unit="" type="double"/>
-                  <parameter name="filename" value="K" unit="" type="string"/>
-                  <parameter name="text" value="Skip this line&#xa;K1,2,3,4&#xa;1,2&#xa;2,3&#xa;4,5&#xa;6,7" unit="" type="textblock"/>
-                  <parameter name="csvsep" value="," unit="" type="string"/>
-                  <parameter name="inid" value="0" unit="" type="integer"/>
-                  <parameter name="outid" value="self.numlineskip" unit="" type="integer"/>
-                  <parameter name="numlineskip" value="1" unit="" type="integer"/>
-                  <parameter name="comment" value="self.filename" unit="" type="string"/>
-                  <parameter name="reload" value="true" unit="" type="bool"/>
+                  <parameter name="y#Value" type="double" value="1" unit=""/>
                 </parameters>
                 <ports>
-                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                  <port name="y" nodetype="NodeSignal" porttype="WritePortType"/>
                 </ports>
                 <hopsangui>
-                  <pose x="1725" a="0" flipped="false" y="2307"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <pose x="1942" y="2141" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject typename="Signal1DLookupTable" displayname="1DLookupTable_1">
+                    <modelobject displayname="TestConstant" typename="SignalConstant">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component name="Gain_2" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
+              <component name="Add_1" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalAdd">
                 <parameters>
-                  <parameter name="in#Value" value="0" unit="" type="double"/>
-                  <parameter name="k#Value" value="subsub_d" unit="" type="double"/>
+                  <parameter name="in1#Value" type="double" value="subsub_a" unit=""/>
+                  <parameter name="in2#Value" type="double" value="1" unit=""/>
                 </parameters>
                 <ports>
-                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="in1" nodetype="NodeSignal" porttype="ReadPortType"/>
+                  <port name="in2" nodetype="NodeSignal" porttype="ReadPortType"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2182" y="2395" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="Add_1" typename="SignalAdd">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Gain" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGain">
+                <parameters>
+                  <parameter name="in#Value" type="double" value="0" unit=""/>
+                  <parameter name="k#Value" type="double" value="subsub_c" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
                   <port name="k" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2057.333333" a="0" flipped="false" y="2141"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <pose x="2136" y="2395" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalGain" displayname="Gain_2">
+                    <modelobject displayname="Gain" typename="SignalGain">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component name="TestConstant" typename="SignalConstant" subtypename="" cqstype="S" disabled="false" locked="false">
+              <component name="Gain_3" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGain">
                 <parameters>
-                  <parameter name="y#Value" value="1" unit="" type="double"/>
+                  <parameter name="in#Value" type="double" value="0" unit=""/>
+                  <parameter name="k#Value" type="double" value="subsub_e" unit=""/>
                 </parameters>
                 <ports>
-                  <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
-                </ports>
-                <hopsangui>
-                  <pose x="1942" a="0" flipped="false" y="2141"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalConstant" displayname="TestConstant">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <component name="Gain" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
-                <parameters>
-                  <parameter name="in#Value" value="0" unit="" type="double"/>
-                  <parameter name="k#Value" value="subsub_c" unit="" type="double"/>
-                </parameters>
-                <ports>
-                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
                   <port name="k" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2136" a="0" flipped="false" y="2395"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <pose x="2115" y="2141" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalGain" displayname="Gain">
+                    <modelobject displayname="Gain_3" typename="SignalGain">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <systemport name="SubsubPortOut" typename="HopsanGUIContainerPort" subtypename="" cqstype="hasNoCqsType" disabled="false" locked="false">
-                <hopsangui>
-                  <pose x="2329" a="0" flipped="false" y="2395"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-                </hopsangui>
-              </systemport>
-              <component name="Gain_3" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
-                <parameters>
-                  <parameter name="in#Value" value="0" unit="" type="double"/>
-                  <parameter name="k#Value" value="subsub_e" unit="" type="double"/>
-                </parameters>
-                <ports>
-                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="k" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-                </ports>
-                <hopsangui>
-                  <pose x="2115" a="0" flipped="false" y="2141"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalGain" displayname="Gain_3">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <component name="Add" typename="SignalAdd" subtypename="" cqstype="S" disabled="false" locked="false">
-                <parameters>
-                  <parameter name="in1#Value" value="subsub_a" unit="" type="double"/>
-                  <parameter name="in2#Value" value="self.in1.Value+1" unit="" type="double"/>
-                </parameters>
-                <ports>
-                  <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="in2" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-                </ports>
-                <hopsangui>
-                  <pose x="2088" a="0" flipped="false" y="2395"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalAdd" displayname="Add">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <component name="Time" typename="SignalTime" subtypename="" cqstype="S" disabled="false" locked="false">
+              <component name="Time_1" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalTime">
                 <parameters/>
                 <ports>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
                 </ports>
                 <hopsangui>
-                  <pose x="1645" a="0" flipped="false" y="2307"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <pose x="2271" y="2249" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalTime" displayname="Time">
+                    <modelobject displayname="Time_1" typename="SignalTime">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component name="1DLookupTable" typename="Signal1DLookupTable" subtypename="" cqstype="S" disabled="false" locked="false">
-                <parameters>
-                  <parameter name="in#Value" value="0" unit="" type="double"/>
-                  <parameter name="filename" value="FilePath" unit="" type="string"/>
-                  <parameter name="text" value="subsub_lookup_textblock" unit="" type="textblock"/>
-                  <parameter name="csvsep" value="," unit="" type="string"/>
-                  <parameter name="inid" value="subsub_lookup_inid" unit="" type="integer"/>
-                  <parameter name="outid" value="1" unit="" type="integer"/>
-                  <parameter name="numlineskip" value="0" unit="" type="integer"/>
-                  <parameter name="comment" value="subsub_lookup_comment" unit="" type="string"/>
-                  <parameter name="reload" value="subsub_lookup_reload" unit="" type="bool"/>
-                </parameters>
-                <ports>
-                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-                </ports>
+              <systemport name="SubsubPortOut" locked="false" disabled="false" cqstype="hasNoCqsType" subtypename="" typename="HopsanGUIContainerPort">
                 <hopsangui>
-                  <pose x="2356" a="0" flipped="false" y="2249"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject typename="Signal1DLookupTable" displayname="1DLookupTable">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <systemport name="SubsubPortIn" typename="HopsanGUIContainerPort" subtypename="" cqstype="hasNoCqsType" disabled="false" locked="false">
-                <hopsangui>
-                  <pose x="1465" a="0" flipped="false" y="2349"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <pose x="2329" y="2395" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                 </hopsangui>
               </systemport>
-              <component name="Time_1" typename="SignalTime" subtypename="" cqstype="S" disabled="false" locked="false">
+              <systemport name="SubsubPortIn" locked="false" disabled="false" cqstype="hasNoCqsType" subtypename="" typename="HopsanGUIContainerPort">
+                <hopsangui>
+                  <pose x="1465" y="2349" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+                </hopsangui>
+              </systemport>
+              <component name="Time" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalTime">
                 <parameters/>
                 <ports>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2271" a="0" flipped="false" y="2249"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <pose x="1645" y="2307" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalTime" displayname="Time_1">
+                    <modelobject displayname="Time" typename="SignalTime">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component name="Gain_1" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
+              <component name="1DLookupTable_1" locked="false" disabled="false" cqstype="S" subtypename="" typename="Signal1DLookupTable">
                 <parameters>
-                  <parameter name="in#Value" value="0" unit="" type="double"/>
-                  <parameter name="k#Value" value="subsub_c" unit="" type="double"/>
+                  <parameter name="in#Value" type="double" value="0" unit=""/>
+                  <parameter name="filename" type="string" value="K" unit=""/>
+                  <parameter name="text" type="textblock" value="Skip this line&#xa;K1,2,3,4&#xa;1,2&#xa;2,3&#xa;4,5&#xa;6,7" unit=""/>
+                  <parameter name="csvsep" type="string" value="," unit=""/>
+                  <parameter name="inid" type="integer" value="0" unit=""/>
+                  <parameter name="outid" type="integer" value="self.numlineskip" unit=""/>
+                  <parameter name="numlineskip" type="integer" value="main_lookup_inid" unit=""/>
+                  <parameter name="comment" type="string" value="self.filename" unit=""/>
+                  <parameter name="reload" type="bool" value="true" unit=""/>
                 </parameters>
                 <ports>
-                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+                </ports>
+                <hopsangui>
+                  <pose x="1725" y="2307" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="1DLookupTable_1" typename="Signal1DLookupTable">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Gain_2" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGain">
+                <parameters>
+                  <parameter name="in#Value" type="double" value="0" unit=""/>
+                  <parameter name="k#Value" type="double" value="subsub_d" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
                   <port name="k" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
                 </ports>
                 <hopsangui>
-                  <pose x="1999.666667" a="0" flipped="false" y="2141"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <pose x="2057.333333" y="2141" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalGain" displayname="Gain_1">
+                    <modelobject displayname="Gain_2" typename="SignalGain">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component name="Add_1" typename="SignalAdd" subtypename="" cqstype="S" disabled="false" locked="false">
+              <component name="1DLookupTable_2" locked="false" disabled="false" cqstype="S" subtypename="" typename="Signal1DLookupTable">
                 <parameters>
-                  <parameter name="in1#Value" value="subsub_a" unit="" type="double"/>
-                  <parameter name="in2#Value" value="1" unit="" type="double"/>
+                  <parameter name="in#Value" type="double" value="0" unit=""/>
+                  <parameter name="filename" type="string" value="FilePath" unit=""/>
+                  <parameter name="text" type="textblock" value="main_lookup_textblock" unit=""/>
+                  <parameter name="csvsep" type="string" value="," unit=""/>
+                  <parameter name="inid" type="integer" value="main_lookup_inid" unit=""/>
+                  <parameter name="outid" type="integer" value="0" unit=""/>
+                  <parameter name="numlineskip" type="integer" value="0" unit=""/>
+                  <parameter name="comment" type="string" value="main_lookup_comment" unit=""/>
+                  <parameter name="reload" type="bool" value="main_lookup_reload" unit=""/>
                 </parameters>
                 <ports>
-                  <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="in2" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                  <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2182" a="0" flipped="false" y="2395"/>
-                  <nametext position="0" visible="0"/>
-                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <pose x="2376" y="2031" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject typename="SignalAdd" displayname="Add_1">
+                    <modelobject displayname="1DLookupTable_2" typename="Signal1DLookupTable">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Gain_1" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGain">
+                <parameters>
+                  <parameter name="in#Value" type="double" value="0" unit=""/>
+                  <parameter name="k#Value" type="double" value="subsub_c" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
+                  <port name="k" nodetype="NodeSignal"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+                </ports>
+                <hopsangui>
+                  <pose x="1999.666667" y="2141" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="Gain_1" typename="SignalGain">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="1DLookupTable" locked="false" disabled="false" cqstype="S" subtypename="" typename="Signal1DLookupTable">
+                <parameters>
+                  <parameter name="in#Value" type="double" value="0" unit=""/>
+                  <parameter name="filename" type="string" value="FilePath" unit=""/>
+                  <parameter name="text" type="textblock" value="subsub_lookup_textblock" unit=""/>
+                  <parameter name="csvsep" type="string" value="," unit=""/>
+                  <parameter name="inid" type="integer" value="subsub_lookup_inid" unit=""/>
+                  <parameter name="outid" type="integer" value="1" unit=""/>
+                  <parameter name="numlineskip" type="integer" value="0" unit=""/>
+                  <parameter name="comment" type="string" value="subsub_lookup_comment" unit=""/>
+                  <parameter name="reload" type="bool" value="subsub_lookup_reload" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2356" y="2249" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="1DLookupTable" typename="Signal1DLookupTable">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Add" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalAdd">
+                <parameters>
+                  <parameter name="in1#Value" type="double" value="subsub_a" unit=""/>
+                  <parameter name="in2#Value" type="double" value="self.in1.Value+1" unit=""/>
+                </parameters>
+                <ports>
+                  <port name="in1" nodetype="NodeSignal" porttype="ReadPortType"/>
+                  <port name="in2" nodetype="NodeSignal" porttype="ReadPortType"/>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2088" y="2395" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="Add" typename="SignalAdd">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Time_2" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalTime">
+                <parameters/>
+                <ports>
+                  <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2283.5" y="2031" a="0" flipped="false"/>
+                  <nametext visible="0" position="0"/>
+                  <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject displayname="Time_2" typename="SignalTime">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
@@ -656,38 +614,46 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <textboxwidget>
                 <hopsangui>
                   <pose x="2239.000000" y="2183.000000"/>
-                  <textobject fontcolor="#556b2f" text="Test lookup of system parametrs for int bool string and textblock" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
-                  <size height="100.000000" width="493.000000"/>
-                  <line style="solidline" color="#556b2f" visible="1" width="2"/>
+                  <textobject reflow="1" fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" text="Test lookup of system parameters for int, bool, string, and textblock"/>
+                  <size width="503.000000" height="100.000000"/>
+                  <line style="solidline" width="2" visible="1" color="#556b2f"/>
                 </hopsangui>
               </textboxwidget>
               <textboxwidget>
                 <hopsangui>
                   <pose x="1250.500000" y="0.000000"/>
-                  <textobject fontcolor="#556b2f" text="Test lookup of system parametrs for int bool string and textblock" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
-                  <size height="100.000000" width="495.000000"/>
-                  <line style="solidline" color="#556b2f" visible="1" width="2"/>
+                  <textobject reflow="1" fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" text="Test lookup of system parametrs for int bool string and textblock"/>
+                  <size width="501.000000" height="100.000000"/>
+                  <line style="solidline" width="2" visible="1" color="#556b2f"/>
                 </hopsangui>
               </textboxwidget>
               <textboxwidget>
                 <hopsangui>
                   <pose x="1273.500000" y="0.000000"/>
-                  <textobject fontcolor="#556b2f" text="Test lookup of system parametrs for int bool string and textblock" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
-                  <size height="100.000000" width="495.000000"/>
-                  <line style="solidline" color="#556b2f" visible="1" width="2"/>
+                  <textobject reflow="1" fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" text="Test lookup of system parametrs for int bool string and textblock"/>
+                  <size width="501.000000" height="100.000000"/>
+                  <line style="solidline" width="2" visible="1" color="#556b2f"/>
                 </hopsangui>
               </textboxwidget>
               <textboxwidget>
                 <hopsangui>
                   <pose x="1616.000000" y="2240.000000"/>
-                  <textobject fontcolor="#556b2f" text="Test using self. for int and string parameters" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
-                  <size height="100.000000" width="336.000000"/>
-                  <line style="solidline" color="#556b2f" visible="1" width="2"/>
+                  <textobject reflow="1" fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" text="Test using self. for int and string parameters"/>
+                  <size width="342.000000" height="100.000000"/>
+                  <line style="solidline" width="2" visible="1" color="#556b2f"/>
+                </hopsangui>
+              </textboxwidget>
+              <textboxwidget>
+                <hopsangui>
+                  <pose x="2143.000000" y="1966.000000"/>
+                  <textobject reflow="1" fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" text="Test lookup of system parameters for int, bool, string and text block from grandparent system"/>
+                  <size width="685.000000" height="100.000000"/>
+                  <line style="solidline" width="2" visible="1" color="#556b2f"/>
                 </hopsangui>
               </textboxwidget>
             </objects>
             <connections>
-              <connect endcomponent="Gain" startcomponent="Add" endport="in" startport="out">
+              <connect endcomponent="Gain" startport="out" endport="in" startcomponent="Add">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2100.50000000000000000000" y="2395.00000000000000000000"/>
@@ -703,7 +669,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Add_1" startcomponent="Gain" endport="in1" startport="out">
+              <connect endcomponent="Add_1" startport="out" endport="in1" startcomponent="Gain">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2148.50000000000000000000" y="2395.00000000000000000000"/>
@@ -719,7 +685,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Add_1" startcomponent="SubsubPortIn" endport="in2" startport="SubsubPortIn">
+              <connect endcomponent="Add_1" startport="SubsubPortIn" endport="in2" startcomponent="SubsubPortIn">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="1465.00000000000000000000" y="2349.00000000000000000000"/>
@@ -733,7 +699,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="SubsubPortOut" startcomponent="Add_1" endport="SubsubPortOut" startport="out">
+              <connect endcomponent="SubsubPortOut" startport="out" endport="SubsubPortOut" startcomponent="Add_1">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2194.50000000000000000000" y="2395.00000000000000000000"/>
@@ -749,7 +715,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Gain_1" startcomponent="TestConstant" endport="in" startport="y">
+              <connect endcomponent="Gain_1" startport="y" endport="in" startcomponent="TestConstant">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="1954.50000000000000000000" y="2141.00000000000000000000"/>
@@ -765,7 +731,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Gain_2" startcomponent="Gain_1" endport="in" startport="out">
+              <connect endcomponent="Gain_2" startport="out" endport="in" startcomponent="Gain_1">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2012.16666699999996126280" y="2141.00000000000000000000"/>
@@ -781,7 +747,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Gain_3" startcomponent="Gain_2" endport="in" startport="out">
+              <connect endcomponent="Gain_3" startport="out" endport="in" startcomponent="Gain_2">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2069.83333300000003873720" y="2141.00000000000000000000"/>
@@ -797,7 +763,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="1DLookupTable_1" startcomponent="Time" endport="in" startport="out">
+              <connect endcomponent="1DLookupTable_1" startport="out" endport="in" startcomponent="Time">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="1657.50000000000000000000" y="2307.00000000000000000000"/>
@@ -813,7 +779,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="1DLookupTable" startcomponent="Time_1" endport="in" startport="out">
+              <connect endcomponent="1DLookupTable" startport="out" endport="in" startcomponent="Time_1">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2283.50000000000000000000" y="2249.00000000000000000000"/>
@@ -829,42 +795,147 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
+              <connect endcomponent="1DLookupTable_2" startport="out" endport="in" startcomponent="Time_2">
+                <hopsangui>
+                  <coordinates>
+                    <coordinate x="2296.00000000000000000000" y="2031.00000000000000000000"/>
+                    <coordinate x="2313.50000000000000000000" y="2031.00000000000000000000"/>
+                    <coordinate x="2313.50000000000000000000" y="2031.00000000000000000000"/>
+                    <coordinate x="2356.00000000000000000000" y="2031.00000000000000000000"/>
+                  </coordinates>
+                  <geometries>
+                    <geometry>vertical</geometry>
+                    <geometry>horizontal</geometry>
+                    <geometry>vertical</geometry>
+                  </geometries>
+                  <style>solid</style>
+                </hopsangui>
+              </connect>
             </connections>
           </system>
-          <component name="Gain_1" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
+          <component name="ShadowParamGain" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGain">
             <parameters>
-              <parameter name="in#Value" value="0" unit="" type="double"/>
-              <parameter name="k#Value" value="sub_b+main_a" unit="" type="double"/>
+              <parameter name="in#Value" type="double" value="0" unit=""/>
+              <parameter name="k#Value" type="double" value="shadow_param" unit=""/>
             </parameters>
             <ports>
-              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
               <port name="k" nodetype="NodeSignal"/>
-              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+              <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
             </ports>
             <hopsangui>
-              <pose x="2427" a="0" flipped="false" y="2203.5"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <pose x="2583" y="2170" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
               <hopsanobjectappearance version="0.3">
-                <modelobject typename="SignalGain" displayname="Gain_1">
+                <modelobject displayname="ShadowParamGain" typename="SignalGain">
                   <ports/>
                 </modelobject>
               </hopsanobjectappearance>
             </hopsangui>
           </component>
-          <component name="NumhopSetValue" typename="SignalConstant" subtypename="" cqstype="S" disabled="false" locked="false">
+          <component name="Greater_Than_Comparer" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGreaterThan">
             <parameters>
-              <parameter name="y#Value" value="0" unit="" type="double"/>
+              <parameter name="in#Value" type="double" value="0" unit=""/>
+              <parameter name="x_limit#Value" type="double" value="0.5" unit=""/>
             </parameters>
             <ports>
-              <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
+              <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
+              <port name="x_limit" nodetype="NodeSignal"/>
+              <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
             </ports>
             <hopsangui>
-              <pose x="2106" a="0" flipped="false" y="2157"/>
-              <nametext position="0" visible="0"/>
-              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <pose x="2342" y="2029" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
               <hopsanobjectappearance version="0.3">
-                <modelobject typename="SignalConstant" displayname="NumhopSetValue">
+                <modelobject displayname="Greater_Than_Comparer" typename="SignalGreaterThan">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component name="Stop_simulation" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalStopSimulation">
+            <parameters>
+              <parameter name="in#Value" type="double" value="0" unit=""/>
+              <parameter name="message" type="string" value="" unit=""/>
+            </parameters>
+            <ports>
+              <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
+            </ports>
+            <hopsangui>
+              <pose x="2438" y="2029" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="Stop_simulation" typename="SignalStopSimulation">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <systemport name="SubPortIn" locked="false" disabled="false" cqstype="hasNoCqsType" subtypename="" typename="HopsanGUIContainerPort">
+            <hopsangui>
+              <pose x="1925" y="2298" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+            </hopsangui>
+          </systemport>
+          <component name="Gain_1" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalGain">
+            <parameters>
+              <parameter name="in#Value" type="double" value="0" unit=""/>
+              <parameter name="k#Value" type="double" value="sub_b+main_a" unit=""/>
+            </parameters>
+            <ports>
+              <port name="in" nodetype="NodeSignal" porttype="ReadPortType"/>
+              <port name="k" nodetype="NodeSignal"/>
+              <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+            </ports>
+            <hopsangui>
+              <pose x="2427" y="2203.5" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="Gain_1" typename="SignalGain">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component name="NumhopSetValue" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalConstant">
+            <parameters>
+              <parameter name="y#Value" type="double" value="0" unit=""/>
+            </parameters>
+            <ports>
+              <port name="y" nodetype="NodeSignal" porttype="WritePortType"/>
+            </ports>
+            <hopsangui>
+              <pose x="2106" y="2157" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="NumhopSetValue" typename="SignalConstant">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component name="Add" locked="false" disabled="false" cqstype="S" subtypename="" typename="SignalAdd">
+            <parameters>
+              <parameter name="in1#Value" type="double" value="0" unit=""/>
+              <parameter name="in2#Value" type="double" value="self.in1.Value" unit=""/>
+            </parameters>
+            <ports>
+              <port name="in1" nodetype="NodeSignal" porttype="ReadPortType"/>
+              <port name="in2" nodetype="NodeSignal" porttype="ReadPortType"/>
+              <port name="out" nodetype="NodeSignal" porttype="WritePortType"/>
+            </ports>
+            <hopsangui>
+              <pose x="2274" y="2029" a="0" flipped="false"/>
+              <nametext visible="0" position="0"/>
+              <animation flowspeed="100" hydraulicmaxpressure="20000000" hydraulicminpressure="0"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject displayname="Add" typename="SignalAdd">
                   <ports/>
                 </modelobject>
               </hopsanobjectappearance>
@@ -873,14 +944,14 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
           <textboxwidget>
             <hopsangui>
               <pose x="2103.000000" y="1934.000000"/>
-              <textobject fontcolor="#556b2f" text="Test when local variable and system variable with same name exists&#xa;In this case in1.value and in1#value" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
-              <size height="130.000000" width="571.000000"/>
-              <line style="solidline" color="#556b2f" visible="1" width="2"/>
+              <textobject reflow="1" fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" text="Test when local variable and system variable with same name exists&#xa;In this case in1.value and in1#value"/>
+              <size width="577.000000" height="130.000000"/>
+              <line style="solidline" width="2" visible="1" color="#556b2f"/>
             </hopsangui>
           </textboxwidget>
         </objects>
         <connections>
-          <connect endcomponent="Subsubsystem" startcomponent="SubPortIn" endport="SubsubPortIn" startport="SubPortIn">
+          <connect endcomponent="Subsubsystem" startport="SubPortIn" endport="SubsubPortIn" startcomponent="SubPortIn">
             <hopsangui>
               <coordinates>
                 <coordinate x="1925.00000000000000000000" y="2298.00000000000000000000"/>
@@ -896,7 +967,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="SubPortOut" startcomponent="Subsubsystem" endport="SubPortOut" startport="SubsubPortOut">
+          <connect endcomponent="SubPortOut" startport="SubsubPortOut" endport="SubPortOut" startcomponent="Subsubsystem">
             <hopsangui>
               <coordinates>
                 <coordinate x="2425.00000000000000000000" y="2298.00000000000000000000"/>
@@ -912,7 +983,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="TestConstant" startcomponent="Gain" endport="y" startport="in">
+          <connect endcomponent="TestConstant" startport="in" endport="y" startcomponent="Gain">
             <hopsangui>
               <coordinates>
                 <coordinate x="2414.50000000000000000000" y="2154.00000000000000000000"/>
@@ -928,7 +999,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="TestConstant" startcomponent="Gain_1" endport="y" startport="in">
+          <connect endcomponent="TestConstant" startport="in" endport="y" startcomponent="Gain_1">
             <hopsangui>
               <coordinates>
                 <coordinate x="2414.50000000000000000000" y="2203.50000000000000000000"/>
@@ -944,7 +1015,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="Add" startcomponent="Greater_Than_Comparer" endport="out" startport="in">
+          <connect endcomponent="Add" startport="in" endport="out" startcomponent="Greater_Than_Comparer">
             <hopsangui>
               <coordinates>
                 <coordinate x="2329.50000000000000000000" y="2029.00000000000000000000"/>
@@ -960,7 +1031,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="Stop_simulation" startcomponent="Greater_Than_Comparer" endport="in" startport="out">
+          <connect endcomponent="Stop_simulation" startport="out" endport="in" startcomponent="Greater_Than_Comparer">
             <hopsangui>
               <coordinates>
                 <coordinate x="2354.50000000000000000000" y="2029.00000000000000000000"/>
@@ -980,7 +1051,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
       </system>
     </objects>
     <connections>
-      <connect endcomponent="TestGain" startcomponent="TestStep" endport="in" startport="out">
+      <connect endcomponent="TestGain" startport="out" endport="in" startcomponent="TestStep">
         <hopsangui>
           <coordinates>
             <coordinate x="2332.50000000000000000000" y="2494.00000000000000000000"/>
@@ -992,7 +1063,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
           <style>solid</style>
         </hopsangui>
       </connect>
-      <connect endcomponent="Subsystem" startcomponent="TestConstant" endport="SubPortIn" startport="y">
+      <connect endcomponent="Subsystem" startport="y" endport="SubPortIn" startcomponent="TestConstant">
         <hopsangui>
           <coordinates>
             <coordinate x="2172.50000000000000000000" y="2310.00000000000000000000"/>

--- a/UnitTests/HopsanCoreTests/SimulationTest/unittestmodel.hmf
+++ b/UnitTests/HopsanCoreTests/SimulationTest/unittestmodel.hmf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hopsanmodelfile hopsanguiversion="2.12.0.20200222.2002" hopsancoreversion="2.12.0.20170101.0001" hmfversion="0.4">
+<hopsanmodelfile hmfversion="0.4" hopsancoreversion="2.12.0.20170101.0001" hopsanguiversion="2.12.0.20200222.1953">
   <requirements>
     <componentlibrary>
       <id>59c07d33-554f-49d3-a163-a928823d4380</id>
@@ -10,40 +10,40 @@
       <name>HopsanInternals</name>
     </componentlibrary>
   </requirements>
-  <system cqstype="UndefinedCQSType" name="unittestmodel" disabled="false" typename="Subsystem" locked="false" subtypename="">
-    <simulationtime start="0" inherit_timestep="true" stop="10" timestep="0.001"/>
+  <system name="unittestmodel" typename="Subsystem" subtypename="" cqstype="UndefinedCQSType" disabled="false" locked="false">
+    <simulationtime inherit_timestep="true" stop="10" timestep="0.001" start="0"/>
     <simulationlogsettings starttime="0" numsamples="2048"/>
     <parameters>
-      <parameter type="double" name="apa" value="7"/>
-      <parameter type="double" name="main_a" value="1"/>
-      <parameter type="double" name="shadow_param" value="-1"/>
-      <parameter type="integer" name="main_int_a" value="1"/>
-      <parameter type="bool" name="main_bool_a" value="true"/>
-      <parameter type="string" name="main_string_a" value="string_a"/>
-      <parameter type="textblock" name="main_textblock_a" value="textblock_a"/>
-      <parameter type="textblock" name="main_textblock_b" value="INVALID"/>
-      <parameter type="string" name="main_string_b" value="INVALID"/>
-      <parameter type="integer" name="main_int_b" value="-1"/>
-      <parameter type="bool" name="main_bool_b" value="true"/>
-      <parameter type="double" name="main_b" value="-1"/>
+      <parameter name="apa" value="7" type="double"/>
+      <parameter name="main_a" value="1" type="double"/>
+      <parameter name="shadow_param" value="-1" type="double"/>
+      <parameter name="main_int_a" value="1" type="integer"/>
+      <parameter name="main_bool_a" value="true" type="bool"/>
+      <parameter name="main_string_a" value="string_a" type="string"/>
+      <parameter name="main_textblock_a" value="textblock_a" type="textblock"/>
+      <parameter name="main_textblock_b" value="INVALID" type="textblock"/>
+      <parameter name="main_string_b" value="INVALID" type="string"/>
+      <parameter name="main_int_b" value="-1" type="integer"/>
+      <parameter name="main_bool_b" value="true" type="bool"/>
+      <parameter name="main_b" value="-1" type="double"/>
     </parameters>
     <aliases/>
     <hopsangui>
-      <pose x="0" flipped="false" a="0" y="0"/>
-      <nametext visible="0" position="0"/>
-      <animation disabled="false" hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-      <viewport x="2277.5" zoom="1" y="2369.5"/>
+      <pose x="0" a="0" flipped="false" y="0"/>
+      <nametext position="0" visible="0"/>
+      <animation hydraulicminpressure="0" disabled="false" hydraulicmaxpressure="20000000" flowspeed="100"/>
+      <viewport x="2283.5" zoom="1" y="2336.5"/>
       <ports hidden="1"/>
       <names hidden="0"/>
       <graphics type="user"/>
       <scriptfile path=""/>
       <hopsanobjectappearance version="0.3">
-        <modelobject displayname="unittestmodel" typename="Subsystem">
+        <modelobject typename="Subsystem" displayname="unittestmodel">
           <icons>
             <icon type="defaultmissing" path="subsystemDefault.svg"/>
           </icons>
           <ports/>
-          <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+          <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
         </modelobject>
       </hopsanobjectappearance>
       <optimization>
@@ -72,10 +72,10 @@
       </senstivitityanalysis>
     </hopsangui>
     <objects>
-      <component cqstype="S" name="TestGain" disabled="false" typename="SignalGain" locked="false" subtypename="">
+      <component name="TestGain" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
         <parameters>
-          <parameter type="double" name="in#Value" value="0" unit=""/>
-          <parameter type="double" name="k#Value" value="1" unit=""/>
+          <parameter name="in#Value" value="0" unit="" type="double"/>
+          <parameter name="k#Value" value="1" unit="" type="double"/>
         </parameters>
         <ports>
           <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
@@ -83,36 +83,59 @@
           <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
         </ports>
         <hopsangui>
-          <pose x="2408" flipped="false" a="0" y="2494"/>
-          <nametext visible="0" position="0"/>
-          <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+          <pose x="2408" a="0" flipped="false" y="2494"/>
+          <nametext position="0" visible="0"/>
+          <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
           <hopsanobjectappearance version="0.3">
-            <modelobject displayname="TestGain" typename="SignalGain">
+            <modelobject typename="SignalGain" displayname="TestGain">
               <ports/>
             </modelobject>
           </hopsanobjectappearance>
         </hopsangui>
       </component>
-      <component cqstype="S" name="TestConstant" disabled="false" typename="SignalConstant" locked="false" subtypename="">
+      <component name="TestConstant" typename="SignalConstant" subtypename="" cqstype="S" disabled="false" locked="false">
         <parameters>
-          <parameter type="double" name="y#Value" value="1" unit=""/>
+          <parameter name="y#Value" value="1" unit="" type="double"/>
         </parameters>
         <ports>
           <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
         </ports>
         <hopsangui>
-          <pose x="2160" flipped="false" a="0" y="2310"/>
-          <nametext visible="0" position="0"/>
-          <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+          <pose x="2160" a="0" flipped="false" y="2310"/>
+          <nametext position="0" visible="0"/>
+          <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
           <hopsanobjectappearance version="0.3">
-            <modelobject displayname="TestConstant" typename="SignalConstant">
+            <modelobject typename="SignalConstant" displayname="TestConstant">
               <ports/>
             </modelobject>
           </hopsanobjectappearance>
         </hopsangui>
       </component>
-      <system cqstype="S" name="Subsystem" disabled="false" typename="Subsystem" locked="false" subtypename="">
-        <simulationtime start="0" inherit_timestep="true" stop="10" timestep="0.001"/>
+      <component name="TestStep" typename="SignalStep" subtypename="" cqstype="S" disabled="false" locked="false">
+        <parameters>
+          <parameter name="y_0#Value" value="-5" unit="" type="double"/>
+          <parameter name="y_A#Value" value="5" unit="" type="double"/>
+          <parameter name="t_step#Value" value="apa" unit="s" type="double"/>
+        </parameters>
+        <ports>
+          <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+          <port name="y_0" nodetype="NodeSignal"/>
+          <port name="y_A" nodetype="NodeSignal"/>
+          <port name="t_step" nodetype="NodeSignal"/>
+        </ports>
+        <hopsangui>
+          <pose x="2320" a="0" flipped="false" y="2494"/>
+          <nametext position="0" visible="0"/>
+          <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+          <hopsanobjectappearance version="0.3">
+            <modelobject typename="SignalStep" displayname="TestStep">
+              <ports/>
+            </modelobject>
+          </hopsanobjectappearance>
+        </hopsangui>
+      </component>
+      <system name="Subsystem" typename="Subsystem" subtypename="" cqstype="S" disabled="false" locked="false">
+        <simulationtime inherit_timestep="true" stop="10" timestep="0.001" start="0"/>
         <simulationlogsettings starttime="0" numsamples="2048"/>
         <numhopscript># Comment line
 NumhopSetValue.y = sub_a;  NumhopSetValue.y = sub_b
@@ -120,39 +143,39 @@ NumhopSetValue.y = sub_a;  NumhopSetValue.y = sub_b
 # Actual test expression
 NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
         <parameters>
-          <parameter type="double" name="sub_a" value="main_a"/>
-          <parameter type="double" name="sub_b" value="2"/>
-          <parameter type="double" description="This is a deliberate complication, adding in1#Value as the name of a system parameter" name="in1#Value" value="1"/>
-          <parameter type="double" name="shadow_param" value="2"/>
-          <parameter type="integer" name="sub_int_a" value="main_int_a"/>
-          <parameter type="integer" name="sub_int_b" value="2"/>
-          <parameter type="bool" name="sub_bool_a" value="main_bool_a"/>
-          <parameter type="bool" name="sub_bool_b" value="false"/>
-          <parameter type="string" name="sub_string_a" value="main_string_a"/>
-          <parameter type="textblock" name="sub_textblock_a" value="main_textblock_a"/>
-          <parameter type="string" name="sub_string_b" value="string_b"/>
-          <parameter type="textblock" name="sub_textblock_b" value="textblock_b"/>
+          <parameter name="sub_a" value="main_a" type="double"/>
+          <parameter name="sub_b" value="2" type="double"/>
+          <parameter name="in1#Value" value="1" description="This is a deliberate complication, adding in1#Value as the name of a system parameter" type="double"/>
+          <parameter name="shadow_param" value="2" type="double"/>
+          <parameter name="sub_int_a" value="main_int_a" type="integer"/>
+          <parameter name="sub_int_b" value="2" type="integer"/>
+          <parameter name="sub_bool_a" value="main_bool_a" type="bool"/>
+          <parameter name="sub_bool_b" value="false" type="bool"/>
+          <parameter name="sub_string_a" value="main_string_a" type="string"/>
+          <parameter name="sub_textblock_a" value="main_textblock_a" type="textblock"/>
+          <parameter name="sub_string_b" value="string_b" type="string"/>
+          <parameter name="sub_textblock_b" value="textblock_b" type="textblock"/>
         </parameters>
         <aliases/>
         <hopsangui>
-          <pose x="2378" flipped="false" a="0" y="2310"/>
-          <nametext visible="0" position="0"/>
-          <animation disabled="false" hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-          <viewport x="2324.5" zoom="1" y="2002.5"/>
+          <pose x="2378" a="0" flipped="false" y="2310"/>
+          <nametext position="0" visible="0"/>
+          <animation hydraulicminpressure="0" disabled="false" hydraulicmaxpressure="20000000" flowspeed="100"/>
+          <viewport x="2348.5" zoom="1" y="2058.5"/>
           <ports hidden="1"/>
           <names hidden="0"/>
           <graphics type="user"/>
           <scriptfile path=""/>
           <hopsanobjectappearance version="0.3">
-            <modelobject displayname="Subsystem" typename="Subsystem">
+            <modelobject typename="Subsystem" displayname="Subsystem">
               <icons>
                 <icon type="defaultmissing" path="subsystemDefault.svg"/>
               </icons>
               <ports>
-                <port x="1" enabled="true" name="SubPortOut" autoplaced="true" a="0" y="0.5"/>
-                <port x="0" enabled="true" name="SubPortIn" autoplaced="true" a="180" y="0.5"/>
+                <port autoplaced="true" name="SubPortOut" x="1" a="0" enabled="true" y="0.5"/>
+                <port autoplaced="true" name="SubPortIn" x="0" a="180" enabled="true" y="0.5"/>
               </ports>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
             </modelobject>
           </hopsanobjectappearance>
           <optimization>
@@ -181,74 +204,17 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
           </senstivitityanalysis>
         </hopsangui>
         <objects>
-          <component cqstype="S" name="NumhopSetValue" disabled="false" typename="SignalConstant" locked="false" subtypename="">
-            <parameters>
-              <parameter type="double" name="y#Value" value="0" unit=""/>
-            </parameters>
-            <ports>
-              <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
+          <systemport name="SubPortOut" typename="HopsanGUIContainerPort" subtypename="" cqstype="hasNoCqsType" disabled="false" locked="false">
             <hopsangui>
-              <pose x="2106" flipped="false" a="0" y="2157"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="NumhopSetValue" typename="SignalConstant">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component cqstype="S" name="Gain_1" disabled="false" typename="SignalGain" locked="false" subtypename="">
-            <parameters>
-              <parameter type="double" name="in#Value" value="0" unit=""/>
-              <parameter type="double" name="k#Value" value="sub_b+main_a" unit=""/>
-            </parameters>
-            <ports>
-              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="k" nodetype="NodeSignal"/>
-              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2427" flipped="false" a="0" y="2203.5"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Gain_1" typename="SignalGain">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <systemport cqstype="hasNoCqsType" name="SubPortOut" disabled="false" typename="HopsanGUIContainerPort" locked="false" subtypename="">
-            <hopsangui>
-              <pose x="2820" flipped="false" a="0" y="2298"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <pose x="2820" a="0" flipped="false" y="2298"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
             </hopsangui>
           </systemport>
-          <component cqstype="S" name="TestConstant" disabled="false" typename="SignalConstant" locked="false" subtypename="">
+          <component name="ShadowParamGain" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
             <parameters>
-              <parameter type="double" name="y#Value" value="1" unit=""/>
-            </parameters>
-            <ports>
-              <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2340" flipped="false" a="0" y="2154"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="TestConstant" typename="SignalConstant">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component cqstype="S" name="Gain" disabled="false" typename="SignalGain" locked="false" subtypename="">
-            <parameters>
-              <parameter type="double" name="in#Value" value="0" unit=""/>
-              <parameter type="double" name="k#Value" value="sub_b+sub_a" unit=""/>
+              <parameter name="in#Value" value="0" unit="" type="double"/>
+              <parameter name="k#Value" value="shadow_param" unit="" type="double"/>
             </parameters>
             <ports>
               <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
@@ -256,58 +222,165 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
             </ports>
             <hopsangui>
-              <pose x="2427" flipped="false" a="0" y="2154"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <pose x="2583" a="0" flipped="false" y="2170"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
               <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Gain" typename="SignalGain">
+                <modelobject typename="SignalGain" displayname="ShadowParamGain">
                   <ports/>
                 </modelobject>
               </hopsanobjectappearance>
             </hopsangui>
           </component>
-          <system cqstype="S" name="Subsubsystem" disabled="false" typename="Subsystem" locked="false" subtypename="">
-            <simulationtime start="0" inherit_timestep="true" stop="10" timestep="0.001"/>
+          <component name="TestConstant" typename="SignalConstant" subtypename="" cqstype="S" disabled="false" locked="false">
+            <parameters>
+              <parameter name="y#Value" value="1" unit="" type="double"/>
+            </parameters>
+            <ports>
+              <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2340" a="0" flipped="false" y="2154"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject typename="SignalConstant" displayname="TestConstant">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component name="Gain" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
+            <parameters>
+              <parameter name="in#Value" value="0" unit="" type="double"/>
+              <parameter name="k#Value" value="sub_b+sub_a" unit="" type="double"/>
+            </parameters>
+            <ports>
+              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="k" nodetype="NodeSignal"/>
+              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2427" a="0" flipped="false" y="2154"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject typename="SignalGain" displayname="Gain">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <systemport name="SubPortIn" typename="HopsanGUIContainerPort" subtypename="" cqstype="hasNoCqsType" disabled="false" locked="false">
+            <hopsangui>
+              <pose x="1925" a="0" flipped="false" y="2298"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+            </hopsangui>
+          </systemport>
+          <component name="Stop_simulation" typename="SignalStopSimulation" subtypename="" cqstype="S" disabled="false" locked="false">
+            <parameters>
+              <parameter name="in#Value" value="0" unit="" type="double"/>
+              <parameter name="message" value="" unit="" type="string"/>
+            </parameters>
+            <ports>
+              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2438" a="0" flipped="false" y="2029"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject typename="SignalStopSimulation" displayname="Stop_simulation">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component name="Add" typename="SignalAdd" subtypename="" cqstype="S" disabled="false" locked="false">
+            <parameters>
+              <parameter name="in1#Value" value="0" unit="" type="double"/>
+              <parameter name="in2#Value" value="self.in1.Value" unit="" type="double"/>
+            </parameters>
+            <ports>
+              <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="in2" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2274" a="0" flipped="false" y="2029"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject typename="SignalAdd" displayname="Add">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <component name="Greater_Than_Comparer" typename="SignalGreaterThan" subtypename="" cqstype="S" disabled="false" locked="false">
+            <parameters>
+              <parameter name="in#Value" value="0" unit="" type="double"/>
+              <parameter name="x_limit#Value" value="0.5" unit="" type="double"/>
+            </parameters>
+            <ports>
+              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+              <port name="x_limit" nodetype="NodeSignal"/>
+              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+            </ports>
+            <hopsangui>
+              <pose x="2342" a="0" flipped="false" y="2029"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <hopsanobjectappearance version="0.3">
+                <modelobject typename="SignalGreaterThan" displayname="Greater_Than_Comparer">
+                  <ports/>
+                </modelobject>
+              </hopsanobjectappearance>
+            </hopsangui>
+          </component>
+          <system name="Subsubsystem" typename="Subsystem" subtypename="" cqstype="S" disabled="false" locked="false">
+            <simulationtime inherit_timestep="true" stop="10" timestep="0.001" start="0"/>
             <simulationlogsettings starttime="0" numsamples="2048"/>
             <parameters>
-              <parameter type="double" name="subsub_a" value="sub_a"/>
-              <parameter type="double" name="subsub_b" value="sub_b"/>
-              <parameter type="double" name="subsub_c" value="sub_a+sub_b"/>
-              <parameter type="double" name="subsub_d" value="self.subsub_a+self.subsub_b"/>
-              <parameter type="double" name="subsub_e" value="main_a+self.subsub_b"/>
-              <parameter type="integer" name="subsub_int_a" value="sub_int_a"/>
-              <parameter type="integer" name="subsub_int_b" value="sub_int_b"/>
-              <parameter type="bool" name="subsub_bool_a" value="sub_bool_a"/>
-              <parameter type="bool" name="subsub_bool_b" value="sub_bool_b"/>
-              <parameter type="string" name="subsub_string_a" value="sub_string_a"/>
-              <parameter type="string" name="subsub_string_b" value="sub_string_b"/>
-              <parameter type="textblock" name="subsub_textblock_a" value="sub_textblock_a"/>
-              <parameter type="textblock" name="subsub_textblock_b" value="sub_textblock_b"/>
-              <parameter type="textblock" name="subsub_lookup_textblock" value="1, 1&#xa;2, 2"/>
-              <parameter type="integer" name="subsub_lookup_inid" value="0"/>
-              <parameter type="string" name="subsub_lookup_comment" value="#"/>
-              <parameter type="bool" name="subsub_lookup_reload" value="true"/>
+              <parameter name="subsub_a" value="sub_a" type="double"/>
+              <parameter name="subsub_b" value="sub_b" type="double"/>
+              <parameter name="subsub_c" value="sub_a+sub_b" type="double"/>
+              <parameter name="subsub_d" value="self.subsub_a+self.subsub_b" type="double"/>
+              <parameter name="subsub_e" value="main_a+self.subsub_b" type="double"/>
+              <parameter name="subsub_int_a" value="sub_int_a" type="integer"/>
+              <parameter name="subsub_int_b" value="sub_int_b" type="integer"/>
+              <parameter name="subsub_bool_a" value="sub_bool_a" type="bool"/>
+              <parameter name="subsub_bool_b" value="sub_bool_b" type="bool"/>
+              <parameter name="subsub_string_a" value="sub_string_a" type="string"/>
+              <parameter name="subsub_string_b" value="sub_string_b" type="string"/>
+              <parameter name="subsub_textblock_a" value="sub_textblock_a" type="textblock"/>
+              <parameter name="subsub_textblock_b" value="sub_textblock_b" type="textblock"/>
+              <parameter name="subsub_lookup_textblock" value="1, 1&#xa;2, 2" type="textblock"/>
+              <parameter name="subsub_lookup_inid" value="0" type="integer"/>
+              <parameter name="subsub_lookup_comment" value="#" type="string"/>
+              <parameter name="subsub_lookup_reload" value="true" type="bool"/>
             </parameters>
             <aliases/>
             <hopsangui>
-              <pose x="2380" flipped="false" a="0" y="2298"/>
-              <nametext visible="0" position="0"/>
-              <animation disabled="false" hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-              <viewport x="2183" zoom="1" y="2245"/>
+              <pose x="2380" a="0" flipped="false" y="2298"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" disabled="false" hydraulicmaxpressure="20000000" flowspeed="100"/>
+              <viewport x="2207.5" zoom="1" y="2181.5"/>
               <ports hidden="1"/>
               <names hidden="1"/>
               <graphics type="user"/>
               <scriptfile path=""/>
               <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Subsubsystem" typename="Subsystem">
+                <modelobject typename="Subsystem" displayname="Subsubsystem">
                   <icons>
                     <icon type="defaultmissing" path="subsystemDefault.svg"/>
                   </icons>
                   <ports>
-                    <port x="0" enabled="true" name="SubsubPortIn" autoplaced="true" a="180" y="0.5"/>
-                    <port x="1" enabled="true" name="SubsubPortOut" autoplaced="true" a="0" y="0.5"/>
+                    <port autoplaced="true" name="SubsubPortOut" x="1" a="0" enabled="true" y="0.5"/>
+                    <port autoplaced="true" name="SubsubPortIn" x="0" a="180" enabled="true" y="0.5"/>
                   </ports>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
                 </modelobject>
               </hopsanobjectappearance>
               <optimization>
@@ -336,10 +409,37 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               </senstivitityanalysis>
             </hopsangui>
             <objects>
-              <component cqstype="S" name="Gain_2" disabled="false" typename="SignalGain" locked="false" subtypename="">
+              <component name="1DLookupTable_1" typename="Signal1DLookupTable" subtypename="" cqstype="S" disabled="false" locked="false">
                 <parameters>
-                  <parameter type="double" name="in#Value" value="0" unit=""/>
-                  <parameter type="double" name="k#Value" value="subsub_d" unit=""/>
+                  <parameter name="in#Value" value="0" unit="" type="double"/>
+                  <parameter name="filename" value="K" unit="" type="string"/>
+                  <parameter name="text" value="Skip this line&#xa;K1,2,3,4&#xa;1,2&#xa;2,3&#xa;4,5&#xa;6,7" unit="" type="textblock"/>
+                  <parameter name="csvsep" value="," unit="" type="string"/>
+                  <parameter name="inid" value="0" unit="" type="integer"/>
+                  <parameter name="outid" value="self.numlineskip" unit="" type="integer"/>
+                  <parameter name="numlineskip" value="1" unit="" type="integer"/>
+                  <parameter name="comment" value="self.filename" unit="" type="string"/>
+                  <parameter name="reload" value="true" unit="" type="bool"/>
+                </parameters>
+                <ports>
+                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="1725" a="0" flipped="false" y="2307"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject typename="Signal1DLookupTable" displayname="1DLookupTable_1">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Gain_2" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
+                <parameters>
+                  <parameter name="in#Value" value="0" unit="" type="double"/>
+                  <parameter name="k#Value" value="subsub_d" unit="" type="double"/>
                 </parameters>
                 <ports>
                   <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
@@ -347,87 +447,38 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2039.333333" flipped="false" a="0" y="2198"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <pose x="2057.333333" a="0" flipped="false" y="2141"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Gain_2" typename="SignalGain">
+                    <modelobject typename="SignalGain" displayname="Gain_2">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <systemport cqstype="hasNoCqsType" name="SubsubPortIn" disabled="false" typename="HopsanGUIContainerPort" locked="false" subtypename="">
-                <hopsangui>
-                  <pose x="2000" flipped="false" a="0" y="2347"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-                </hopsangui>
-              </systemport>
-              <component cqstype="S" name="Gain_3" disabled="false" typename="SignalGain" locked="false" subtypename="">
+              <component name="TestConstant" typename="SignalConstant" subtypename="" cqstype="S" disabled="false" locked="false">
                 <parameters>
-                  <parameter type="double" name="in#Value" value="0" unit=""/>
-                  <parameter type="double" name="k#Value" value="subsub_e" unit=""/>
-                </parameters>
-                <ports>
-                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="k" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-                </ports>
-                <hopsangui>
-                  <pose x="2097" flipped="false" a="0" y="2198"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Gain_3" typename="SignalGain">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <component cqstype="S" name="Gain_1" disabled="false" typename="SignalGain" locked="false" subtypename="">
-                <parameters>
-                  <parameter type="double" name="in#Value" value="0" unit=""/>
-                  <parameter type="double" name="k#Value" value="subsub_c" unit=""/>
-                </parameters>
-                <ports>
-                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-                  <port name="k" nodetype="NodeSignal"/>
-                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-                </ports>
-                <hopsangui>
-                  <pose x="1981.666667" flipped="false" a="0" y="2198"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-                  <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Gain_1" typename="SignalGain">
-                      <ports/>
-                    </modelobject>
-                  </hopsanobjectappearance>
-                </hopsangui>
-              </component>
-              <component cqstype="S" name="TestConstant" disabled="false" typename="SignalConstant" locked="false" subtypename="">
-                <parameters>
-                  <parameter type="double" name="y#Value" value="1" unit=""/>
+                  <parameter name="y#Value" value="1" unit="" type="double"/>
                 </parameters>
                 <ports>
                   <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose x="1924" flipped="false" a="0" y="2198"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <pose x="1942" a="0" flipped="false" y="2141"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="TestConstant" typename="SignalConstant">
+                    <modelobject typename="SignalConstant" displayname="TestConstant">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component cqstype="S" name="Gain" disabled="false" typename="SignalGain" locked="false" subtypename="">
+              <component name="Gain" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
                 <parameters>
-                  <parameter type="double" name="in#Value" value="0" unit=""/>
-                  <parameter type="double" name="k#Value" value="subsub_c" unit=""/>
+                  <parameter name="in#Value" value="0" unit="" type="double"/>
+                  <parameter name="k#Value" value="subsub_c" unit="" type="double"/>
                 </parameters>
                 <ports>
                   <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
@@ -435,20 +486,48 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2136" flipped="false" a="0" y="2395"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <pose x="2136" a="0" flipped="false" y="2395"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Gain" typename="SignalGain">
+                    <modelobject typename="SignalGain" displayname="Gain">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component cqstype="S" name="Add" disabled="false" typename="SignalAdd" locked="false" subtypename="">
+              <systemport name="SubsubPortOut" typename="HopsanGUIContainerPort" subtypename="" cqstype="hasNoCqsType" disabled="false" locked="false">
+                <hopsangui>
+                  <pose x="2329" a="0" flipped="false" y="2395"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                </hopsangui>
+              </systemport>
+              <component name="Gain_3" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
                 <parameters>
-                  <parameter type="double" name="in1#Value" value="subsub_a" unit=""/>
-                  <parameter type="double" name="in2#Value" value="self.in1.Value+1" unit=""/>
+                  <parameter name="in#Value" value="0" unit="" type="double"/>
+                  <parameter name="k#Value" value="subsub_e" unit="" type="double"/>
+                </parameters>
+                <ports>
+                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="k" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2115" a="0" flipped="false" y="2141"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject typename="SignalGain" displayname="Gain_3">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Add" typename="SignalAdd" subtypename="" cqstype="S" disabled="false" locked="false">
+                <parameters>
+                  <parameter name="in1#Value" value="subsub_a" unit="" type="double"/>
+                  <parameter name="in2#Value" value="self.in1.Value+1" unit="" type="double"/>
                 </parameters>
                 <ports>
                   <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
@@ -456,47 +535,107 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2088" flipped="false" a="0" y="2395"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <pose x="2088" a="0" flipped="false" y="2395"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Add" typename="SignalAdd">
+                    <modelobject typename="SignalAdd" displayname="Add">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component cqstype="S" name="1DLookupTable" disabled="false" typename="Signal1DLookupTable" locked="false" subtypename="">
+              <component name="Time" typename="SignalTime" subtypename="" cqstype="S" disabled="false" locked="false">
+                <parameters/>
+                <ports>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="1645" a="0" flipped="false" y="2307"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject typename="SignalTime" displayname="Time">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="1DLookupTable" typename="Signal1DLookupTable" subtypename="" cqstype="S" disabled="false" locked="false">
                 <parameters>
-                  <parameter type="double" name="in#Value" value="0" unit=""/>
-                  <parameter type="string" name="filename" value="FilePath" unit=""/>
-                  <parameter type="textblock" name="text" value="subsub_lookup_textblock" unit=""/>
-                  <parameter type="string" name="csvsep" value="," unit=""/>
-                  <parameter type="integer" name="inid" value="subsub_lookup_inid" unit=""/>
-                  <parameter type="integer" name="outid" value="1" unit=""/>
-                  <parameter type="integer" name="numlineskip" value="0" unit=""/>
-                  <parameter type="string" name="comment" value="subsub_lookup_comment" unit=""/>
-                  <parameter type="bool" name="reload" value="subsub_lookup_reload" unit=""/>
+                  <parameter name="in#Value" value="0" unit="" type="double"/>
+                  <parameter name="filename" value="FilePath" unit="" type="string"/>
+                  <parameter name="text" value="subsub_lookup_textblock" unit="" type="textblock"/>
+                  <parameter name="csvsep" value="," unit="" type="string"/>
+                  <parameter name="inid" value="subsub_lookup_inid" unit="" type="integer"/>
+                  <parameter name="outid" value="1" unit="" type="integer"/>
+                  <parameter name="numlineskip" value="0" unit="" type="integer"/>
+                  <parameter name="comment" value="subsub_lookup_comment" unit="" type="string"/>
+                  <parameter name="reload" value="subsub_lookup_reload" unit="" type="bool"/>
                 </parameters>
                 <ports>
                   <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
                   <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2288" flipped="false" a="0" y="2245"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <pose x="2356" a="0" flipped="false" y="2249"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="1DLookupTable" typename="Signal1DLookupTable">
+                    <modelobject typename="Signal1DLookupTable" displayname="1DLookupTable">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <component cqstype="S" name="Add_1" disabled="false" typename="SignalAdd" locked="false" subtypename="">
+              <systemport name="SubsubPortIn" typename="HopsanGUIContainerPort" subtypename="" cqstype="hasNoCqsType" disabled="false" locked="false">
+                <hopsangui>
+                  <pose x="1465" a="0" flipped="false" y="2349"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                </hopsangui>
+              </systemport>
+              <component name="Time_1" typename="SignalTime" subtypename="" cqstype="S" disabled="false" locked="false">
+                <parameters/>
+                <ports>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="2271" a="0" flipped="false" y="2249"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject typename="SignalTime" displayname="Time_1">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Gain_1" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
                 <parameters>
-                  <parameter type="double" name="in1#Value" value="subsub_a" unit=""/>
-                  <parameter type="double" name="in2#Value" value="1" unit=""/>
+                  <parameter name="in#Value" value="0" unit="" type="double"/>
+                  <parameter name="k#Value" value="subsub_c" unit="" type="double"/>
+                </parameters>
+                <ports>
+                  <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
+                  <port name="k" nodetype="NodeSignal"/>
+                  <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+                </ports>
+                <hopsangui>
+                  <pose x="1999.666667" a="0" flipped="false" y="2141"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
+                  <hopsanobjectappearance version="0.3">
+                    <modelobject typename="SignalGain" displayname="Gain_1">
+                      <ports/>
+                    </modelobject>
+                  </hopsanobjectappearance>
+                </hopsangui>
+              </component>
+              <component name="Add_1" typename="SignalAdd" subtypename="" cqstype="S" disabled="false" locked="false">
+                <parameters>
+                  <parameter name="in1#Value" value="subsub_a" unit="" type="double"/>
+                  <parameter name="in2#Value" value="1" unit="" type="double"/>
                 </parameters>
                 <ports>
                   <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
@@ -504,26 +643,51 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
                 </ports>
                 <hopsangui>
-                  <pose x="2182" flipped="false" a="0" y="2395"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <pose x="2182" a="0" flipped="false" y="2395"/>
+                  <nametext position="0" visible="0"/>
+                  <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
                   <hopsanobjectappearance version="0.3">
-                    <modelobject displayname="Add_1" typename="SignalAdd">
+                    <modelobject typename="SignalAdd" displayname="Add_1">
                       <ports/>
                     </modelobject>
                   </hopsanobjectappearance>
                 </hopsangui>
               </component>
-              <systemport cqstype="hasNoCqsType" name="SubsubPortOut" disabled="false" typename="HopsanGUIContainerPort" locked="false" subtypename="">
+              <textboxwidget>
                 <hopsangui>
-                  <pose x="2329" flipped="false" a="0" y="2395"/>
-                  <nametext visible="0" position="0"/>
-                  <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+                  <pose x="2239.000000" y="2183.000000"/>
+                  <textobject fontcolor="#556b2f" text="Test lookup of system parametrs for int bool string and textblock" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
+                  <size height="100.000000" width="493.000000"/>
+                  <line style="solidline" color="#556b2f" visible="1" width="2"/>
                 </hopsangui>
-              </systemport>
+              </textboxwidget>
+              <textboxwidget>
+                <hopsangui>
+                  <pose x="1250.500000" y="0.000000"/>
+                  <textobject fontcolor="#556b2f" text="Test lookup of system parametrs for int bool string and textblock" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
+                  <size height="100.000000" width="495.000000"/>
+                  <line style="solidline" color="#556b2f" visible="1" width="2"/>
+                </hopsangui>
+              </textboxwidget>
+              <textboxwidget>
+                <hopsangui>
+                  <pose x="1273.500000" y="0.000000"/>
+                  <textobject fontcolor="#556b2f" text="Test lookup of system parametrs for int bool string and textblock" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
+                  <size height="100.000000" width="495.000000"/>
+                  <line style="solidline" color="#556b2f" visible="1" width="2"/>
+                </hopsangui>
+              </textboxwidget>
+              <textboxwidget>
+                <hopsangui>
+                  <pose x="1616.000000" y="2240.000000"/>
+                  <textobject fontcolor="#556b2f" text="Test using self. for int and string parameters" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
+                  <size height="100.000000" width="336.000000"/>
+                  <line style="solidline" color="#556b2f" visible="1" width="2"/>
+                </hopsangui>
+              </textboxwidget>
             </objects>
             <connections>
-              <connect endcomponent="Gain" startport="out" endport="in" startcomponent="Add">
+              <connect endcomponent="Gain" startcomponent="Add" endport="in" startport="out">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2100.50000000000000000000" y="2395.00000000000000000000"/>
@@ -539,7 +703,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Add_1" startport="out" endport="in1" startcomponent="Gain">
+              <connect endcomponent="Add_1" startcomponent="Gain" endport="in1" startport="out">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2148.50000000000000000000" y="2395.00000000000000000000"/>
@@ -555,11 +719,11 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Add_1" startport="SubsubPortIn" endport="in2" startcomponent="SubsubPortIn">
+              <connect endcomponent="Add_1" startcomponent="SubsubPortIn" endport="in2" startport="SubsubPortIn">
                 <hopsangui>
                   <coordinates>
-                    <coordinate x="2000.00000000000000000000" y="2347.00000000000000000000"/>
-                    <coordinate x="2182.00000000000000000000" y="2347.00000000000000000000"/>
+                    <coordinate x="1465.00000000000000000000" y="2349.00000000000000000000"/>
+                    <coordinate x="2182.00000000000000000000" y="2349.00000000000000000000"/>
                     <coordinate x="2182.00000000000000000000" y="2382.50000000000000000000"/>
                   </coordinates>
                   <geometries>
@@ -569,7 +733,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="SubsubPortOut" startport="out" endport="SubsubPortOut" startcomponent="Add_1">
+              <connect endcomponent="SubsubPortOut" startcomponent="Add_1" endport="SubsubPortOut" startport="out">
                 <hopsangui>
                   <coordinates>
                     <coordinate x="2194.50000000000000000000" y="2395.00000000000000000000"/>
@@ -585,13 +749,13 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Gain_1" startport="y" endport="in" startcomponent="TestConstant">
+              <connect endcomponent="Gain_1" startcomponent="TestConstant" endport="in" startport="y">
                 <hopsangui>
                   <coordinates>
-                    <coordinate x="1936.50000000000000000000" y="2198.00000000000000000000"/>
-                    <coordinate x="1948.50000000000000000000" y="2198.00000000000000000000"/>
-                    <coordinate x="1948.50000000000000000000" y="2198.00000000000000000000"/>
-                    <coordinate x="1969.16666699999996126280" y="2198.00000000000000000000"/>
+                    <coordinate x="1954.50000000000000000000" y="2141.00000000000000000000"/>
+                    <coordinate x="1966.50000000000000000000" y="2141.00000000000000000000"/>
+                    <coordinate x="1966.50000000000000000000" y="2141.00000000000000000000"/>
+                    <coordinate x="1987.16666699999996126280" y="2141.00000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -601,13 +765,13 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Gain_2" startport="out" endport="in" startcomponent="Gain_1">
+              <connect endcomponent="Gain_2" startcomponent="Gain_1" endport="in" startport="out">
                 <hopsangui>
                   <coordinates>
-                    <coordinate x="1994.16666699999996126280" y="2198.00000000000000000000"/>
-                    <coordinate x="2028.16666666666651508422" y="2198.00000000000000000000"/>
-                    <coordinate x="2028.16666666666651508422" y="2198.00000000000000000000"/>
-                    <coordinate x="2026.83333300000003873720" y="2198.00000000000000000000"/>
+                    <coordinate x="2012.16666699999996126280" y="2141.00000000000000000000"/>
+                    <coordinate x="2046.16666666666651508422" y="2141.00000000000000000000"/>
+                    <coordinate x="2046.16666666666651508422" y="2141.00000000000000000000"/>
+                    <coordinate x="2044.83333300000003873720" y="2141.00000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -617,13 +781,45 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
                   <style>solid</style>
                 </hopsangui>
               </connect>
-              <connect endcomponent="Gain_3" startport="out" endport="in" startcomponent="Gain_2">
+              <connect endcomponent="Gain_3" startcomponent="Gain_2" endport="in" startport="out">
                 <hopsangui>
                   <coordinates>
-                    <coordinate x="2051.83333300000003873720" y="2198.00000000000000000000"/>
-                    <coordinate x="2051.28824835833302131505" y="2198.00000000000000000000"/>
-                    <coordinate x="2051.28824835833302131505" y="2198.00000000000000000000"/>
-                    <coordinate x="2084.50000000000000000000" y="2198.00000000000000000000"/>
+                    <coordinate x="2069.83333300000003873720" y="2141.00000000000000000000"/>
+                    <coordinate x="2069.28824835833347606240" y="2141.00000000000000000000"/>
+                    <coordinate x="2069.28824835833347606240" y="2141.00000000000000000000"/>
+                    <coordinate x="2102.50000000000000000000" y="2141.00000000000000000000"/>
+                  </coordinates>
+                  <geometries>
+                    <geometry>vertical</geometry>
+                    <geometry>horizontal</geometry>
+                    <geometry>vertical</geometry>
+                  </geometries>
+                  <style>solid</style>
+                </hopsangui>
+              </connect>
+              <connect endcomponent="1DLookupTable_1" startcomponent="Time" endport="in" startport="out">
+                <hopsangui>
+                  <coordinates>
+                    <coordinate x="1657.50000000000000000000" y="2307.00000000000000000000"/>
+                    <coordinate x="1685.00000000000000000000" y="2307.00000000000000000000"/>
+                    <coordinate x="1685.00000000000000000000" y="2307.00000000000000000000"/>
+                    <coordinate x="1705.00000000000000000000" y="2307.00000000000000000000"/>
+                  </coordinates>
+                  <geometries>
+                    <geometry>vertical</geometry>
+                    <geometry>horizontal</geometry>
+                    <geometry>vertical</geometry>
+                  </geometries>
+                  <style>solid</style>
+                </hopsangui>
+              </connect>
+              <connect endcomponent="1DLookupTable" startcomponent="Time_1" endport="in" startport="out">
+                <hopsangui>
+                  <coordinates>
+                    <coordinate x="2283.50000000000000000000" y="2249.00000000000000000000"/>
+                    <coordinate x="2316.00000000000000000000" y="2249.00000000000000000000"/>
+                    <coordinate x="2316.00000000000000000000" y="2249.00000000000000000000"/>
+                    <coordinate x="2336.00000000000000000000" y="2249.00000000000000000000"/>
                   </coordinates>
                   <geometries>
                     <geometry>vertical</geometry>
@@ -635,38 +831,10 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               </connect>
             </connections>
           </system>
-          <component cqstype="S" name="Add" disabled="false" typename="SignalAdd" locked="false" subtypename="">
+          <component name="Gain_1" typename="SignalGain" subtypename="" cqstype="S" disabled="false" locked="false">
             <parameters>
-              <parameter type="double" name="in1#Value" value="0" unit=""/>
-              <parameter type="double" name="in2#Value" value="self.in1.Value" unit=""/>
-            </parameters>
-            <ports>
-              <port name="in1" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="in2" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2274" flipped="false" a="0" y="2029"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Add" typename="SignalAdd">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <systemport cqstype="hasNoCqsType" name="SubPortIn" disabled="false" typename="HopsanGUIContainerPort" locked="false" subtypename="">
-            <hopsangui>
-              <pose x="1925" flipped="false" a="0" y="2298"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-            </hopsangui>
-          </systemport>
-          <component cqstype="S" name="ShadowParamGain" disabled="false" typename="SignalGain" locked="false" subtypename="">
-            <parameters>
-              <parameter type="double" name="in#Value" value="0" unit=""/>
-              <parameter type="double" name="k#Value" value="shadow_param" unit=""/>
+              <parameter name="in#Value" value="0" unit="" type="double"/>
+              <parameter name="k#Value" value="sub_b+main_a" unit="" type="double"/>
             </parameters>
             <ports>
               <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
@@ -674,51 +842,29 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
             </ports>
             <hopsangui>
-              <pose x="2583" flipped="false" a="0" y="2170"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <pose x="2427" a="0" flipped="false" y="2203.5"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
               <hopsanobjectappearance version="0.3">
-                <modelobject displayname="ShadowParamGain" typename="SignalGain">
+                <modelobject typename="SignalGain" displayname="Gain_1">
                   <ports/>
                 </modelobject>
               </hopsanobjectappearance>
             </hopsangui>
           </component>
-          <component cqstype="S" name="Greater_Than_Comparer" disabled="false" typename="SignalGreaterThan" locked="false" subtypename="">
+          <component name="NumhopSetValue" typename="SignalConstant" subtypename="" cqstype="S" disabled="false" locked="false">
             <parameters>
-              <parameter type="double" name="in#Value" value="0" unit=""/>
-              <parameter type="double" name="x_limit#Value" value="0.5" unit=""/>
+              <parameter name="y#Value" value="0" unit="" type="double"/>
             </parameters>
             <ports>
-              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-              <port name="x_limit" nodetype="NodeSignal"/>
-              <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
+              <port name="y" porttype="WritePortType" nodetype="NodeSignal"/>
             </ports>
             <hopsangui>
-              <pose x="2342" flipped="false" a="0" y="2029"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
+              <pose x="2106" a="0" flipped="false" y="2157"/>
+              <nametext position="0" visible="0"/>
+              <animation hydraulicminpressure="0" hydraulicmaxpressure="20000000" flowspeed="100"/>
               <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Greater_Than_Comparer" typename="SignalGreaterThan">
-                  <ports/>
-                </modelobject>
-              </hopsanobjectappearance>
-            </hopsangui>
-          </component>
-          <component cqstype="S" name="Stop_simulation" disabled="false" typename="SignalStopSimulation" locked="false" subtypename="">
-            <parameters>
-              <parameter type="double" name="in#Value" value="0" unit=""/>
-              <parameter type="string" name="message" value="" unit=""/>
-            </parameters>
-            <ports>
-              <port name="in" porttype="ReadPortType" nodetype="NodeSignal"/>
-            </ports>
-            <hopsangui>
-              <pose x="2438" flipped="false" a="0" y="2029"/>
-              <nametext visible="0" position="0"/>
-              <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-              <hopsanobjectappearance version="0.3">
-                <modelobject displayname="Stop_simulation" typename="SignalStopSimulation">
+                <modelobject typename="SignalConstant" displayname="NumhopSetValue">
                   <ports/>
                 </modelobject>
               </hopsanobjectappearance>
@@ -727,14 +873,14 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
           <textboxwidget>
             <hopsangui>
               <pose x="2103.000000" y="1934.000000"/>
-              <textobject text="Test when local variable and system variable with same name exists&#xa;In this case in1.value and in1#value" reflow="1" fontcolor="#556b2f" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular"/>
-              <size height="130.000000" width="565.000000"/>
-              <line visible="1" color="#556b2f" width="2" style="solidline"/>
+              <textobject fontcolor="#556b2f" text="Test when local variable and system variable with same name exists&#xa;In this case in1.value and in1#value" font="Noto Sans,12,-1,0,50,0,0,0,0,0,Regular" reflow="1"/>
+              <size height="130.000000" width="571.000000"/>
+              <line style="solidline" color="#556b2f" visible="1" width="2"/>
             </hopsangui>
           </textboxwidget>
         </objects>
         <connections>
-          <connect endcomponent="Subsubsystem" startport="SubPortIn" endport="SubsubPortIn" startcomponent="SubPortIn">
+          <connect endcomponent="Subsubsystem" startcomponent="SubPortIn" endport="SubsubPortIn" startport="SubPortIn">
             <hopsangui>
               <coordinates>
                 <coordinate x="1925.00000000000000000000" y="2298.00000000000000000000"/>
@@ -750,7 +896,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="SubPortOut" startport="SubsubPortOut" endport="SubPortOut" startcomponent="Subsubsystem">
+          <connect endcomponent="SubPortOut" startcomponent="Subsubsystem" endport="SubPortOut" startport="SubsubPortOut">
             <hopsangui>
               <coordinates>
                 <coordinate x="2425.00000000000000000000" y="2298.00000000000000000000"/>
@@ -766,7 +912,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="TestConstant" startport="in" endport="y" startcomponent="Gain">
+          <connect endcomponent="TestConstant" startcomponent="Gain" endport="y" startport="in">
             <hopsangui>
               <coordinates>
                 <coordinate x="2414.50000000000000000000" y="2154.00000000000000000000"/>
@@ -782,7 +928,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="TestConstant" startport="in" endport="y" startcomponent="Gain_1">
+          <connect endcomponent="TestConstant" startcomponent="Gain_1" endport="y" startport="in">
             <hopsangui>
               <coordinates>
                 <coordinate x="2414.50000000000000000000" y="2203.50000000000000000000"/>
@@ -798,7 +944,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="Add" startport="in" endport="out" startcomponent="Greater_Than_Comparer">
+          <connect endcomponent="Add" startcomponent="Greater_Than_Comparer" endport="out" startport="in">
             <hopsangui>
               <coordinates>
                 <coordinate x="2329.50000000000000000000" y="2029.00000000000000000000"/>
@@ -814,7 +960,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
               <style>solid</style>
             </hopsangui>
           </connect>
-          <connect endcomponent="Stop_simulation" startport="out" endport="in" startcomponent="Greater_Than_Comparer">
+          <connect endcomponent="Stop_simulation" startcomponent="Greater_Than_Comparer" endport="in" startport="out">
             <hopsangui>
               <coordinates>
                 <coordinate x="2354.50000000000000000000" y="2029.00000000000000000000"/>
@@ -832,32 +978,9 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
           </connect>
         </connections>
       </system>
-      <component cqstype="S" name="TestStep" disabled="false" typename="SignalStep" locked="false" subtypename="">
-        <parameters>
-          <parameter type="double" name="y_0#Value" value="-5" unit=""/>
-          <parameter type="double" name="y_A#Value" value="5" unit=""/>
-          <parameter type="double" name="t_step#Value" value="apa" unit="s"/>
-        </parameters>
-        <ports>
-          <port name="out" porttype="WritePortType" nodetype="NodeSignal"/>
-          <port name="y_0" nodetype="NodeSignal"/>
-          <port name="y_A" nodetype="NodeSignal"/>
-          <port name="t_step" nodetype="NodeSignal"/>
-        </ports>
-        <hopsangui>
-          <pose x="2320" flipped="false" a="0" y="2494"/>
-          <nametext visible="0" position="0"/>
-          <animation hydraulicmaxpressure="20000000" flowspeed="100" hydraulicminpressure="0"/>
-          <hopsanobjectappearance version="0.3">
-            <modelobject displayname="TestStep" typename="SignalStep">
-              <ports/>
-            </modelobject>
-          </hopsanobjectappearance>
-        </hopsangui>
-      </component>
     </objects>
     <connections>
-      <connect endcomponent="TestGain" startport="out" endport="in" startcomponent="TestStep">
+      <connect endcomponent="TestGain" startcomponent="TestStep" endport="in" startport="out">
         <hopsangui>
           <coordinates>
             <coordinate x="2332.50000000000000000000" y="2494.00000000000000000000"/>
@@ -869,7 +992,7 @@ NumhopSetValue.y = (sub_a + sub_b ) * ShadowParamGain.k</numhopscript>
           <style>solid</style>
         </hopsangui>
       </connect>
-      <connect endcomponent="Subsystem" startport="y" endport="SubPortIn" startcomponent="TestConstant">
+      <connect endcomponent="Subsystem" startcomponent="TestConstant" endport="SubPortIn" startport="y">
         <hopsangui>
           <coordinates>
             <coordinate x="2172.50000000000000000000" y="2310.00000000000000000000"/>


### PR DESCRIPTION
Replaces PR #1752 
Resolves #1694

- Adds requirement on self.ParamName to reference parameters in the same component. This affect both component and system parameter expressions. Embedded init scripts (numhop) in systems also get this requirement.

- Adds automatic update of models saved prior to 2.14.0.
HopsanCore will fully update old models for batch or remote simulation.
HopsanGUI will auto update everything except embedded init scripts (numhop) in systems, but a pop-up and warning message in th terminal will show what parameters need to be renamed.
Embedded init-scripts are not updated automatically as this would remove the formatting upon saving the model.

- Automatic updates will only affect parameter values of type "double" as the other types could no refer to other own parameters before.

- Adds new functionality to refer to other own parameters using self. for int, bool, string and textblock parameters (including system parameters)

- Make parameter evaluation behavior consistent for all types, (except conditional). They support self. referencing and will recursively try to evaluate system parameter names (those without self.) upwards in the model hierarchy.
