### PR TITLE
Fix SignalLogger file stream on Windows

### DIFF
--- a/componentLibraries/defaultLibrary/Signal/Sources&Sinks/SignalLogger.hpp
+++ b/componentLibraries/defaultLibrary/Signal/Sources&Sinks/SignalLogger.hpp
@@ -193,6 +193,14 @@ namespace hopsan {
                 }
             }
 
+            //Close and re-open file in append mode
+            mFile.close();
+            mFile.open(mFilePath.c_str(),std::ios_base::app);
+            if (!mFile.is_open()) {
+                stopSimulation("Could not open file for writing: "+mFilePath);
+                return;
+            }
+
             mLastLogTime = mTime-(*mpDt);
             simulateOneTimestep();
         }


### PR DESCRIPTION
For some reason the ofstream needs to be closed and re-opened in append mode for this to work in Windows. Otherwise it only logs a few steps with a constant value. This has been tested and works on both Windows and Linux.