### PR TITLE
Fix loading of FMUs with different file name and FMU name

### DIFF
--- a/HopsanGenerator/src/HopsanGeneratorLib.cpp
+++ b/HopsanGenerator/src/HopsanGeneratorLib.cpp
@@ -227,7 +227,7 @@ bool callFmuImportGenerator(const char* fmuFilePath, const char* targetPath, con
     // Generate the component library files
     QStringList hppFiles {hppFileInfo.filePath()};
     QString libName = QDir(fmuImportRoot.canonicalFilePath()).dirName();
-    bool genOK = pGenerator->generateNewLibrary(fmuImportRoot.canonicalFilePath(), libName, hppFiles, {libName+".xml"}, cflags, lflags);
+    bool genOK = pGenerator->generateNewLibrary(fmuImportRoot.canonicalFilePath(), libName, hppFiles, {typeName+".xml"}, cflags, lflags);
     if (!genOK) {
         pGenerator->printErrorMessage("Failed to generate FMU import library");
         return false;


### PR DESCRIPTION
If the name specified in modelDescription.xml is different from the filename of the FMU, the component CAF file would get the FMU filename while the library XML would expect the name from the model description.

This has not been discovered before, since those names are the same for both FMUs.