### PR TITLE
Abort optimization while evaluating initial candidates

### DIFF
--- a/HopsanGUI/OptimizationHandler.cpp
+++ b/HopsanGUI/OptimizationHandler.cpp
@@ -720,7 +720,7 @@ bool OptimizationHandler::evaluateAllCandidates()
     mNeedsRescheduling = false;
 
     //Multi-threading, we cannot use the "evalall" function
-    for(size_t i=0; i<mpWorker->getNumberOfCandidates(); ++i)
+    for(size_t i=0; i<mpWorker->getNumberOfCandidates() && !mpWorker->aborted(); ++i)
     {
         mpHcomHandler->setModelPtr(mModelPtrs[i]);
         mpHcomHandler->executeCommand("opt set evalid "+QString::number(i));

--- a/Ops/include/OpsWorker.h
+++ b/Ops/include/OpsWorker.h
@@ -125,6 +125,8 @@ public:
 
     double opsRand();
 
+    bool aborted();
+
 protected:
     size_t mIterationCounter;
     size_t mNumCandidates;

--- a/Ops/src/OpsEvaluator.cpp
+++ b/Ops/src/OpsEvaluator.cpp
@@ -60,7 +60,7 @@ void Evaluator::evaluateAllPoints()
     }
     else
     {
-        for(size_t i=0; i<mpWorker->mNumPoints; ++i)
+        for(size_t i=0; i<mpWorker->mNumPoints && !mpWorker->aborted(); ++i)
         {
             mpWorker->mCandidatePoints[0] = mpWorker->mPoints[i];
             evaluateCandidate(0);
@@ -79,7 +79,7 @@ void Evaluator::evaluateCandidate(size_t idx)
 
 void Evaluator::evaluateAllCandidates()
 {
-    for(size_t i=0; i<mpWorker->mNumCandidates; ++i)
+    for(size_t i=0; i<mpWorker->mNumCandidates && !mpWorker->aborted(); ++i)
     {
         evaluateCandidate(i);
     }

--- a/Ops/src/OpsWorker.cpp
+++ b/Ops/src/OpsWorker.cpp
@@ -367,6 +367,11 @@ double Worker::opsRand()
     return double(rand())/double(RAND_MAX);
 }
 
+bool Worker::aborted()
+{
+    return mpMessageHandler->aborted();
+}
+
 void Worker::setParameterLimits(size_t idx, double min, double max)
 {
     mParameterMin[idx] = min;


### PR DESCRIPTION
Resolves #1923.

Evaluation will never be aborted during a simulation, only between simulations. Parallel simulation with multiple models cannot be aborted, since it uses a blocking call to HopsanCore.