### PR TITLE
Correct tab names and tab index after restoring state

### DIFF
--- a/HopsanGUI/ModelHandler.cpp
+++ b/HopsanGUI/ModelHandler.cpp
@@ -771,7 +771,7 @@ void ModelHandler::setToolBarSimulationTimeFromTab(ModelWidget *pModel)
 
 void ModelHandler::saveState()
 {
-    mStateInfoIndex = mCurrentIdx;
+    mStateInfoIndex = gpCentralTabWidget->currentIndex();
     mStateInfoList.clear();
 
     while(!mModelPtrs.isEmpty())
@@ -811,7 +811,7 @@ void ModelHandler::saveState()
 
 void ModelHandler::restoreState()
 {
-    int numTextTabs = gpCentralTabWidget->count();
+    int numTextTabs = gpCentralTabWidget->count()-1;
     for(int i=0; i<mStateInfoList.size(); ++i)
     {
         ModelStateInfo info = mStateInfoList[i];
@@ -842,7 +842,7 @@ void ModelHandler::restoreState()
 //        getCurrentTopLevelSystem()->setLogDataHandler(mStateInfoLogDataHandlersList[i]);
 //        mStateInfoLogDataHandlersList[i]->setParentContainerObject(getCurrentTopLevelSystem());
     }
-    this->setCurrentModel(mStateInfoIndex);
+    gpCentralTabWidget->setCurrentIndex(mStateInfoIndex);
     mStateInfoList.clear();
 }
 


### PR DESCRIPTION
This fixes annoying bugs after reloading or recompiling libraries. All tab names are now left intact, and the current tab index is remembered correctly.