### PR TITLE
Always reload models before starting a new optimization

### DIFF
--- a/HopsanGUI/OptimizationHandler.cpp
+++ b/HopsanGUI/OptimizationHandler.cpp
@@ -189,6 +189,7 @@ void OptimizationHandler::startOptimization(ModelWidget *pModel, QString &modelP
 void OptimizationHandler::initModels(ModelWidget *pModel, int nModels, QString &modelPath)
 {
     QString originalModelBasePath = pModel->getTopLevelSystemContainer()->getAppearanceData()->getBasePath();
+    mModelPtrs.clear();
     while(mModelPtrs.size() < nModels)
     {
         auto pNewModel = gpModelHandler->loadModel(modelPath, ModelHandler::IgnoreAlreadyOpen | ModelHandler::Detatched);


### PR DESCRIPTION
This fixes a weird bug where changing a model between two optimization has no effect. For some reason the temporary optimization models were only updated before the first optimization. They should be reloaded every time, in case the model has changed.

@petkr14 This should solve the problem with your filter optimization model.