### PR TITLE
Create bode plots in rad/s, to match unit in plot window

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -5167,7 +5167,7 @@ void HcomHandler::executeBodeCommand(const QString cmd)
     int fMax = 500;
     if(args.size() > 2)
     {
-        fMax = args[2].toInt(); //!< @todo parse check needed
+        fMax = args[2].toInt()/(2*M_PI); //!< @todo parse check needed
     }
 
     PlotWindow *pWindow = gpPlotHandler->createNewPlotWindowOrGetCurrentOne("Bode plot");

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -1152,6 +1152,14 @@ void HcomHandler::createCommands()
     bodeCmd.group = "Plot Commands";
     mCmdList << bodeCmd;
 
+    HcomCommand nyquistCmd;
+    nyquistCmd.cmd = "nyquist";
+    nyquistCmd.description.append("Creates a Nyquist plot from specified curves");
+    nyquistCmd.help.append(" Usage: nyquist [invar] [outvar]");
+    nyquistCmd.fnc = &HcomHandler::executeNyquistCommand;
+    nyquistCmd.group = "Plot Commands";
+    mCmdList << nyquistCmd;
+
     HcomCommand optCmd;
     optCmd.cmd = "opt";
     optCmd.description.append("Initialize an optimization");
@@ -5174,6 +5182,33 @@ void HcomHandler::executeBodeCommand(const QString cmd)
     pWindow->closeAllTabs();
     pWindow->createBodePlot(pData1, pData2, fMax);
 }
+
+
+//! @brief Execute function for "nyquist" command
+void HcomHandler::executeNyquistCommand(const QString cmd)
+{
+    QStringList args = splitCommandArguments(cmd);
+    if(args.size() != 2)
+    {
+        HCOMERR("Wrong number of arguments.");
+        return;
+    }
+
+    QString var1 = args[0];
+    QString var2 = args[1];
+    SharedVectorVariableT pData1 = getLogVariable(var1);
+    SharedVectorVariableT pData2 = getLogVariable(var2);
+    if(!pData1 || !pData2)
+    {
+        HCOMERR("Data variable not found.");
+        return;
+    }
+
+    PlotWindow *pWindow = gpPlotHandler->createNewPlotWindowOrGetCurrentOne("Nyquist plot");
+    pWindow->closeAllTabs();
+    pWindow->createBodePlot(pData1, pData2, 0, false, true);
+}
+
 
 
 //! @brief Execute function for "opt" command

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -5172,7 +5172,7 @@ void HcomHandler::executeBodeCommand(const QString cmd)
         HCOMERR("Data variable not found.");
         return;
     }
-    int fMax = 500;
+    int fMax = 500*2*M_PI;
     if(args.size() > 2)
     {
         fMax = args[2].toInt()/(2*M_PI); //!< @todo parse check needed

--- a/HopsanGUI/HcomHandler.h
+++ b/HopsanGUI/HcomHandler.h
@@ -209,6 +209,7 @@ private:
     void executeChangeTimestepCommand(const QString cmd);
     void executeInheritTimestepCommand(const QString cmd);
     void executeBodeCommand(const QString cmd);
+    void executeNyquistCommand(const QString cmd);
     void executeOptimizationCommand(const QString cmd);
     void executeCallFunctionCommand(const QString cmd);
     void executeEchoCommand(const QString cmd);

--- a/HopsanGUI/LogVariable.cpp
+++ b/HopsanGUI/LogVariable.cpp
@@ -2134,6 +2134,7 @@ void createBodeVariables(const SharedVectorVariableT pInput, const SharedVectorV
 
     // Create the output variables for bode diagram
     SharedVectorVariableT pFrequencyVar = createFreeFrequencyVectorVariabel(freq);
+    pFrequencyVar->multData(M_PI*2);
 
     SharedVariableDescriptionT pGainDesc(new VariableDescription());
     pGainDesc->mDataName = "Magnitude";

--- a/HopsanGUI/PlotTab.cpp
+++ b/HopsanGUI/PlotTab.cpp
@@ -1467,6 +1467,15 @@ void PlotTab::openCreateBodePlotDialog()
         pSliderLayout->addWidget(pMaxFrequencyValue);
         pSliderLayout->addWidget(pMaxFrequencyUnit);
 
+        QCheckBox *pBodeCheckBox = new QCheckBox("Create Bode Plot", pBodeDialog);
+        QCheckBox *pNyquistCheckBox = new QCheckBox("Create Nyquist Plot", pBodeDialog);
+        pBodeCheckBox->setChecked(true);
+        pNyquistCheckBox->setChecked(false);
+        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencySlider, SLOT(setEnabled(bool)));
+        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencyLabel, SLOT(setEnabled(bool)));
+        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencyValue, SLOT(setEnabled(bool)));
+        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencyUnit, SLOT(setEnabled(bool)));
+
         QPushButton *pCancelButton = new QPushButton("Cancel");
         QPushButton *pNextButton = new QPushButton("Go!");
 
@@ -1477,13 +1486,16 @@ void PlotTab::openCreateBodePlotDialog()
         pToolBar->addAction(pHelpAction);
 
         QGridLayout *pBodeDialogLayout = new QGridLayout;
-        pBodeDialogLayout->addWidget(pInputGroupBox, 0, 0, 1, 3);
-        pBodeDialogLayout->addWidget(pOutputGroupBox, 1, 0, 1, 3);
-        pBodeDialogLayout->addWidget(pMaxFrequencyLabel, 2, 0, 1, 3);
-        pBodeDialogLayout->addLayout(pSliderLayout, 3, 0, 1, 3);
-        pBodeDialogLayout->addWidget(pToolBar, 4, 0, 1, 1);
-        pBodeDialogLayout->addWidget(pCancelButton, 4, 1, 1, 1);
-        pBodeDialogLayout->addWidget(pNextButton, 4, 2, 1, 1);
+        int row=0;
+        pBodeDialogLayout->addWidget(pInputGroupBox,        row++, 0, 1, 3);
+        pBodeDialogLayout->addWidget(pOutputGroupBox,       row++, 0, 1, 3);
+        pBodeDialogLayout->addWidget(pMaxFrequencyLabel,    row++, 0, 1, 3);
+        pBodeDialogLayout->addLayout(pSliderLayout,         row++, 0, 1, 3);
+        pBodeDialogLayout->addWidget(pBodeCheckBox,         row++, 0, 1, 3);
+        pBodeDialogLayout->addWidget(pNyquistCheckBox,      row++, 0, 1, 3);
+        pBodeDialogLayout->addWidget(pToolBar,              row,   0, 1, 1);
+        pBodeDialogLayout->addWidget(pCancelButton,         row,   1, 1, 1);
+        pBodeDialogLayout->addWidget(pNextButton,           row,   2, 1, 1);
 
         pBodeDialog->setLayout(pBodeDialogLayout);
         pBodeDialog->setPalette(gpConfig->getPalette());
@@ -1524,7 +1536,7 @@ void PlotTab::openCreateBodePlotDialog()
             }
             else
             {
-                mpParentPlotWindow->createBodePlot(pInputCurve->getSharedVectorVariable(), pOutputCurve->getSharedVectorVariable(), pMaxFrequencySlider->value()/(2*M_PI));
+                mpParentPlotWindow->createBodePlot(pInputCurve->getSharedVectorVariable(), pOutputCurve->getSharedVectorVariable(), pMaxFrequencySlider->value()/(2*M_PI), pBodeCheckBox->isChecked(), pNyquistCheckBox->isChecked());
             }
         }
     }

--- a/HopsanGUI/PlotTab.cpp
+++ b/HopsanGUI/PlotTab.cpp
@@ -1449,10 +1449,10 @@ void PlotTab::openCreateBodePlotDialog()
     {
         const double dataSize = pTimeVector->getDataSize()+1;
         const double stopTime = pTimeVector->last();
-        const double maxFreq = dataSize/stopTime/2;
+        const double maxFreq = dataSize/stopTime/2*M_PI*2;
         QLabel *pMaxFrequencyLabel = new QLabel("Maximum frequency in bode plot:");
         QLabel *pMaxFrequencyValue = new QLabel();
-        QLabel *pMaxFrequencyUnit = new QLabel("Hz");
+        QLabel *pMaxFrequencyUnit = new QLabel("rad/s");
         QSlider *pMaxFrequencySlider;
         pMaxFrequencyValue->setNum(maxFreq);
         pMaxFrequencySlider = new QSlider(this);
@@ -1524,7 +1524,7 @@ void PlotTab::openCreateBodePlotDialog()
             }
             else
             {
-                mpParentPlotWindow->createBodePlot(pInputCurve->getSharedVectorVariable(), pOutputCurve->getSharedVectorVariable(), pMaxFrequencySlider->value());
+                mpParentPlotWindow->createBodePlot(pInputCurve->getSharedVectorVariable(), pOutputCurve->getSharedVectorVariable(), pMaxFrequencySlider->value()/(2*M_PI));
             }
         }
     }

--- a/HopsanGUI/PlotTab.cpp
+++ b/HopsanGUI/PlotTab.cpp
@@ -1215,6 +1215,24 @@ void PlotTab::exportImageSelectFile()
     }
 }
 
+//! @brief Updates maximum frequency in Bode dialog for Hz
+//! @param [in] value Maximum frequency in rad/s
+void PlotTab::updateMaximumBodeFreqHz(int value)
+{
+    mpMaxFrequencyHzSpinBox->blockSignals(true);
+    mpMaxFrequencyHzSpinBox->setValue(value/(2*M_PI));
+    mpMaxFrequencyHzSpinBox->blockSignals(false);
+}
+
+//! @brief Updates maximum frequency in Bode dialog for rad/s
+//! @param [in] value Maximum frequency in Hz
+void PlotTab::updateMaximumBodeFreqRadSec(int value)
+{
+    mpMaxFrequencyRadSecSpinBox->blockSignals(true);
+    mpMaxFrequencyRadSecSpinBox->setValue(value*2*M_PI);
+    mpMaxFrequencyRadSecSpinBox->blockSignals(false);
+}
+
 PlotArea *PlotTab::addPlotArea()
 {
     PlotArea *pArea = new PlotArea(this);
@@ -1449,32 +1467,38 @@ void PlotTab::openCreateBodePlotDialog()
     {
         const double dataSize = pTimeVector->getDataSize()+1;
         const double stopTime = pTimeVector->last();
-        const double maxFreq = dataSize/stopTime/2*M_PI*2;
+        const double maxFreq = dataSize/stopTime/2;
         QLabel *pMaxFrequencyLabel = new QLabel("Maximum frequency in bode plot:");
-        QLabel *pMaxFrequencyValue = new QLabel();
-        QLabel *pMaxFrequencyUnit = new QLabel("rad/s");
-        QSlider *pMaxFrequencySlider;
-        pMaxFrequencyValue->setNum(maxFreq);
-        pMaxFrequencySlider = new QSlider(this);
-        pMaxFrequencySlider->setOrientation(Qt::Horizontal);
-        pMaxFrequencySlider->setMinimum(0);
-        pMaxFrequencySlider->setMaximum(maxFreq);
-        pMaxFrequencySlider->setValue(maxFreq);
-        connect(pMaxFrequencySlider, SIGNAL(valueChanged(int)), pMaxFrequencyValue, SLOT(setNum(int)));
+        QLabel *pMaxFrequencyHzUnit = new QLabel("Hz");
+        QLabel *pMaxFrequencyRadSecUnit = new QLabel("rad/s");
+        mpMaxFrequencyHzSpinBox = new QSpinBox(this);
+        mpMaxFrequencyHzSpinBox->setMinimum(0);
+        mpMaxFrequencyHzSpinBox->setMaximum(maxFreq);
+        mpMaxFrequencyHzSpinBox->setValue(maxFreq);
+        mpMaxFrequencyHzSpinBox->setSingleStep(1);
+        mpMaxFrequencyRadSecSpinBox = new QSpinBox(this);
+        mpMaxFrequencyRadSecSpinBox->setMinimum(0);
+        mpMaxFrequencyRadSecSpinBox->setMaximum(maxFreq*2*M_PI);
+        mpMaxFrequencyRadSecSpinBox->setValue(maxFreq*2*M_PI);
+        mpMaxFrequencyRadSecSpinBox->setSingleStep(1);
+        connect(mpMaxFrequencyHzSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateMaximumBodeFreqRadSec(int)));
+        connect(mpMaxFrequencyRadSecSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateMaximumBodeFreqHz(int)));
 
         QHBoxLayout *pSliderLayout = new QHBoxLayout();
-        pSliderLayout->addWidget(pMaxFrequencySlider);
-        pSliderLayout->addWidget(pMaxFrequencyValue);
-        pSliderLayout->addWidget(pMaxFrequencyUnit);
+        pSliderLayout->addWidget(mpMaxFrequencyHzSpinBox);
+        pSliderLayout->addWidget(pMaxFrequencyHzUnit);
+        pSliderLayout->addWidget(mpMaxFrequencyRadSecSpinBox);
+        pSliderLayout->addWidget(pMaxFrequencyRadSecUnit);
 
         QCheckBox *pBodeCheckBox = new QCheckBox("Create Bode Plot", pBodeDialog);
         QCheckBox *pNyquistCheckBox = new QCheckBox("Create Nyquist Plot", pBodeDialog);
         pBodeCheckBox->setChecked(true);
         pNyquistCheckBox->setChecked(false);
-        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencySlider, SLOT(setEnabled(bool)));
+        connect(pBodeCheckBox, SIGNAL(toggled(bool)), mpMaxFrequencyHzSpinBox, SLOT(setEnabled(bool)));
+        connect(pBodeCheckBox, SIGNAL(toggled(bool)), mpMaxFrequencyRadSecSpinBox, SLOT(setEnabled(bool)));
         connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencyLabel, SLOT(setEnabled(bool)));
-        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencyValue, SLOT(setEnabled(bool)));
-        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencyUnit, SLOT(setEnabled(bool)));
+        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencyHzUnit, SLOT(setEnabled(bool)));
+        connect(pBodeCheckBox, SIGNAL(toggled(bool)), pMaxFrequencyRadSecUnit, SLOT(setEnabled(bool)));
 
         QPushButton *pCancelButton = new QPushButton("Cancel");
         QPushButton *pNextButton = new QPushButton("Go!");
@@ -1536,7 +1560,7 @@ void PlotTab::openCreateBodePlotDialog()
             }
             else
             {
-                mpParentPlotWindow->createBodePlot(pInputCurve->getSharedVectorVariable(), pOutputCurve->getSharedVectorVariable(), pMaxFrequencySlider->value()/(2*M_PI), pBodeCheckBox->isChecked(), pNyquistCheckBox->isChecked());
+                mpParentPlotWindow->createBodePlot(pInputCurve->getSharedVectorVariable(), pOutputCurve->getSharedVectorVariable(), mpMaxFrequencyHzSpinBox->value(), pBodeCheckBox->isChecked(), pNyquistCheckBox->isChecked());
             }
         }
     }

--- a/HopsanGUI/PlotTab.h
+++ b/HopsanGUI/PlotTab.h
@@ -230,6 +230,8 @@ protected slots:
     void saveToXml();
     void exportImage();
     void exportImageSelectFile();
+    void updateMaximumBodeFreqHz(int value);
+    void updateMaximumBodeFreqRadSec(int value);
 
 protected:
     PlotArea *addPlotArea();
@@ -252,6 +254,9 @@ protected:
 
     // Export graphics settings
     PlotGraphicsExporter mGraphicsExporter;
+
+    QSpinBox *mpMaxFrequencyHzSpinBox;
+    QSpinBox *mpMaxFrequencyRadSecSpinBox;
 };
 
 class BodePlotTab : public PlotTab

--- a/HopsanGUI/PlotWindow.h
+++ b/HopsanGUI/PlotWindow.h
@@ -81,7 +81,7 @@ public:
     PlotTab *getCurrentPlotTab();
     PlotTabWidget *getPlotTabWidget(); //!< @todo should this really be needed
 
-    void createBodePlot(SharedVectorVariableT var1, SharedVectorVariableT var2, int Fmax);
+    void createBodePlot(SharedVectorVariableT var1, SharedVectorVariableT var2, int Fmax, bool bode=true, bool nyquist=false);
 
     void showHelpPopupMessage(const QString &rMessage);
 


### PR DESCRIPTION
Resolves #1905.

This will make bode plots always in rad/s. Does this make sense, or do we want it to default to Hz? What are your opinion @petkr14 @larsviktorlarsson?