### PR TITLE
Make all text editor tabs appear last in tab widget

### DIFF
--- a/HopsanGUI/ModelHandler.cpp
+++ b/HopsanGUI/ModelHandler.cpp
@@ -91,7 +91,7 @@ void ModelHandler::addModelWidget(ModelWidget *pModelWidget, const QString &name
     {
         mModelPtrs.append(pModelWidget);
         mCurrentIdx = mModelPtrs.size()-1;
-        gpCentralTabWidget->setCurrentIndex(gpCentralTabWidget->addTab(pModelWidget, name));
+        gpCentralTabWidget->setCurrentIndex(gpCentralTabWidget->insertTab(mCurrentIdx+1, pModelWidget, name));
         emit newModelWidgetAdded();
         emit modelChanged(pModelWidget);
     }


### PR DESCRIPTION
This makes sure model tabs are indexed correctly, and will thereby prevent crashes.

By always having one range of model widgets followed by another range of text editors, it will be easier to separate the two widget types from each other.