### PR TITLE
Run HopsanGUI tests offscreen in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - ./runValidationTests.sh
   - cd bin
   - ls -l
-#  - otool -lv hopsancli
-#  - otool -lv hopsangui
-#  - otool -lv holc
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -lv hopsancli ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -lv hopsangui ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -lv holc ; fi
 #  - ./hopsangui ../Scripts/HCOM/exit.hcom

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 # Enable C++ support
 language: cpp
 
-matrix:
+jobs:
   include:
     - os: linux
       sudo: required
-      dist: trusty
+      dist: xenial
+      addons:
+        apt_packages:
+          - qt5-default
+          - qtbase5-dev
+          - libqt5webkit5-dev
+          - libqt5svg5-dev
+          - libqt5opengl5-dev
       compiler: gcc
       env:
-        - QT_SELECT=4
+        - QT_SELECT=qt5
         - HOPSAN_BUILD_QMAKE_SPEC=linux-g++
     - os: osx
       compiler: clang
@@ -25,19 +32,18 @@ script:
   - bash --version
   - echo OSType $OSTYPE
   - cd Dependencies
+  - source ./setHopsanBuildPaths.sh
   - ./setupDiscount.sh
   - ./setupFMILibrary.sh
   - ./setupQwt.sh
   - ./setupZeroMQ.sh
   - ./setupKatex.sh
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./setupPythonQt.sh release 2.7 3.0 ; fi
   - cd ..
   - mkdir -p build
   - cd build
-  - source ../Dependencies/setHopsanBuildPaths.sh
   - ${HOPSAN_BUILD_QT_QMAKE} ../HopsanNG.pro -r -spec ${HOPSAN_BUILD_QMAKE_SPEC} -config release
   - cd ..
-  - make -j4 -C build
+  - make -j6 -C build
   - ./runUnitTests.sh
   - ./runValidationTests.sh
   - cd bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ jobs:
           - libqt5webkit5-dev
           - libqt5svg5-dev
           - libqt5opengl5-dev
+      services:
+        - xvfb
       compiler: gcc
       env:
         - QT_SELECT=qt5
@@ -44,7 +46,8 @@ script:
   - ${HOPSAN_BUILD_QT_QMAKE} ../HopsanNG.pro -r -spec ${HOPSAN_BUILD_QMAKE_SPEC} -config release
   - cd ..
   - make -j6 -C build
-  - ./runUnitTests.sh
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run -a ./runUnitTests.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./runUnitTests.sh ; fi
   - ./runValidationTests.sh
   - cd bin
   - ls -l

--- a/Dependencies/setHopsanBuildPaths.sh
+++ b/Dependencies/setHopsanBuildPaths.sh
@@ -22,6 +22,7 @@ elif [[ $(command -v qmake) ]]; then
     # On debian based systems this script assumes that qmake is in fact, qtchooser
     export HOPSAN_BUILD_QT_QMAKE=qmake
     echo Found qmake in PATH
+    qmake --version
 elif [[ $OSTYPE == darwin* ]]; then
     # On macOS we break here with failure
     echo ERROR: Did not find qmake, aborting!

--- a/Dependencies/zeromq.pri
+++ b/Dependencies/zeromq.pri
@@ -12,7 +12,7 @@ have_local_zeromq() {
   unix:LIBS *= -L$${zeromq_lib} -lzmq$${dbg_ext}
   macx {
     # TODO: I am unable to get RPATH to work on osx, so ugly copying the dylib. file for now
-    QMAKE_POST_LINK += $$QMAKE_COPY $$quote($${zeromq_lib}/libzmq$${dbg_ext}.dylib) $$quote($${PWD}/../bin) $$escape_expand(\\n\\t)
+    QMAKE_POST_LINK += $$QMAKE_COPY $$quote($${zeromq_lib}/libzmq$${dbg_ext}*.dylib) $$quote($${PWD}/../bin) $$escape_expand(\\n\\t)
   } else {
     # Note! The RPATH is absolute and only meant for dev builds in the IDE, on release runtime paths should be stripped
     unix:QMAKE_RPATHDIR *= $${zeromq_lib}

--- a/runUnitTests.bat
+++ b/runUnitTests.bat
@@ -14,6 +14,9 @@ for /r "." %%a in (tst_*.exe) do (
 )
 
 REM Run HopsanGUI built-in tests
+REM Assume libstd++ and Qt libraries are in PATH already, set PATH to find local dependencies
+set deps=%~dp0\Dependencies
+set PATH=%deps%\qwt\lib;%deps%\zeromq\bin;%deps%\hdf5\bin;%deps%\discount\lib;%deps%\FMILibrary\lib;%PATH%
 hopsangui.exe --test --platform offscreen
 if !errorlevel! neq 0 (
   echo HopsanGUI test FAILED

--- a/runUnitTests.bat
+++ b/runUnitTests.bat
@@ -4,6 +4,7 @@ SETLOCAL EnableDelayedExpansion
 set failed=0
 
 cd bin
+REM Run test programs
 for /r "." %%a in (tst_*.exe) do (
   "%%~fa"
   if !errorlevel! neq 0 (
@@ -11,6 +12,14 @@ for /r "." %%a in (tst_*.exe) do (
     set failed=1
   )
 )
+
+REM Run HopsanGUI built-in tests
+hopsangui.exe --test --platform offscreen
+if !errorlevel! neq 0 (
+  echo HopsanGUI test FAILED
+  set failed=1
+)
+
 cd ..
 if !failed! equ 1 (
   echo ERROR: At least one unit test failed!

--- a/runUnitTests.sh
+++ b/runUnitTests.sh
@@ -1,11 +1,36 @@
 #!/bin/bash
 
-set -e
 set -u
 
 cd bin
+# Run test programs
+numfailed=0
 tests=$(ls tst_*)
 for test in ${tests}; do
     ./${test}
+    if [[ $? -ne 0 ]]; then
+        ((numfailed++))
+    fi
 done
-echo All tests passed
+
+# Run HopsanGUI built-in tests
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    # TODO make this work
+    echo Warning: HopsanGUI tests disabled on macOS Travis CI
+else
+   ./hopsangui --test --platform offscreen
+fi
+
+if [[ $? -ne 0 ]]; then
+    ((numfailed++))
+fi
+
+if [[ ${numfailed} -eq 0 ]]; then
+    echo
+    echo All tests passed
+    exit 0
+else
+    echo
+    echo ${numfailed} test applications failed
+    exit 1
+fi


### PR DESCRIPTION
- Add HopsanGUI tests offscreen (but not on osx)
- Run all tests from script even on failure
- Update to Xenial and Qt5 on Travis CI (Qt4 is not unsupported)