### PR TITLE
Reset lock axis setting when changing units or X-axis variable

### DIFF
--- a/HopsanGUI/PlotArea.cpp
+++ b/HopsanGUI/PlotArea.cpp
@@ -1067,6 +1067,7 @@ void PlotArea::dropEvent(QDropEvent *event)
                             QCursor cursor;
                             if(this->mapFromGlobal(cursor.pos()).y() > getQwtPlot()->canvas()->height()*2.0/3.0+getQwtPlot()->canvas()->y()+10 && getNumberOfCurves() >= 1)
                             {
+                                setAxisLocked(QwtPlot::xBottom, false);
                                 setCustomXVectorForAll(data);
                                 //! @todo do we need to reset to default unit too ?
                             }
@@ -1309,12 +1310,18 @@ void PlotArea::contextMenuEvent(QContextMenuEvent *event)
     {
         auto it = dataActionToCurveMap.find(pSelectedAction);
         if (it != dataActionToCurveMap.end()) {
+            if(it.value()->getCurrentPlotUnit() != pSelectedAction->text()) {
+                setAxisLocked((QwtPlot::Axis)it.value()->getAxisY(), false); //Reset lock axis setting, but only if unit is different from existing unit
+            }
             it.value()->setCurveDataUnitScale(pSelectedAction->text());
         }
 
         auto lit = timeorfreqActionToCurveMap.find(pSelectedAction);
         if (lit != timeorfreqActionToCurveMap.end()) {
             for (auto pCurve : *lit) {
+                if(pCurve->getCurrentTFPlotUnit() != pSelectedAction->text()) {
+                    setAxisLocked(QwtPlot::xBottom, false); //Reset lock axis setting, but only if unit is different from existing unit
+                }
                 pCurve->setCurveTFUnitScale(pSelectedAction->text());
             }
         }
@@ -1322,6 +1329,9 @@ void PlotArea::contextMenuEvent(QContextMenuEvent *event)
         auto cxlit = customxActionToCurveMap.find(pSelectedAction);
         if (cxlit != customxActionToCurveMap.end()) {
             for (auto pCurve : *cxlit) {
+                if(pCurve->getCurrentXPlotUnit() != pSelectedAction->text()) {
+                    setAxisLocked(QwtPlot::xBottom, false); //Reset lock axis setting, but only if unit is different from existing unit
+                }
                 pCurve->setCurveCustomXDataUnitScale(pSelectedAction->text());
             }
         }

--- a/HopsanGUI/PlotCurve.cpp
+++ b/HopsanGUI/PlotCurve.cpp
@@ -349,6 +349,15 @@ QString PlotCurve::getCurrentXPlotUnit() const
     return {};
 }
 
+QString PlotCurve::getCurrentTFPlotUnit() const
+{
+    UnitConverter uc = getCurveTFUnitScale();
+    if (!uc.isEmpty()) {
+        return uc.mUnit;
+    }
+    return {};
+}
+
 VariableSourceTypeT PlotCurve::getDataSource() const
 {
     return mData->getVariableSourceType();

--- a/HopsanGUI/PlotCurve.h
+++ b/HopsanGUI/PlotCurve.h
@@ -131,6 +131,7 @@ public:
 
     QString getCurrentPlotUnit() const;
     QString getCurrentXPlotUnit() const;
+    QString getCurrentTFPlotUnit() const;
 
     UnitConverter getCurveTFUnitScale() const;
     void setCurveTFUnitScale(const UnitConverter &us);


### PR DESCRIPTION
Resolves #1928.

Always unset lock axis setting when changing units or changing X axis variable. Perhaps a bit annoying to lose zoom setting, but less annoying than keeping zoom setting for previous unit or variable.

A proper solution would be to recompute the zoom factor when changing units, but that will be quite complicated, especially for non-linear units (i.e. dB).