### PR TITLE
Auto copy dependencies runtime dll to bin directory on Windows using …

### DIFF
--- a/HopsanGenerator/HopsanGenerator.pro
+++ b/HopsanGenerator/HopsanGenerator.pro
@@ -15,18 +15,6 @@ QT += core xml
 #--------------------------------------------------------
 # Set the FMILibrary include and library paths
 include($${PWD}/../dependencies/fmilibrary.pri)
-# On Windows, since RPATH is ignored by LoadLibrary(), copy the fmi library file to the bin directory after build,
-# so that libHopsanGenerator may find it when loaded at runtime
-# (this is only necessary for dev builds, on release all DLLs will be copied anyway)
-# TODO: It would be better if this could be handled by the fmilibrary.pri somehow
-win32 {
-  src_file = $$quote($${PWD}/../dependencies/fmilibrary/lib/libfmilib_shared.dll)
-  dst_dir = $$quote($${DESTDIR})
-  # Replace slashes in paths with backslashes for Windows
-  src_file ~= s,/,\\,g
-  dst_dir ~= s,/,\\,g
-  QMAKE_POST_LINK *= $$QMAKE_COPY $${src_file} $${dst_dir}
-}
 
 #--------------------------------------------------
 # Add the include path to our self, (HopsanGenerator)

--- a/dependencies/discount.pri
+++ b/dependencies/discount.pri
@@ -38,7 +38,15 @@ have_local_libmarkdown() {
   macx {
     # TODO: I am unable to get RPATH to work on osx, so ugly copying the dylib. file for now
     QMAKE_POST_LINK += $$QMAKE_COPY $$quote($${discount_lib}/lib$${libname}$${dbg_ext}.dylib) $$quote($${PWD}/../bin) $$escape_expand(\\n\\t)
-  } else {
+  } win32 {
+    # On Windows, since RPATH is ignored by LoadLibrary(), copy the library file to the bin directory after build instead
+    src_file = $$quote($${discount_home}/bin/lib$${libname}.dll)
+    dst_dir = $$quote($${PWD}/../bin)
+    # Replace slashes in paths with backslashes for Windows
+    src_file ~= s,/,\\,g
+    dst_dir ~= s,/,\\,g
+    QMAKE_POST_LINK += $$QMAKE_COPY $${src_file} $${dst_dir} $$escape_expand(\\n\\t)
+  }  else {
     # Note! The RPATH is absolute and only meant for dev builds in the IDE, on release runtime paths should be stripped
     QMAKE_RPATHDIR *= $${discount_lib}
   }

--- a/dependencies/fmilibrary.pri
+++ b/dependencies/fmilibrary.pri
@@ -7,6 +7,14 @@ macx {
   QMAKE_RPATHDIR *= $${fmi_home}/lib
   # TODO: I am unable to get RPATH to work on osx, so ugly copying the dylib file for now
   QMAKE_POST_LINK += $$QMAKE_COPY $$quote($${fmi_home}/lib/libfmilib_shared.dylib) $$quote($${PWD}/../bin) $$escape_expand(\\n\\t)
+} win32 {
+  # On Windows, since RPATH is ignored by LoadLibrary(), copy the library file to the bin directory after build instead
+  src_file = $$quote($${fmi_home}/lib/libfmilib_shared.dll)
+  dst_dir = $$quote($${PWD}/../bin)
+  # Replace slashes in paths with backslashes for Windows
+  src_file ~= s,/,\\,g
+  dst_dir ~= s,/,\\,g
+  QMAKE_POST_LINK += $$QMAKE_COPY $${src_file} $${dst_dir} $$escape_expand(\\n\\t)
 } else {
   # Note! The RPATH is absolute and only meant for dev builds in the IDE, on release runtime paths should be stripped
   QMAKE_RPATHDIR *= $${fmi_home}/lib

--- a/dependencies/hdf5.pri
+++ b/dependencies/hdf5.pri
@@ -36,9 +36,23 @@ defineTest(have_hdf5) {
 have_local_hdf5() {
   INCLUDEPATH *= $${homedir}/include
   LIBS *= -L$${libdir} -L$${bindir} -lhdf5$${dbg_ext} -lhdf5_cpp$${dbg_ext}
-  # Note! The RPATH is absolute and only meant for dev builds in the IDE, on release runtime paths should be stripped
-  QMAKE_RPATHDIR *= $${libdir}
-  QMAKE_RPATHDIR *= $${bindir}
+  win32 {
+     # On Windows, since RPATH is ignored by LoadLibrary(), copy the library file to the bin directory after build instead
+     src_file1 = $$quote($${homedir}/bin/hdf5$${dbg_ext}.dll)
+     src_file2 = $$quote($${homedir}/bin/hdf5_cpp$${dbg_ext}.dll)
+     dst_dir = $$quote($${PWD}/../bin)
+     # Replace slashes in paths with backslashes for Windows
+     src_file1 ~= s,/,\\,g
+     src_file2 ~= s,/,\\,g
+     dst_dir ~= s,/,\\,g
+     QMAKE_POST_LINK += $$QMAKE_COPY $${src_file1} $${dst_dir} $$escape_expand(\\n\\t)
+     QMAKE_POST_LINK += $$QMAKE_COPY $${src_file2} $${dst_dir} $$escape_expand(\\n\\t)
+   } else {
+     # Note! The RPATH is absolute and only meant for dev builds in the IDE, on release runtime paths should be stripped
+     QMAKE_RPATHDIR *= $${libdir}
+     QMAKE_RPATHDIR *= $${bindir}
+   }
+
   message(Found local HDF5)
 } else:have_system_hdf5() {
   unix:system(pkg-config --exists hdf5) {

--- a/dependencies/qwt.pri
+++ b/dependencies/qwt.pri
@@ -44,6 +44,13 @@ have_local_qwt() {
   macx {
     # TODO: I am unable to get RPATH to work on osx, so ugly copying the dylib. file for now
     QMAKE_POST_LINK += $$QMAKE_COPY $$quote($${qwt_lib}/lib$${libname}$${dbg_ext}.6.dylib) $$quote($${PWD}/../bin) $$escape_expand(\\n\\t)
+  } win32 {
+    src_file = $$quote($${qwt_home}/lib/$${libname}$${dbg_ext}.dll)
+    dst_dir = $$quote($${PWD}/../bin)
+    # Replace slashes in paths with backslashes for Windows
+    src_file ~= s,/,\\,g
+    dst_dir ~= s,/,\\,g
+    QMAKE_POST_LINK += $$QMAKE_COPY $${src_file} $${dst_dir} $$escape_expand(\\n\\t)
   } else {
     # Note! The RPATH is absolute and only meant for dev builds in the IDE, on releaspe runtime paths should be stripped
     QMAKE_RPATHDIR *= $${qwt_lib}

--- a/dependencies/zeromq.pri
+++ b/dependencies/zeromq.pri
@@ -13,10 +13,17 @@ have_local_zeromq() {
   macx {
     # TODO: I am unable to get RPATH to work on osx, so ugly copying the dylib. file for now
     QMAKE_POST_LINK += $$QMAKE_COPY $$quote($${zeromq_lib}/libzmq$${dbg_ext}*.dylib) $$quote($${PWD}/../bin) $$escape_expand(\\n\\t)
+  } win32 {
+    # On Windows, since RPATH is ignored by LoadLibrary(), copy the library file to the bin directory after build instead
+    src_file = $$quote($${zeromq_home}/bin/libzmq$${dbg_ext}.dll)
+    dst_dir = $$quote($${PWD}/../bin)
+    # Replace slashes in paths with backslashes for Windows
+    src_file ~= s,/,\\,g
+    dst_dir ~= s,/,\\,g
+    QMAKE_POST_LINK += $$QMAKE_COPY $${src_file} $${dst_dir} $$escape_expand(\\n\\t)
   } else {
     # Note! The RPATH is absolute and only meant for dev builds in the IDE, on release runtime paths should be stripped
     unix:QMAKE_RPATHDIR *= $${zeromq_lib}
-    win32:QMAKE_RPATHDIR *= $${zeromq_bin}
   }
   message(Found local ZeroMQ)
 } else:have_system_zeromq() {


### PR DESCRIPTION
…qmake build system

Automatic PATH setup no longer seem to work when launching inside QtCreator