### PR TITLE
Open add component line edit by double-click

### DIFF
--- a/HopsanGUI/GraphicsView.cpp
+++ b/HopsanGUI/GraphicsView.cpp
@@ -179,6 +179,8 @@ void GraphicsView::mouseDoubleClickEvent(QMouseEvent *event)
 
         this->setIgnoreNextMouseReleaseEvent();
     }
+
+    QGraphicsView::mouseDoubleClickEvent(event);
 }
 
 void GraphicsView::insertComponentFromLineEdit()

--- a/HopsanGUI/GraphicsView.h
+++ b/HopsanGUI/GraphicsView.h
@@ -103,6 +103,7 @@ protected:
     virtual void keyPressEvent(QKeyEvent *event);
     virtual void keyReleaseEvent(QKeyEvent *event);
     virtual void contextMenuEvent ( QContextMenuEvent * event );
+    virtual void mouseDoubleClickEvent(QMouseEvent *event);
 
 private slots:
     void insertComponentFromLineEdit();

--- a/HopsanGUI/LogVariable.cpp
+++ b/HopsanGUI/LogVariable.cpp
@@ -53,7 +53,7 @@ SharedVariableDescriptionT createTimeVariableDescription()
 }
 
 
-SharedVariableDescriptionT createFrequencyVariableDescription()
+SharedVariableDescriptionT  createFrequencyVariableDescription()
 {
     SharedVariableDescriptionT pVarDesc(new VariableDescription());
     pVarDesc->mDataName = FREQUENCYVARIABLENAME;


### PR DESCRIPTION
Resolves #1908.

Change the quick add component feature so that it requires double-click instead of single-click. This makes it less likely to appear by accident.