### PR TITLE
Use standard Modelica attributes for input and output variables

### DIFF
--- a/HopsanGenerator/src/generators/HopsanGeneratorBase.cpp
+++ b/HopsanGenerator/src/generators/HopsanGeneratorBase.cpp
@@ -1128,10 +1128,10 @@ QString HopsanGeneratorBase::generateModelicaCodeFromComponentSpec(ComponentSpec
     for(int p=0; p<comp.portNodeTypes.size(); ++p) {
         QString nodeType = comp.portNodeTypes[p];
         if(nodeType == "NodeSignal" && comp.portTypes[p] == "ReadPort") {
-            nodeType.append("In");
+            nodeType = "input Real";
         }
         else if(nodeType == "NodeSignal" && comp.portTypes[p] == "WritePort") {
-            nodeType.append("Out");
+            nodeType = "output Real";
         }
         outStream << indent << nodeType << " " << comp.portNames[p] << ";\n";
     }

--- a/HopsanGenerator/src/generators/HopsanModelicaGenerator.cpp
+++ b/HopsanGenerator/src/generators/HopsanModelicaGenerator.cpp
@@ -246,21 +246,21 @@ void HopsanModelicaGenerator::parseModelicaModel(QString code, QString &typeName
                     variablesList.append(varSpec);
                 }
             }
-            else if(words.at(0) == "NodeSignalOut")                //Signal connector (output)
+            else if(words.at(0) == "output" && words.at(1) == "Real")                //Signal connector (output)
             {
                 for(int i=0; i<lines.at(l).count(",")+1; ++i)
                 {
-                    QString name = lines.at(l).trimmed().section(" ", 1).section(",",i,i).section(";",0,0).trimmed();
+                    QString name = lines.at(l).trimmed().section(" ", 2).section(",",i,i).section(";",0,0).trimmed();
                     PortSpecification port("WritePort", "NodeSignal", name);
                     portList.append(port);
                     portNames << name;
                 }
             }
-            else if(words.at(0) == "NodeSignalIn")                //Signal connector (input)
+            else if(words.at(0) == "input" && words.at(1) == "Real")                //Signal connector (input)
             {
                 for(int i=0; i<lines.at(l).count(",")+1; ++i)
                 {
-                    QString name = lines.at(l).trimmed().section(" ", 1).section(",",i,i).section(";",0,0).trimmed();
+                    QString name = lines.at(l).trimmed().section(" ", 2).section(",",i,i).section(";",0,0).trimmed();
                     PortSpecification port("ReadPort", "NodeSignal", name);
                     portList.append(port);
                     portNames << name;


### PR DESCRIPTION
The Modelica generator uses custom data types for input and output variables. This replaces them with standard Modelica attributes for input and output:

`NodeSignalIn`-> `input Real`
`NodeSignalOut`-> `output Real`

This affects both template code generator and the translator from Modelica to C++.