### PR TITLE
Use focal config for eoan

### DIFF
--- a/makeDebRelease.sh
+++ b/makeDebRelease.sh
@@ -20,7 +20,7 @@ debianDistArchArray=( buster:amd64:qt5py3_buster   buster:i386:qt5py3_buster \
                       stretch:amd64:qt5py27        stretch:i386:qt5py27 \
                       jessie:amd64:qt5py27_jessie  jessie:i386:qt5py27_jessie )
 ubuntuDistArchArray=( focal:amd64:focal
-                      eoan:amd64:qt5py3_2          eoan:i386:qt5py3_2 \
+                      eoan:amd64:focal             eoan:i386:focal \
                       bionic:amd64:qt5py3_1        bionic:i386:qt5py3_1 \
                       xenial:amd64:qt5py27         xenial:i386:qt5py27 \
                       trusty:amd64:trusty          trusty:i386:trusty )

--- a/packaging/deb/focal/debian/control
+++ b/packaging/deb/focal/debian/control
@@ -26,7 +26,7 @@ Homepage: https://github.com/Hopsan/hopsan
 
 Package: hopsan
 Architecture: any
-Depends: python3
+Depends: python3,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: This is a free simulation environment for fluid and mechatronic systems.


### PR DESCRIPTION
It seems like pythonqt have been removed from the eoan repository, but I still had the package
in the build environment for some reason

Resolves #1941 