### PR TITLE
Load text files internally in Hopsan with HCOM edit command

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -5566,7 +5566,15 @@ void HcomHandler::executeEditCommand(const QString cmd)
     QString path = args[0];
     path.remove("\"");
     path.prepend(mPwd+"/");
-    QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+
+    QString suffix = QFileInfo(path).suffix();
+    QStringList textFileSuffixes = QStringList() << "hcom" << "hpp" << "cpp" << "h" << "c" << "cc" << "cci" << "xml" << "plo" << "csv" << "txt";
+    if(textFileSuffixes.contains(suffix)) {
+        gpModelHandler->loadTextFile(path);
+    }
+    else {
+        QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+    }
 }
 
 


### PR DESCRIPTION
HCOM "edit" command shall open supported files in Hopsan text editor instead of external editor (which quite often is not found anyway).