### PR TITLE
Correct tab names after reload with multiple models

### DIFF
--- a/HopsanGUI/ModelHandler.cpp
+++ b/HopsanGUI/ModelHandler.cpp
@@ -834,9 +834,9 @@ void ModelHandler::restoreState()
         {
             addNewModel();
         }
-        gpCentralTabWidget->setCurrentIndex(numTextTabs+i);
+        gpCentralTabWidget->setCurrentIndex(1+i);
         this->mCurrentIdx = numTextTabs+i;
-        gpCentralTabWidget->setTabText(numTextTabs+i, info.tabName);
+        gpCentralTabWidget->setTabText(1+i, info.tabName);
 
         //! @todo FIXA /Peter
 //        getCurrentTopLevelSystem()->setLogDataHandler(mStateInfoLogDataHandlersList[i]);


### PR DESCRIPTION
Apparently the fix in #1965 was not sufficient in all cases. This fix should work also when there are more than one text tab open.