### PR TITLE
Use angular velocity quantity instead of rad/s in components

### DIFF
--- a/componentLibraries/defaultLibrary/Hydraulic/MachineParts/HydraulicValvePlate.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/MachineParts/HydraulicValvePlate.hpp
@@ -83,7 +83,7 @@ namespace hopsan {
             addInputVariable("theta_1", "Angle 1", "deg", 6, &mpTh1);
             addInputVariable("theta_2", "Angle 2", "deg", 90, &mpTh2);
             addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
-            addInputVariable("movement", "Movement", "rad/s", 160, &mpMovement);
+            addInputVariable("movement", "Movement", "AngularVelocity", 160, &mpMovement);
             addOutputVariable("DEBUG1", "DEBUG1", "");
             addOutputVariable("DEBUG2", "DEBUG1", "");
             addOutputVariable("DEBUG3", "DEBUG1", "");

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicFixedDisplacementPump.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicFixedDisplacementPump.hpp
@@ -61,9 +61,9 @@ namespace hopsan {
             mpP1 = addPowerPort("P1", "NodeHydraulic");
             mpP2 = addPowerPort("P2", "NodeHydraulic");
 
-            addOutputVariable("a", "Angle", "rad", 0.0, &mpND_a);
-            addInputVariable("n_p", "Angular Velocity", "rad/s", 250.0, &mpN);
-            addInputVariable("D_p", "Displacement", "m^3/rev", 0.00005, &mpDp);
+            addOutputVariable("a", "Angle", "Angle", 0.0, &mpND_a);
+            addInputVariable("n_p", "Angular Velocity", "AngularVelocity", 250.0, &mpN);
+            addInputVariable("D_p", "Displacement", "Displacement", 0.00005, &mpDp);
             addInputVariable("C_lp", "Leakage Coefficient", "(m^3/s)/Pa", 0.0, &mpClp);
         }
 

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicPressureControlledPump.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicPressureControlledPump.hpp
@@ -73,13 +73,13 @@ namespace hopsan {
             mpPREF = addPowerPort("PREF", "NodeHydraulic", "", Port::NotRequired);
 
             addOutputVariable("eps", "NodeSignal", "", 1.0, &mpEps);
-            addOutputVariable("a", "NodeSignal", "rad", 0, &mpA);
+            addOutputVariable("a", "NodeSignal", "Angle", 0, &mpA);
             addInputVariable("p_dif", "Reference pressure difference", "Pa", 1000000, &mpPdif);
-            addInputVariable("omega_p", "Pump movement", "rad/s", 125, &mpMovement);
+            addInputVariable("omega_p", "Pump movement", "AngularVelocity", 125, &mpMovement);
             addInputVariable("q_max", "Nominal maximal flow (at 125 rad/s)", "m^3/s", 0.00125, &mpQmax);
             addInputVariable("l_p", "Regulator inductance at nominal pressure", "", 70000000, &mpLp);
             addInputVariable("r_p", "Static characteristic at nominal pressure", "", 1000000000, &mpRp);
-            addInputVariable("omega_p1", "Lead frequency of regulator", "rad/s", 200, &mpWp1);
+            addInputVariable("omega_p1", "Lead frequency of regulator", "AngularVelocity", 200, &mpWp1);
             addInputVariable("C_lp", "Leakage coefficient of pump", "", 0.000000000001, &mpClp);
             addInputVariable("tao_v", "Time constant of control valve", "s", 0.001, &mpTaov);
             addInputVariable("t_p", "Time from min to full displacement", "s", 0.15, &mpTp);

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicVariableDisplacementPump.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicVariableDisplacementPump.hpp
@@ -60,7 +60,7 @@ namespace hopsan {
 
             addOutputVariable("a", "Angle", "", 0.0, &mpA);
             addInputVariable("eps", "Displacement setting", "", 1.0, &mpEps);
-            addInputVariable("omega_p", "Angular Velocity", "rad/s", 50.0, &mpN);
+            addInputVariable("omega_p", "Angular Velocity", "AngularVelocity", 50.0, &mpN);
             addInputVariable("D_p", "Displacement", "m^3/rev", 0.00005, &mpDp);
             addInputVariable("K_cp", "Leakage Coefficient", "(m^3/s)/Pa", 0.0, &mpKcp);
         }

--- a/componentLibraries/defaultLibrary/Mechanic/Rotational/MechanicAngularVelocityTransformer.hpp
+++ b/componentLibraries/defaultLibrary/Mechanic/Rotational/MechanicAngularVelocityTransformer.hpp
@@ -61,7 +61,7 @@ namespace hopsan {
         void configure()
         {
             mpOut = addPowerPort("out", "NodeMechanicRotational");
-            addInputVariable("omega", "Generated angular velocity", "rad/s", 0.0, &mpW);
+            addInputVariable("omega", "Generated angular velocity", "AngularVelocity", 0.0, &mpW);
         }
 
 

--- a/componentLibraries/defaultLibrary/Mechanic/Rotational/MechanicThetaSource.hpp
+++ b/componentLibraries/defaultLibrary/Mechanic/Rotational/MechanicThetaSource.hpp
@@ -74,7 +74,7 @@ public:
      {
         // Add inputVariables ports to the component
         mpPthetain=addInputVariable("thetain","Angle", "rad", 0, &mpIn_theta);
-        mpPwin=addInputVariable("omega","Angular Velocity", "rad/s", 0, &mpIn_w);
+        mpPwin=addInputVariable("omega","Angular Velocity", "AngularVelocity", 0, &mpIn_w);
 
         // Add ports to the component
         mpPmr1=addPowerPort("Pmr1","NodeMechanicRotational");


### PR DESCRIPTION
Resolves #1907.

Use "AngularVelocity"  and some other quantities instead of hard-coded default units.

I intentionally avoided changing generated components.