### PR TITLE
Issue 1927 autocopy systemparameters

### DIFF
--- a/HopsanGUI/CoreAccess.cpp
+++ b/HopsanGUI/CoreAccess.cpp
@@ -1395,10 +1395,18 @@ double evalWithNumHop(const QString &rExpression)
     return value;
 }
 
-QStringList getEmbeddedSriptVariableNames(const QString& expression, CoreSystemAccess* pCoreSystem)
+QStringList getEmbeddedSriptVariableNames(const QString& expression, const QString& subcomponentName,  CoreSystemAccess* pCoreSystem)
 {
     hopsan::NumHopHelper numhop;
-    numhop.setSystem(pCoreSystem->getCoreSystemPtr());
+    hopsan::ComponentSystem* pSystem = pCoreSystem->getCoreSystemPtr();
+    if (subcomponentName.isEmpty()) {
+        numhop.setSystem(pCoreSystem->getCoreSystemPtr());
+    }
+    else {
+        hopsan::Component* pComponent = pSystem->getSubComponent(qPrintable(subcomponentName));
+        numhop.setComponent(pComponent);
+    }
+
     auto hnames = numhop.extractVariableNames(qPrintable(expression));
     QStringList names;
     names.reserve(hnames.size());

--- a/HopsanGUI/CoreAccess.cpp
+++ b/HopsanGUI/CoreAccess.cpp
@@ -1464,3 +1464,27 @@ QString checkPrependSelfToEmbeddedScripts(ContainerObject *pTopLevelGUISystem)
     processSystem(pTopLevelGUISystem);
     return output;
 }
+
+bool CoreParameterData::hasBooleanValue() const
+{
+    // These are the values used for bool inside HopsanCore
+    return (mType == "bool") && ((mValue == "true") || (mValue == "false") || (mValue == "1") || (mValue == "0"));
+}
+
+bool CoreParameterData::hasIntegerValue() const
+{
+    bool isNummeric = false;
+    if (mType == "integer") {
+        mValue.toInt(&isNummeric);
+    }
+    return isNummeric;
+}
+
+bool CoreParameterData::hasDoubleValue() const
+{
+    bool isNummeric = false;
+    if (mType == "double") {
+        mValue.toDouble(&isNummeric);
+    }
+    return isNummeric;
+}

--- a/HopsanGUI/CoreAccess.h
+++ b/HopsanGUI/CoreAccess.h
@@ -98,7 +98,7 @@ public:
 
 double evalWithNumHop(const QString &rExpression);
 
-QStringList getEmbeddedSriptVariableNames(const QString& expression, CoreSystemAccess* pCoreSystem);
+QStringList getEmbeddedSriptVariableNames(const QString& expression, const QString& subcomponentName, CoreSystemAccess* pCoreSystem);
 
 void prependSelfToParameterExpressions(ContainerObject* pTopLevelGUISystem);
 QString checkPrependSelfToEmbeddedScripts(ContainerObject *pTopLevelGUISystem);

--- a/HopsanGUI/CoreAccess.h
+++ b/HopsanGUI/CoreAccess.h
@@ -111,6 +111,10 @@ public:
     CoreParameterData(const QString name, const QString value, const QString type, const QString quantity="", const QString unit="", const QString desc="")
         : mName(name), mValue(value), mType(type), mQuantity(quantity), mUnit(unit), mDescription(desc) {}
 
+    bool hasBooleanValue() const;
+    bool hasIntegerValue() const;
+    bool hasDoubleValue() const;
+
     QString mName;
     QString mAlias;
     QString mValue;

--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -1501,7 +1501,12 @@ void ContainerObject::copySelected(CopyStack *xmlStack)
             val.toDouble(&isNumber);
             QStringList exprVariables;
             if (!isNumber) {
-                exprVariables = getEmbeddedSriptVariableNames(val, getCoreSystemAccessPtr());
+                exprVariables = getEmbeddedSriptVariableNames(val, (*it)->getName(), getCoreSystemAccessPtr());
+                // Erase all begining with .self as those can not be system parameters
+                auto new_end = std::remove_if(exprVariables.begin(), exprVariables.end(), [](QString& v){
+                    return v.startsWith("self.");
+                });
+                exprVariables.erase(new_end, exprVariables.end());
             }
 
             for (const auto& var : exprVariables) {


### PR DESCRIPTION
Solves new bug when copying components with system parameters to a new systems.
System parameters would not be included. (due to new code dealing with self.NAME parameters)

Also resolves #1927 
