### PR TITLE
Automatically move cursor into automatically added parenthesis

### DIFF
--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -719,6 +719,7 @@ void TextEditor::keyPressEvent(QKeyEvent* event)
             cursor.beginEditBlock();
             if(next.isSpace() || next == '\n') {
                 insertPlainText("()");
+                cursor.movePosition(QTextCursor::Left, QTextCursor::MoveAnchor, 1);
             }
             else {
                 insertPlainText("(");


### PR DESCRIPTION
Very minor fix to text editor.

When typing "(" with space or new line as next character, a ")" is automatically added. This fix makes sure the cursor is automatically moved inside the two parentheses, so user don't need to press left arrow key before typing.