### PR TITLE
Issue 1976 filter individual variables with log only

### DIFF
--- a/HopsanCLI/ModelUtilities.cpp
+++ b/HopsanCLI/ModelUtilities.cpp
@@ -24,12 +24,8 @@
 
 //!
 //! @file   ModelUtilities.cpp
-//! @author FluMeS
-//! @date   2012-05-30
-//!
 //! @brief Contains model specific helpfunctions for CLI
 //!
-//$Id$
 
 #include <iostream>
 #include <fstream>

--- a/HopsanCLI/ModelUtilities.h
+++ b/HopsanCLI/ModelUtilities.h
@@ -47,7 +47,8 @@ void printComponentHierarchy(hopsan::ComponentSystem *pSystem, std::string prefi
 
 // ===== Save Functions =====
 enum SaveResults {Final, Full};
-void saveResults(hopsan::ComponentSystem *pSys, const std::string &rFileName, const SaveResults howMany, std::string prefix="", std::ofstream *pFile=0);
+void saveResults(hopsan::ComponentSystem *pSys, const std::string &rFileName, const SaveResults howMany, const std::vector<std::string> &includeFilter,
+                 std::string prefix="", std::ofstream *pFile=0);
 void transposeCSVresults(const std::string &rFileName);
 void exportParameterValuesToCSV(const std::string &rFileName, hopsan::ComponentSystem* pSystem, std::string prefix="", std::ofstream *pFile=0);
 

--- a/HopsanCLI/ModelUtilities.h
+++ b/HopsanCLI/ModelUtilities.h
@@ -24,9 +24,6 @@
 
 //!
 //! @file   ModelUtilities.h
-//! @author FluMeS
-//! @date   2012-05-30
-//!
 //! @brief Contains model specific helpfunctions for CLI
 //!
 //$Id$

--- a/HopsanCLI/main.cpp
+++ b/HopsanCLI/main.cpp
@@ -24,12 +24,8 @@
 
 //!
 //! @file   HopsanCLI/main.cpp
-//! @author FluMeS
-//! @date   2011-03-28
-//!
 //! @brief The HopsanCLI main file
 //!
-//$Id$
 
 #include <iostream>
 #include <string>
@@ -337,7 +333,7 @@ int main(int argc, char *argv[])
             for (size_t i=0; i<types.size(); ++i)
             {
                 Component *pComp = gHopsanCore.createComponent(types[i].c_str());
-                nErrors += gHopsanCore.getNumErrorMessages() + gHopsanCore.getNumFatalMessages(); + gHopsanCore.getNumWarningMessages();
+                nErrors += gHopsanCore.getNumErrorMessages() + gHopsanCore.getNumFatalMessages();// + gHopsanCore.getNumWarningMessages();
                 printWaitingMessages(printDebugOption.getValue(), silentOption.getValue());
                 gHopsanCore.removeComponent(pComp);
             }


### PR DESCRIPTION
Related to #1976 

Enable filtering csv results on individual variables, the entire port is still logged in memory, but only the desired variables are written to file. Entire ports can still be specified like it used to work.

Test command-line:
`./hopsancli -m ../../hopsan-code/Models/Example\ Models/Sub\ System\ Example.hmf -s hmf --logonly Servo1\$Gain\#out,Pulse\#out\#Value,Servo1\$Cylinder_C\#P3\#Position,Servo1\$Translational_Mass\#P2 --resultsFullCSV out.csv`