### PR TITLE
Make many signal components replacable with each other

### DIFF
--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalAbsoluteValue.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalAbsoluteValue.xml
@@ -4,6 +4,11 @@
         <icons>
             <icon scale="1" path="SignalAbsoluteValue.svg" iconrotation="OFF" type="iso"/>
         </icons>
+       <replacables>
+            <replacable typename="SignalSquare"/>
+            <replacable typename="SignalGain"/>
+            <replacable typename="SignalSign"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalAdd.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalAdd.xml
@@ -4,6 +4,11 @@
         <icons>
             <icon scale="1" path="SignalAdd.svg" iconrotation="ON" type="iso"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalDivide"/>
+            <replacable typename="SignalMultiply"/>
+            <replacable typename="SignalSubtract"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
             <port x="0" y="0.5" a="180" name="in1"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalDivide.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalDivide.xml
@@ -4,6 +4,11 @@
         <icons>
             <icon scale="1" path="SignalDivide.svg" iconrotation="ON" type="iso"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAdd"/>
+            <replacable typename="SignalMultiply"/>
+            <replacable typename="SignalSubtract"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
             <port x="0" y="0.5" a="180" name="in1"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalGain.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalGain.xml
@@ -4,6 +4,11 @@
         <icons>
             <icon scale="1" path="SignalGain.svg" iconrotation="ON" type="iso"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAbsoluteValue"/>
+            <replacable typename="SignalSquare"/>
+            <replacable typename="SignalSign"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalMax.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalMax.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="SignalMax.svg" iconrotation="ON" type="iso"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalMin"/>
+            <replacable typename="SignalSum"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalMin.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalMin.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="SignalMin.svg" iconrotation="ON" type="iso"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalMax"/>
+            <replacable typename="SignalSum"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalMultiply.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalMultiply.xml
@@ -4,6 +4,11 @@
         <icons>
             <icon scale="1" path="SignalMultiply.svg" iconrotation="ON" type="iso"/>
         </icons>
+       <replacables>
+            <replacable typename="SignalDivide"/>
+            <replacable typename="SignalAdd"/>
+            <replacable typename="SignalSubtract"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
             <port x="0" y="0.5" a="180" name="in1"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalSign.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalSign.xml
@@ -4,6 +4,11 @@
         <icons>
             <icon scale="1" path="SignalSign.svg" iconrotation="ON" type="user"/>
         </icons>
+       <replacables>
+            <replacable typename="SignalAbsoluteValue"/>
+            <replacable typename="SignalGain"/>
+            <replacable typename="SignalSquare"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalSquare.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalSquare.xml
@@ -4,6 +4,11 @@
         <icons>
             <icon scale="1" path="SignalSquare.svg" iconrotation="OFF" type="iso"/>
         </icons>
+       <replacables>
+            <replacable typename="SignalAbsoluteValue"/>
+            <replacable typename="SignalGain"/>
+            <replacable typename="SignalSign"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalSubtract.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalSubtract.xml
@@ -4,6 +4,11 @@
         <icons>
             <icon scale="1" path="SignalSubtract.svg" iconrotation="ON" type="iso"/>
         </icons>
+       <replacables>
+            <replacable typename="SignalDivide"/>
+            <replacable typename="SignalMultiply"/>
+            <replacable typename="SignalAdd"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
             <port x="0" y="0.5" a="180" name="in1"/>

--- a/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalSum.xml
+++ b/componentLibraries/defaultLibrary/Signal/Arithmetics/SignalSum.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="SignalSum.svg" iconrotation="ON" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalMin"/>
+            <replacable typename="SignalMax"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Filters/firstorder.xml
+++ b/componentLibraries/defaultLibrary/Signal/Filters/firstorder.xml
@@ -8,6 +8,15 @@
             <text>General first order filter using bilinear transform.</text>
             <picture>firstorderhelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalHP1Filter"/>
+            <replacable typename="SignalHP2Filter"/>
+            <replacable typename="SignalIntegrator2"/>
+            <replacable typename="SignalLP1Filter"/>
+            <replacable typename="SignalLP2Filter"/>
+            <replacable typename="SignalSecondOrderTransferFunction"/>
+            <replacable typename="SignalSecondOrderFilter"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Filters/hp1filter.xml
+++ b/componentLibraries/defaultLibrary/Signal/Filters/hp1filter.xml
@@ -8,6 +8,15 @@
             <text>First order high pass filter using bilinear transform.</text>
             <picture>hp1filterhelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalFirstOrderFilter"/>
+            <replacable typename="SignalHP2Filter"/>
+            <replacable typename="SignalIntegrator2"/>
+            <replacable typename="SignalLP1Filter"/>
+            <replacable typename="SignalLP2Filter"/>
+            <replacable typename="SignalSecondOrderTransferFunction"/>
+            <replacable typename="SignalSecondOrderFilter"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Filters/hp2filter.xml
+++ b/componentLibraries/defaultLibrary/Signal/Filters/hp2filter.xml
@@ -8,6 +8,15 @@
             <text>Second order high pass filter using bilinear transform.</text>
             <picture>hp2filterhelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalFirstOrderFilter"/>
+            <replacable typename="SignalHP1Filter"/>
+            <replacable typename="SignalIntegrator2"/>
+            <replacable typename="SignalLP1Filter"/>
+            <replacable typename="SignalLP2Filter"/>
+            <replacable typename="SignalSecondOrderTransferFunction"/>
+            <replacable typename="SignalSecondOrderFilter"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Filters/integrator.xml
+++ b/componentLibraries/defaultLibrary/Signal/Filters/integrator.xml
@@ -7,6 +7,15 @@
         <help>
             <text>Integrator component using trapezoid method. Start value on output port will be used as initial value.</text>
         </help>
+        <replacables>
+            <replacable typename="SignalFirstOrderFilter"/>
+            <replacable typename="SignalHP1Filter"/>
+            <replacable typename="SignalHP2Filter"/>
+            <replacable typename="SignalLP1Filter"/>
+            <replacable typename="SignalLP2Filter"/>
+            <replacable typename="SignalSecondOrderTransferFunction"/>
+            <replacable typename="SignalSecondOrderFilter"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Filters/lp1filter.xml
+++ b/componentLibraries/defaultLibrary/Signal/Filters/lp1filter.xml
@@ -8,6 +8,15 @@
             <text>First order low pass filter using bilinear transform.</text>
             <picture>lp1filterhelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalFirstOrderFilter"/>
+            <replacable typename="SignalHP1Filter"/>
+            <replacable typename="SignalHP2Filter"/>
+            <replacable typename="SignalIntegrator2"/>
+            <replacable typename="SignalLP2Filter"/>
+            <replacable typename="SignalSecondOrderTransferFunction"/>
+            <replacable typename="SignalSecondOrderFilter"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Filters/lp2filter.xml
+++ b/componentLibraries/defaultLibrary/Signal/Filters/lp2filter.xml
@@ -8,6 +8,15 @@
             <text>Second order low pass filter using bilinear transform.</text>
             <picture>lp2filterhelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalFirstOrderFilter"/>
+            <replacable typename="SignalHP1Filter"/>
+            <replacable typename="SignalHP2Filter"/>
+            <replacable typename="SignalIntegrator2"/>
+            <replacable typename="SignalLP1Filter"/>
+            <replacable typename="SignalSecondOrderTransferFunction"/>
+            <replacable typename="SignalSecondOrderFilter"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Filters/secondorder.xml
+++ b/componentLibraries/defaultLibrary/Signal/Filters/secondorder.xml
@@ -8,6 +8,15 @@
             <text>General second order filter using bilinear transform.</text>
             <picture>secondorderhelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalFirstOrderFilter"/>
+            <replacable typename="SignalHP1Filter"/>
+            <replacable typename="SignalHP2Filter"/>
+            <replacable typename="SignalIntegrator2"/>
+            <replacable typename="SignalLP1Filter"/>
+            <replacable typename="SignalLP2Filter"/>
+            <replacable typename="SignalSecondOrderTransferFunction"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Filters/secondordertf.xml
+++ b/componentLibraries/defaultLibrary/Signal/Filters/secondordertf.xml
@@ -8,6 +8,15 @@
             <text>Second order transfer function using bilinear transform. Parameters are continous, and will be discretized automatically by the component. Start value on output port is used as initial value.</text>
             <picture>secondordertfhelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalFirstOrderFilter"/>
+            <replacable typename="SignalHP1Filter"/>
+            <replacable typename="SignalHP2Filter"/>
+            <replacable typename="SignalIntegrator2"/>
+            <replacable typename="SignalLP1Filter"/>
+            <replacable typename="SignalLP2Filter"/>
+            <replacable typename="SignalSecondOrderFilter"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Logic/SignalNot.xml
+++ b/componentLibraries/defaultLibrary/Signal/Logic/SignalNot.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="SignalNot.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalGreaterThan"/>
+            <replacable typename="SignalSmallerThan"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
             <port x="0" y="0.5" a="180" name="in"/>

--- a/componentLibraries/defaultLibrary/Signal/Logic/and.xml
+++ b/componentLibraries/defaultLibrary/Signal/Logic/and.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="and.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalOr"/>
+            <replacable typename="SignalXor"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
             <port x="0" y="0.25" a="180" name="in1"/>

--- a/componentLibraries/defaultLibrary/Signal/Logic/greaterthan.xml
+++ b/componentLibraries/defaultLibrary/Signal/Logic/greaterthan.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="greaterthan.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalNot"/>
+            <replacable typename="SignalSmallerThan"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Logic/or.xml
+++ b/componentLibraries/defaultLibrary/Signal/Logic/or.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="or.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAnd"/>
+            <replacable typename="SignalXor"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
             <port x="0" y="0.25" a="180" name="in1"/>

--- a/componentLibraries/defaultLibrary/Signal/Logic/smallerthan.xml
+++ b/componentLibraries/defaultLibrary/Signal/Logic/smallerthan.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="smallerthan.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalGreaterThan"/>
+            <replacable typename="SignalNot"/>
+        </replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Logic/xor.xml
+++ b/componentLibraries/defaultLibrary/Signal/Logic/xor.xml
@@ -4,6 +4,10 @@
         <icons>
             <icon scale="1" path="xor.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAnd"/>
+            <replacable typename="SignalOr"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
             <port x="0" y="0.25" a="180" name="in1"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalAcos.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalAcos.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalAcos.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalAsin.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalAsin.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalAsin.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalAtan.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalAtan.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalAtan.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalCeil.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalCeil.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalCeil.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalCos.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalCos.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalCos.svg" iconrotation="ON" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalCosh.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalCosh.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalCosh.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalExp.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalExp.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalExp.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalLog.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalLog.xml
@@ -4,10 +4,28 @@
         <icons>
             <icon scale="1" path="SignalLog.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>
-			<port x="0.5" y="1" a="90" name="error"/>
+            <port x="0.5" y="1" a="90" name="error"/>
         </ports>
     </modelobject>
 </hopsanobjectappearance>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalLog10.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalLog10.xml
@@ -4,10 +4,28 @@
         <icons>
             <icon scale="1" path="SignalLog10.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>
-			<port x="0.5" y="1" a="90" name="error"/>
+            <port x="0.5" y="1" a="90" name="error"/>
         </ports>
     </modelobject>
 </hopsanobjectappearance>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalPower.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalPower.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalPower.svg" iconrotation="OFF" type="iso"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalRound.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalRound.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalRound.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalSin.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalSin.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalSin.svg" iconrotation="ON" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalSinh.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalSinh.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalSinh.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalSqrt.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalSqrt.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalSqrt.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalTanh"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalTan.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalTan.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalTan.svg" iconrotation="ON" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTanh"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalTanh.xml
+++ b/componentLibraries/defaultLibrary/Signal/MathFunctions/SignalTanh.xml
@@ -4,6 +4,24 @@
         <icons>
             <icon scale="1" path="SignalTanh.svg" iconrotation="" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalAcos"/>
+            <replacable typename="SignalAsin"/>
+            <replacable typename="SignalAtan"/>
+            <replacable typename="SignalCeil"/>
+            <replacable typename="SignalCosh"/>
+            <replacable typename="SignalCos"/>
+            <replacable typename="SignalExp"/>
+            <replacable typename="SignalFloor"/>
+            <replacable typename="SignalLog10"/>
+            <replacable typename="SignalLog"/>
+            <replacable typename="SignalPower"/>
+            <replacable typename="SignalRound"/>
+            <replacable typename="SignalSinh"/>
+            <replacable typename="SignalSin"/>
+            <replacable typename="SignalSqrt"/>
+            <replacable typename="SignalTan"/>
+	</replacables>
         <ports>
             <port x="0" y="0.5" a="180" name="in"/>
             <port x="1" y="0.5" a="0" name="out"/>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/SignalConstant.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/SignalConstant.xml
@@ -4,6 +4,20 @@
         <icons>
             <icon scale="1" path="SignalConstant.svg" iconrotation="OFF" type="iso"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="y"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/SignalTimestep.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/SignalTimestep.xml
@@ -4,6 +4,20 @@
         <icons>
             <icon scale="1" path="SignalTimestep.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="ts"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/noise.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/noise.xml
@@ -7,6 +7,20 @@
         <help>
             <text>Source component that generates white gaussian noise.</text>
         </help>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalTime"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/pulse.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/pulse.xml
@@ -7,6 +7,20 @@
         <help>
             <picture>pulsehelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/pulsewave.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/pulsewave.xml
@@ -8,6 +8,20 @@
             <text>The dutycycle D, is the ratio of the PeroidTime dT when the signal is high</text>
             <picture>pulsewavehelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/ramp.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/ramp.xml
@@ -7,6 +7,20 @@
         <help>
             <picture>ramphelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/sinewave.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/sinewave.xml
@@ -8,6 +8,20 @@
             <text>Implemets the function y=Ya*sin(((T-Tstart)-y_offset)*2PI*f)</text>
             <picture>sinewavehelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/softstep.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/softstep.xml
@@ -7,6 +7,20 @@
         <help>
             <picture>softstephelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/squarewave.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/squarewave.xml
@@ -7,6 +7,20 @@
         <help>
             <picture>squarewavehelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/staircase.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/staircase.xml
@@ -4,6 +4,20 @@
         <icons>
             <icon scale="1.0" path="staircase.svg" iconrotation="OFF" type="user"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1.0" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/step.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/step.xml
@@ -7,6 +7,20 @@
         <help>
             <picture>stephelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/stepexpdelay.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/stepexpdelay.xml
@@ -7,6 +7,20 @@
         <help>
             <picture>stepexpdelayhelp.svg</picture>
         </help>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalTime"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>

--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/time.xml
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/time.xml
@@ -4,6 +4,20 @@
         <icons>
             <icon scale="1" path="time.svg" iconrotation="OFF" type="iso"/>
         </icons>
+        <replacables>
+            <replacable typename="SignalStep"/>
+            <replacable typename="SignalStepExponentialDelay"/>
+            <replacable typename="SignalStaircase"/>
+            <replacable typename="SignalSquareWave"/>
+            <replacable typename="SignalSoftStep"/>
+            <replacable typename="SignalSineWave"/>
+            <replacable typename="SignalTimestep"/>
+            <replacable typename="SignalConstant"/>
+            <replacable typename="SignalRamp"/>
+            <replacable typename="SignalPulse"/>
+            <replacable typename="SignalPulseWave"/>
+            <replacable typename="SignalNoise"/>
+        </replacables>
         <ports>
             <port x="1" y="0.5" a="0" name="out"/>
         </ports>


### PR DESCRIPTION
Add replaceable tags in signal CAF files, to make components replaceable with other similar components.

Especially helpful for signal sources, where you can quickly replace e.g. a step with a pulse.