### PR TITLE
Units, description precision and color settings for display component

### DIFF
--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -197,8 +197,10 @@ void AnimatedComponent::updateAnimation()
     {
         double textData;
         mpModelObject->getPort("in")->getLastNodeData("Value", textData);
+        textData *= mUnitScaling;
         QString text = QString::number(textData,'g', 4);
         text = text.left(6);
+        text.append(mUnit);
         mpText->setPlainText(text);
     }
 
@@ -529,6 +531,10 @@ void AnimatedComponent::setupAnimationBase(QString basePath)
     {
         mpText->setDefaultTextColor(Qt::green);
         mpText->show();
+
+        //Figure out unit and scaling
+        mUnit = mpModelObject->getParameterValue("unit");
+        mUnitScaling = mpModelObject->getParameterValue("unitscaling").toDouble();
     }
 }
 

--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -200,6 +200,7 @@ void AnimatedComponent::updateAnimation()
         textData *= mUnitScaling;
         QString text = QString::number(textData,'g', 4);
         text = text.left(6);
+        text.prepend(mDescription);
         text.append(mUnit);
         mpText->setPlainText(text);
     }
@@ -531,6 +532,12 @@ void AnimatedComponent::setupAnimationBase(QString basePath)
     {
         mpText->setDefaultTextColor(Qt::green);
         mpText->show();
+
+        //Figure out description text
+        mDescription = mpModelObject->getParameterValue("description");
+        if(!mDescription.isEmpty()) {
+            mDescription.append(" ");
+        }
 
         //Figure out unit and scaling
         mUnit = mpModelObject->getParameterValue("unit");

--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -206,6 +206,7 @@ void AnimatedComponent::updateAnimation()
         text.prepend(mDescription);
         text.append(mUnit);
         mpText->setPlainText(text);
+        mpText->setHtml(mHtml+ text + "</div>");
     }
 
     //Loop through all movable icons
@@ -548,6 +549,13 @@ void AnimatedComponent::setupAnimationBase(QString basePath)
 
         //Figure out precision
         mPrecision = mpModelObject->getParameterValue("precision").toInt();
+
+        //Figure out colors
+        mBackgroundColor = mpModelObject->getParameterValue("backgroundcolor");
+        mTextColor = mpModelObject->getParameterValue("textcolor");
+
+        //Generate HTML style string
+        mHtml = "<div style='background:rgba("+mBackgroundColor+", 100%);font-family: monospace;color:rgba("+mTextColor+", 100%); '>";
     }
 }
 

--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -198,8 +198,11 @@ void AnimatedComponent::updateAnimation()
         double textData;
         mpModelObject->getPort("in")->getLastNodeData("Value", textData);
         textData *= mUnitScaling;
-        QString text = QString::number(textData,'g', 4);
-        text = text.left(6);
+        QString text = QString::number(textData,'f', mPrecision);
+        text = text.left(mPrecision);
+        while(text.size() < mPrecision) {
+            text.append("0");
+        }
         text.prepend(mDescription);
         text.append(mUnit);
         mpText->setPlainText(text);
@@ -542,6 +545,9 @@ void AnimatedComponent::setupAnimationBase(QString basePath)
         //Figure out unit and scaling
         mUnit = mpModelObject->getParameterValue("unit");
         mUnitScaling = mpModelObject->getParameterValue("unitscaling").toDouble();
+
+        //Figure out precision
+        mPrecision = mpModelObject->getParameterValue("precision").toInt();
     }
 }
 

--- a/HopsanGUI/GUIObjects/AnimatedComponent.h
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.h
@@ -88,6 +88,7 @@ protected:
     QGraphicsTextItem *mpText;
     QString mDescription, mUnit;
     double mUnitScaling;
+    int mPrecision;
 
     QMap<QString, QPointF> mPortPositions;
 

--- a/HopsanGUI/GUIObjects/AnimatedComponent.h
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.h
@@ -84,7 +84,10 @@ protected:
     QList<QList<QVector<double> > > *mpData;
     QList<QList<double*> > *mpNodeDataPtrs;
 
+    //Display component members
     QGraphicsTextItem *mpText;
+    QString mUnit;
+    double mUnitScaling;
 
     QMap<QString, QPointF> mPortPositions;
 

--- a/HopsanGUI/GUIObjects/AnimatedComponent.h
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.h
@@ -86,7 +86,7 @@ protected:
 
     //Display component members
     QGraphicsTextItem *mpText;
-    QString mUnit;
+    QString mDescription, mUnit;
     double mUnitScaling;
 
     QMap<QString, QPointF> mPortPositions;

--- a/HopsanGUI/GUIObjects/AnimatedComponent.h
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.h
@@ -86,7 +86,7 @@ protected:
 
     //Display component members
     QGraphicsTextItem *mpText;
-    QString mDescription, mUnit;
+    QString mDescription, mUnit, mBackgroundColor, mTextColor, mHtml;
     double mUnitScaling;
     int mPrecision;
 

--- a/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.hpp
+++ b/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.hpp
@@ -46,7 +46,7 @@ class SignalDisplay : public ComponentC
 {
 
     private:
-        HString mUnit;
+        HString mUnit, mDescription;
         double mUnitScaling;
 
     public:
@@ -59,6 +59,7 @@ class SignalDisplay : public ComponentC
         {
             //Add ports to the component
             addInputVariable("in","","",0.0);
+            addConstant("description","Description label", "", mDescription);
             addConstant("unit","Unit","", mUnit);
             addConstant("unitscaling", "Unit scaling (from SI unit)", "", 1, mUnitScaling);
         }

--- a/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.hpp
+++ b/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.hpp
@@ -48,6 +48,7 @@ class SignalDisplay : public ComponentC
     private:
         HString mUnit, mDescription;
         double mUnitScaling;
+        int mPrecision;
 
     public:
         static Component *Creator()
@@ -62,6 +63,7 @@ class SignalDisplay : public ComponentC
             addConstant("description","Description label", "", mDescription);
             addConstant("unit","Unit","", mUnit);
             addConstant("unitscaling", "Unit scaling (from SI unit)", "", 1, mUnitScaling);
+            addConstant("precision", "Maximum number of total digits", "", 8, mPrecision);
         }
 
 

--- a/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.hpp
+++ b/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.hpp
@@ -46,7 +46,7 @@ class SignalDisplay : public ComponentC
 {
 
     private:
-        HString mUnit, mDescription;
+        HString mUnit, mDescription, mBackgroundColor, mTextColor;
         double mUnitScaling;
         int mPrecision;
 
@@ -64,6 +64,8 @@ class SignalDisplay : public ComponentC
             addConstant("unit","Unit","", mUnit);
             addConstant("unitscaling", "Unit scaling (from SI unit)", "", 1, mUnitScaling);
             addConstant("precision", "Maximum number of total digits", "", 8, mPrecision);
+            addConstant("backgroundcolor", "Background color (red,green,blue)", "", "255,255,255", mBackgroundColor);
+            addConstant("textcolor", "Text color (red,green,blue)", "", "0,50,80", mTextColor);
         }
 
 

--- a/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.hpp
+++ b/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.hpp
@@ -46,6 +46,8 @@ class SignalDisplay : public ComponentC
 {
 
     private:
+        HString mUnit;
+        double mUnitScaling;
 
     public:
         static Component *Creator()
@@ -57,6 +59,8 @@ class SignalDisplay : public ComponentC
         {
             //Add ports to the component
             addInputVariable("in","","",0.0);
+            addConstant("unit","Unit","", mUnit);
+            addConstant("unitscaling", "Unit scaling (from SI unit)", "", 1, mUnitScaling);
         }
 
 

--- a/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.xml
+++ b/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay.xml
@@ -7,5 +7,8 @@
         <ports>
             <port x="0.0" y="0.5" a="0" name="in"/>
         </ports>
+	<animation>
+            <icon userpath="SignalDisplay_base.svg"/>
+	</animation>
     </modelobject>
 </hopsanobjectappearance>

--- a/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay_base.svg
+++ b/componentLibraries/defaultLibrary/Signal/Animation/SignalDisplay_base.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="88.375"
+   height="35.375"
+   id="svg4568"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   version="1.0"
+   sodipodi:docname="SignalDisplay_base.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs4570">
+    <linearGradient
+       id="linearGradient3774">
+      <stop
+         id="stop3776"
+         offset="0"
+         style="stop-color:#191919;stop-opacity:1;" />
+      <stop
+         style="stop-color:#505050;stop-opacity:1;"
+         offset="0.70597875"
+         id="stop3778" />
+      <stop
+         id="stop3780"
+         offset="1"
+         style="stop-color:#969696;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3990">
+      <stop
+         style="stop-color:#191919;stop-opacity:1;"
+         offset="0"
+         id="stop3992" />
+      <stop
+         id="stop3772"
+         offset="0.83561641"
+         style="stop-color:#505050;stop-opacity:1;" />
+      <stop
+         style="stop-color:#969696;stop-opacity:1;"
+         offset="1"
+         id="stop3994" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3950">
+      <stop
+         style="stop-color:#454545;stop-opacity:1;"
+         offset="0"
+         id="stop3952" />
+      <stop
+         style="stop-color:#e7e7e7;stop-opacity:1;"
+         offset="1"
+         id="stop3954" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective4576" />
+    <inkscape:perspective
+       id="perspective3635"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3931"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3614"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3950"
+       id="linearGradient3966"
+       x1="-9.327692"
+       y1="29.470081"
+       x2="64.886086"
+       y2="29.470081"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3990"
+       id="linearGradient3996"
+       x1="-3.3372149"
+       y1="43.112244"
+       x2="41.252586"
+       y2="-1.303017"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3990"
+       id="linearGradient4030"
+       x1="-8.5167408"
+       y1="48.217121"
+       x2="45.654873"
+       y2="-6.1801238"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3950-9"
+       id="linearGradient3784-1"
+       x1="331.57333"
+       y1="295.89786"
+       x2="419.94833"
+       y2="295.89786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-7,3.5)" />
+    <linearGradient
+       id="linearGradient3950-9">
+      <stop
+         style="stop-color:#454545;stop-opacity:1;"
+         offset="0"
+         id="stop3952-6" />
+      <stop
+         style="stop-color:#e7e7e7;stop-opacity:1;"
+         offset="1"
+         id="stop3954-6" />
+    </linearGradient>
+    <linearGradient
+       y2="295.89786"
+       x2="419.94833"
+       y1="295.89786"
+       x1="331.57333"
+       gradientTransform="translate(-331.57333,-278.21036)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3801"
+       xlink:href="#linearGradient3950-9"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-58.243588"
+     inkscape:cy="-2.3304185"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata4573">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-324.5625,-281.71875)" />
+</svg>


### PR DESCRIPTION
Resolves #1968.

The display components now has parameters for description, unit, unit scaling, precision, background color and text color.

Right now only decimal number format is supported, with a precision setting that limits the maximum length of the string (mostly for cosmetic reasons). I am not sure if we need scientific output format as well?