### PR TITLE
Correct units and consistent default values for leakage coefficients

### DIFF
--- a/componentLibraries/defaultLibrary/Hydraulic/LinearActuators/HydraulicCylinderC.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/LinearActuators/HydraulicCylinderC.hpp
@@ -95,14 +95,14 @@ class HydraulicCylinderC : public ComponentC
             mpP3 = addPowerPort("P3", "NodeMechanic");
 
             // Add input variables
-            addInputVariable("A_1", "Piston Area 1", "m^2", 0.001, &mpA1);
-            addInputVariable("A_2", "Piston Area 2", "m^2", 0.001, &mpA2);
+            addInputVariable("A_1", "Piston area 1", "m^2", 0.001, &mpA1);
+            addInputVariable("A_2", "Piston area 2", "m^2", 0.001, &mpA2);
             addInputVariable("s_l", "Stroke", "m", 1.0, &mpSl);
-            addInputVariable("V_1", "Dead Volume in Chamber 1", "m^3", 0.0003, &mpV01);
-            addInputVariable("V_2", "Dead Volume in Chamber 2", "m^3", 0.0003, &mpV02);
-            addInputVariable("B_p", "Viscous Friction", "Ns/m", 1000.0, &mpBp);
-            addInputVariable("Beta_e", "Bulk Modulus", "Pa", 1000000000.0, &mpBetae);
-            addInputVariable("c_leak", "Leakage Coefficient", "", 0.00000000001, &mpCLeak);
+            addInputVariable("V_1", "Dead volume in chamber 1", "m^3", 0.0003, &mpV01);
+            addInputVariable("V_2", "Dead volume in chamber 2", "m^3", 0.0003, &mpV02);
+            addInputVariable("B_p", "Viscous friction", "Ns/m", 1000.0, &mpBp);
+            addInputVariable("Beta_e", "Bulk modulus", "Pa", 1000000000.0, &mpBetae);
+            addInputVariable("c_leak", "Leakage coefficient", "(m^3/s)/Pa", 0.00000000001, &mpCLeak);
 
             addOutputVariable("q_leak", "Internal Leakage Flow", "Flow", 0, &mpQLeak);
         }

--- a/componentLibraries/defaultLibrary/Hydraulic/LinearActuators/HydraulicFourChamberPiston.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/LinearActuators/HydraulicFourChamberPiston.hpp
@@ -82,23 +82,23 @@ class HydraulicFourChamberPiston : public ComponentC
             mpP5 = addPowerPort("P5", "NodeMechanic");
 
             //Register changeable parameters to the HOPSAN++ core
-            addInputVariable("A_1", "Piston Area 1", "m^2", 0.001, &mpA1);
-            addInputVariable("A_2", "Piston Area 2", "m^2", 0.001, &mpA2);
-            addInputVariable("A_3", "Piston Area 3", "m^2", 0.001, &mpA3);
-            addInputVariable("A_4", "Piston Area 4", "m^2", 0.001, &mpA4);
+            addInputVariable("A_1", "Piston area 1", "m^2", 0.001, &mpA1);
+            addInputVariable("A_2", "Piston area 2", "m^2", 0.001, &mpA2);
+            addInputVariable("A_3", "Piston area 3", "m^2", 0.001, &mpA3);
+            addInputVariable("A_4", "Piston area 4", "m^2", 0.001, &mpA4);
             addInputVariable("s_l", "Stroke", "m", 1.0, &mpSl);
-            addInputVariable("V_1", "Dead Volume in Chamber 1", "m^3", 0.0003, &mpV01);
-            addInputVariable("V_2", "Dead Volume in Chamber 2", "m^3", 0.0003, &mpV02);
-            addInputVariable("V_3", "Dead Volume in Chamber 3", "m^3", 0.0003, &mpV03);
-            addInputVariable("V_4", "Dead Volume in Chamber 4", "m^3", 0.0003, &mpV04);
-            addInputVariable("B_p", "Viscous Friction", "Ns/m", 1000.0, &mpBp);
-            addInputVariable("Beta_e", "Bulk Modulus", "Pa", 1000000000.0, &mpBetae);
-            addInputVariable("c_leak12", "Leakage Coefficient Between Chamber 1 and 2", "", 0.00000000001, &mpCLeak12);
-            addInputVariable("c_leak13", "Leakage Coefficient Between Chamber 1 and 3", "", 0, &mpCLeak13);
-            addInputVariable("c_leak14", "Leakage Coefficient Between Chamber 1 and 4", "", 0.00000000001, &mpCLeak14);
-            addInputVariable("c_leak23", "Leakage Coefficient Between Chamber 2 and 3", "", 0, &mpCLeak23);
-            addInputVariable("c_leak24", "Leakage Coefficient Between Chamber 2 and 4", "", 0, &mpCLeak24);
-            addInputVariable("c_leak34", "Leakage Coefficient Between Chamber 3 and 4", "", 0.00000000001, &mpCLeak34);
+            addInputVariable("V_1", "Dead volume in chamber 1", "m^3", 0.0003, &mpV01);
+            addInputVariable("V_2", "Dead volume in chamber 2", "m^3", 0.0003, &mpV02);
+            addInputVariable("V_3", "Dead volume in chamber 3", "m^3", 0.0003, &mpV03);
+            addInputVariable("V_4", "Dead volume in chamber 4", "m^3", 0.0003, &mpV04);
+            addInputVariable("B_p", "Viscous friction", "Ns/m", 1000.0, &mpBp);
+            addInputVariable("Beta_e", "Bulk modulus", "Pa", 1000000000.0, &mpBetae);
+            addInputVariable("c_leak12", "Leakage coefficient between chamber 1 and 2", "(m^3/s)/Pa", 0.00000000001, &mpCLeak12);
+            addInputVariable("c_leak13", "Leakage coefficient between chamber 1 and 3", "(m^3/s)/Pa", 0, &mpCLeak13);
+            addInputVariable("c_leak14", "Leakage coefficient between chamber 1 and 4", "(m^3/s)/Pa", 0.00000000001, &mpCLeak14);
+            addInputVariable("c_leak23", "Leakage coefficient between chamber 2 and 3", "(m^3/s)/Pa", 0, &mpCLeak23);
+            addInputVariable("c_leak24", "Leakage coefficient between chamber 2 and 4", "(m^3/s)/Pa", 0, &mpCLeak24);
+            addInputVariable("c_leak34", "Leakage coefficient between chamber 3 and 4", "(m^3/s)/Pa", 0.00000000001, &mpCLeak34);
         }
 
         void initialize()

--- a/componentLibraries/defaultLibrary/Hydraulic/LinearActuators/HydraulicSpringLoadedPistonC.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/LinearActuators/HydraulicSpringLoadedPistonC.hpp
@@ -83,15 +83,15 @@ class HydraulicSpringLoadedPistonC : public ComponentC
 
 
             //Register changeable parameters to the HOPSAN++ core
-            addInputVariable("A_1", "Piston Area 1", "m^2", 0.001, &mpA1);
-            addInputVariable("A_2", "Piston Area 2", "m^2", 0.001, &mpA2);
+            addInputVariable("A_1", "Piston area 1", "m^2", 0.001, &mpA1);
+            addInputVariable("A_2", "Piston area 2", "m^2", 0.001, &mpA2);
             addInputVariable("s_l", "Stroke", "m", 1.0, &mpSl);
-            addInputVariable("F_s", "Spring Force", "N", 1000.0, &mpFs);
-            addInputVariable("V_1", "Dead Volume in Chamber 1", "m^3", 0.0003, &mpV01);
-            addInputVariable("V_2", "Dead Volume in Chamber 2", "m^3", 0.0003, &mpV02);
-            addInputVariable("B_p", "Viscous Friction", "Ns/m", 1000.0, &mpBp);
-            addInputVariable("Beta_e", "Bulk Modulus", "Pa", 1000000000.0, &mpBetae);
-            addInputVariable("c_leak", "Leakage Coefficient", "", 0.00000000001, &mpCLeak);
+            addInputVariable("F_s", "Spring force", "N", 1000.0, &mpFs);
+            addInputVariable("V_1", "Dead volume in chamber 1", "m^3", 0.0003, &mpV01);
+            addInputVariable("V_2", "Dead volume in chamber 2", "m^3", 0.0003, &mpV02);
+            addInputVariable("B_p", "Viscous friction", "Ns/m", 1000.0, &mpBp);
+            addInputVariable("Beta_e", "Bulk modulus", "Pa", 1000000000.0, &mpBetae);
+            addInputVariable("c_leak", "Leakage coefficient", "(m^3/s)/Pa", 0.00000000001, &mpCLeak);
         }
 
 

--- a/componentLibraries/defaultLibrary/Hydraulic/MachineParts/HydraulicPumpPiston.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/MachineParts/HydraulicPumpPiston.hpp
@@ -77,13 +77,13 @@ class HydraulicPumpPiston : public ComponentC
             mpP3 = addPowerPort("P3", "NodeMechanic");
 
             //Register changeable parameters to the HOPSAN++ core
-            addInputVariable("A_1", "Piston Area", "m^2", 0.001, &mpA1);
+            addInputVariable("A_1", "Piston area", "m^2", 0.001, &mpA1);
             addInputVariable("s_l", "Stroke", "m", 1.0, &mpSl);
-            addInputVariable("V_1", "Dead Volume in Chamber 1", "m^3", 0.0003, &mpV01);
-            addInputVariable("B_p", "Viscous Friction", "Ns/m", 1000.0, &mpBp);
-            addInputVariable("Beta_e", "Bulk Modulus", "Pa", 1000000000.0, &mpBetae);
-            addInputVariable("c_leak", "Leakage Coefficient", "", 0.00000000001, &mpCLeak);
-            addInputVariable("F_0", "Spring Force", "N", 1000, &mpF0);
+            addInputVariable("V_1", "Dead volume in chamber 1", "m^3", 0.0003, &mpV01);
+            addInputVariable("B_p", "Viscous friction", "Ns/m", 1000.0, &mpBp);
+            addInputVariable("Beta_e", "Bulk modulus", "Pa", 1000000000.0, &mpBetae);
+            addInputVariable("c_leak", "Leakage coefficient", "(m^3/s)/Pa", 0.00000000001, &mpCLeak);
+            addInputVariable("F_0", "Spring force", "N", 1000, &mpF0);
         }
 
 

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicFixedDisplacementMotorQ.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicFixedDisplacementMotorQ.hpp
@@ -66,9 +66,9 @@ namespace hopsan {
         void configure()
         {
             addInputVariable("D_m", "Displacement", "m^3/rev", 0.00005, &mpDm);
-            addInputVariable("B_m", "Viscous Friction", "Nm/rad", 0.0, &mpBm);
-            addInputVariable("C_lm", "Leakage Coefficient", "", 0.0, &mpClm);
-            addInputVariable("J_m", "Inertia Load", "kg*m^2", 0.1, &mpJ);
+            addInputVariable("B_m", "Viscous friction", "Nm/rad", 0.0, &mpBm);
+            addInputVariable("C_lm", "Leakage coefficient", "(m^3/s)/Pa", 1e-12, &mpClm);
+            addInputVariable("J_m", "Inertia load", "kg*m^2", 0.1, &mpJ);
 
             mpP1 = addPowerPort("P1", "NodeHydraulic");
             mpP2 = addPowerPort("P2", "NodeHydraulic");

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicFixedDisplacementPump.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicFixedDisplacementPump.hpp
@@ -64,7 +64,7 @@ namespace hopsan {
             addOutputVariable("a", "Angle", "Angle", 0.0, &mpND_a);
             addInputVariable("n_p", "Angular Velocity", "AngularVelocity", 250.0, &mpN);
             addInputVariable("D_p", "Displacement", "Displacement", 0.00005, &mpDp);
-            addInputVariable("C_lp", "Leakage Coefficient", "(m^3/s)/Pa", 0.0, &mpClp);
+            addInputVariable("C_lp", "Leakage coefficient", "(m^3/s)/Pa", 1e-12, &mpClp);
         }
 
 

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicMachineC.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicMachineC.hpp
@@ -78,7 +78,7 @@ namespace hopsan {
             addInputVariable("V_1", "Volume at port 1", "m^3", 0.005, &mpV1);
             addInputVariable("V_2", "Volume at port 2", "m^3", 0.005, &mpV2);
             addInputVariable("D_m", "Displacement", "m^3/rev", 0.00005, &mpDm);
-            addInputVariable("C_lm", "Leakage coefficient", "", 0.0, &mpClm);
+            addInputVariable("C_lm", "Leakage coefficient", "(m^3/s)/Pa", 1e-12, &mpClm);
             addInputVariable("B_m", "Viscous friction coefficient", "Nms/rad", 0.0, &mpBm);
 
             addConstant("J_em", "Equivalent load of inertia", "kg*m^2", 1, je);

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicPressureControlledPump.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicPressureControlledPump.hpp
@@ -80,7 +80,7 @@ namespace hopsan {
             addInputVariable("l_p", "Regulator inductance at nominal pressure", "", 70000000, &mpLp);
             addInputVariable("r_p", "Static characteristic at nominal pressure", "", 1000000000, &mpRp);
             addInputVariable("omega_p1", "Lead frequency of regulator", "AngularVelocity", 200, &mpWp1);
-            addInputVariable("C_lp", "Leakage coefficient of pump", "", 0.000000000001, &mpClp);
+            addInputVariable("C_lp", "Leakage coefficient", "(m^3/s)/Pa", 1e-12, &mpClp);
             addInputVariable("tao_v", "Time constant of control valve", "s", 0.001, &mpTaov);
             addInputVariable("t_p", "Time from min to full displacement", "s", 0.15, &mpTp);
             addInputVariable("t_m", "Time from full to min displacement", "s", 0.12, &mpTm);

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicVariableDisplacementMotorQ.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicVariableDisplacementMotorQ.hpp
@@ -68,10 +68,10 @@ namespace hopsan {
             mpP3 = addPowerPort("P3", "NodeMechanicRotational");
 
             addInputVariable("D_m", "Displacement", "m^3/rev", 0.00005, &mpDm);
-            addInputVariable("B_m", "Viscous Friction", "Nms/rad", 0.0, &mpBm);
-            addInputVariable("C_im", "Leakage Coefficient", "", 0.0, &mpClm);
-            addInputVariable("J_m", "Inertia Load", "kgm^2", 0.1, &mpJ);
-            addInputVariable("eps", "Displacement Position", "", 1.0, &mpEps);
+            addInputVariable("B_m", "Viscous friction", "Nms/rad", 0.0, &mpBm);
+            addInputVariable("C_im", "Leakage coefficient", "(m^3/s)/Pa", 1e-12, &mpClm);
+            addInputVariable("J_m", "Inertia load", "kgm^2", 0.1, &mpJ);
+            addInputVariable("eps", "Displacement position", "", 1.0, &mpEps);
         }
 
 

--- a/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicVariableDisplacementPump.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Pumps&Motors/HydraulicVariableDisplacementPump.hpp
@@ -60,9 +60,9 @@ namespace hopsan {
 
             addOutputVariable("a", "Angle", "", 0.0, &mpA);
             addInputVariable("eps", "Displacement setting", "", 1.0, &mpEps);
-            addInputVariable("omega_p", "Angular Velocity", "AngularVelocity", 50.0, &mpN);
+            addInputVariable("omega_p", "Angular velocity", "AngularVelocity", 50.0, &mpN);
             addInputVariable("D_p", "Displacement", "m^3/rev", 0.00005, &mpDp);
-            addInputVariable("K_cp", "Leakage Coefficient", "(m^3/s)/Pa", 0.0, &mpKcp);
+            addInputVariable("K_cp", "Leakage coefficient", "(m^3/s)/Pa", 1e-12, &mpKcp);
         }
 
 


### PR DESCRIPTION
- Added missing unit to leakage parameter for all pump/motor components
- Set default value for leakage parameter to 1e-12 for all pump/motor components

Resolves #2025.