### PR TITLE
Apply icon scale when adding subsystem components

### DIFF
--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -576,6 +576,7 @@ ModelObject* ContainerObject::addModelObject(QString fullTypeName, QPointF posit
             pObj->setAppearanceDataBasePath(fileInfo.absolutePath());
             pObj->loadFromDomElement(systemElement);
             pObj->setIconPath(pAppearanceData->getIconPath(UserGraphics, Absolute), UserGraphics, Absolute);
+            pObj->getAppearanceData()->setIconScale(pAppearanceData->getIconScale(UserGraphics), UserGraphics);
             pObj->refreshAppearance();
             return pObj;
         }


### PR DESCRIPTION
Make sure to apply scale setting when adding subsystem components (i.e. components based on a HMF file) to a model. 
