### PR TITLE
Consistent default parameter for density (870 kg/m^3)

### DIFF
--- a/componentLibraries/defaultLibrary/Hydraulic/HydroDynamicComponents/HydraulicCentrifugalPump.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/HydroDynamicComponents/HydraulicCentrifugalPump.hpp
@@ -163,7 +163,7 @@ public:
             addInputVariable("beta2", "Outlet flow angle", "rad", \
 1.57,&mpbeta2);
             addInputVariable("Ap", "outlet flow area", "m2", 0.001,&mpAp);
-            addInputVariable("rho", "Fluid density", "kg/m2", 860,&mprho);
+            addInputVariable("rho", "Fluid density", "kg/m2", 870, &mprho);
             addInputVariable("Kcp", "Leakage coeff", "m3/s/Pa", \
 1.e-11,&mpKcp);
             addInputVariable("Bp", "Visc friction coeff", "Nm/rad/s", \

--- a/componentLibraries/defaultLibrary/Hydraulic/HydroDynamicComponents/HydraulicCentrifugalPumpJ.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/HydroDynamicComponents/HydraulicCentrifugalPumpJ.hpp
@@ -178,7 +178,7 @@ public:
             addInputVariable("beta2", "Outlet flow angle", "rad", \
 1.57,&mpbeta2);
             addInputVariable("Ap", "outlet flow area", "m2", 0.001,&mpAp);
-            addInputVariable("rho", "Fluid density", "kg/m2", 860,&mprho);
+            addInputVariable("rho", "Fluid density", "kg/m2", 870, &mprho);
             addInputVariable("Kcp", "Leakage coeff", "m3/s/Pa", \
 1.e-11,&mpKcp);
             addInputVariable("Bp", "Visc friction coeff", "Nm/rad/s", \

--- a/componentLibraries/defaultLibrary/Hydraulic/MachineParts/HydraulicValvePlate.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/MachineParts/HydraulicValvePlate.hpp
@@ -82,7 +82,7 @@ namespace hopsan {
             addInputVariable("R_f", "Radius to groove center line", "m", 0.03, &mpRf);
             addInputVariable("theta_1", "Angle 1", "deg", 6, &mpTh1);
             addInputVariable("theta_2", "Angle 2", "deg", 90, &mpTh2);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("movement", "Movement", "AngularVelocity", 160, &mpMovement);
             addOutputVariable("DEBUG1", "DEBUG1", "");
             addOutputVariable("DEBUG2", "DEBUG1", "");

--- a/componentLibraries/defaultLibrary/Hydraulic/Restrictors/HydraulicOrificeG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Restrictors/HydraulicOrificeG.hpp
@@ -151,7 +151,7 @@ public:
         //Add inputVariables to the component
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "Dynamic viscosity ", "m", \
 0.12,&mpvisc);
             addInputVariable("Ao", "Orifice area", "m2", 1.e-7,&mpAo);

--- a/componentLibraries/defaultLibrary/Hydraulic/Restrictors/HydraulicTurbulentOrifice.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Restrictors/HydraulicTurbulentOrifice.hpp
@@ -66,7 +66,7 @@ namespace hopsan {
 
             addInputVariable("A", "Area", "Area", 0.00001, &mpA);
             addInputVariable("C_q", "Flow coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
         }
 
 

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicCounterBalanceValveG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicCounterBalanceValveG.hpp
@@ -178,7 +178,7 @@ public:
             addInputVariable("pref","Reference pressure","Pa",1.e6,&mppref);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "viscosity ", "Ns/m2", 0.03,&mpvisc);
             addInputVariable("Dv", "Spool diameter", "m", 0.03,&mpDv);
             addInputVariable("frac", "Fraction of spool opening", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicOrificeCheckValveG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicOrificeCheckValveG.hpp
@@ -157,7 +157,7 @@ diameter","m",0.3,&mpdh);
             addInputVariable("lo","Length","m",0.001,&mplo);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "Dynamic viscosity ", "m", \
 0.12,&mpvisc);
             addInputVariable("Cdt", "Turbulent flow coefficient.", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureCompensatingValveG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureCompensatingValveG.hpp
@@ -176,7 +176,7 @@ public:
             addInputVariable("pref","Reference pressure","Pa",1.e6,&mppref);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "viscosity ", "Ns/m2", 0.03,&mpvisc);
             addInputVariable("Dv", "Spool diameter", "m", 0.03,&mpDv);
             addInputVariable("frac", "Fraction of spool opening", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureControlValveG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureControlValveG.hpp
@@ -191,7 +191,7 @@ public:
             addInputVariable("pref","Reference pressure","Pa",1.e6,&mppref);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "viscosity ", "Ns/m2", 0.03,&mpvisc);
             addInputVariable("Dv", "Spool diameter", "m", 0.01,&mpDv);
             addInputVariable("frac", "Fraction of spool opening", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureControlledPumpG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureControlledPumpG.hpp
@@ -198,7 +198,7 @@ public:
             addInputVariable("speed","Pump speed","rad/sec",157,&mpspeed);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("qmin", "Min flow at nom speed", "m3/s", \
 0.,&mpqmin);
             addInputVariable("Dp", "Max pump displacement", "m3", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureReducingValveG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureReducingValveG.hpp
@@ -159,7 +159,7 @@ public:
             addInputVariable("pref","Reference pressure","Pa",1.e7,&mppref);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "viscosity ", "Ns/m2", 0.03,&mpvisc);
             addInputVariable("Dv", "Spool diameter", "m", 0.01,&mpDv);
             addInputVariable("frac", "Fraction of spool opening", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureRelief2ValveG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureRelief2ValveG.hpp
@@ -167,7 +167,7 @@ public:
             addInputVariable("pref","Reference pressure","Pa",1.e7,&mppref);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "viscosity ", "Ns/m2", 0.03,&mpvisc);
             addInputVariable("Dv", "Spool diameter", "m", 0.01,&mpDv);
             addInputVariable("Bv", "Damping", "N/(m s)", 1000,&mpBv);

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureReliefValveG.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicPressureReliefValveG.hpp
@@ -161,7 +161,7 @@ public:
             addInputVariable("pref","Reference pressure","Pa",1.e7,&mppref);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "viscosity ", "Ns/m2", 0.03,&mpvisc);
             addInputVariable("Dv", "Spool diameter", "m", 0.01,&mpDv);
             addInputVariable("frac", "Fraction of spool opening", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicSlitOrifice.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicSlitOrifice.hpp
@@ -154,7 +154,7 @@ public:
 hight","m2",0.0001,&mpb);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("visc", "Dynamic viscosity ", "m", \
 0.12,&mpvisc);
             addInputVariable("Ao", "Orifice area", "m2", 1.e-7,&mpAo);

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicValve33.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicValve33.hpp
@@ -173,7 +173,7 @@ public:
             addInputVariable("xv","Spool position","m",0.,&mpxv);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("Cq", "Flow coefficient.", "", 0.67,&mpCq);
             addInputVariable("Sd", "spool diameter", "m", 0.01,&mpSd);
             addInputVariable("Frap", "Spool cricle fraction(P-A)", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicValve43.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicValve43.hpp
@@ -223,7 +223,7 @@ public:
             addInputVariable("xv","Spool position","m",0.,&mpxv);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("Cq", "Flow coefficient.", "", 0.67,&mpCq);
             addInputVariable("Sd", "spool diameter", "m", 0.01,&mpSd);
             addInputVariable("Frap", "Spool circle fraction(P-A)", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicValve43LS.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicValve43LS.hpp
@@ -234,7 +234,7 @@ public:
             addInputVariable("xv","Spool position","m",0.,&mpxv);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("Cq", "Flow coefficient.", "", 0.67,&mpCq);
             addInputVariable("Sd", "spool diameter", "m", 0.01,&mpSd);
             addInputVariable("Frap", "Spool cricle fraction(P-A)", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicValve63OC.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Special/HydraulicValve63OC.hpp
@@ -244,7 +244,7 @@ public:
             addInputVariable("xv","Spool position","m",0.,&mpxv);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("Cq", "Flow coefficient.", "", 0.67,&mpCq);
             addInputVariable("Sd", "spool diameter", "m", 0.015,&mpSd);
             addInputVariable("Frap", "Spool cricle fraction(P-A)", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/DirectionalValves/Hydraulic22DirectionalValve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/DirectionalValves/Hydraulic22DirectionalValve.hpp
@@ -75,7 +75,7 @@ namespace hopsan {
             mpOut = addOutputVariable("xv", "Spool position", "m", 0.0);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f", "Spool Fraction of the Diameter", "-", 1.0, &mpF);
             addInputVariable("x_vmax", "Maximum Spool Displacement", "m", 0.01, &mpXvmax);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/DirectionalValves/Hydraulic32DirectionalValve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/DirectionalValves/Hydraulic32DirectionalValve.hpp
@@ -75,7 +75,7 @@ namespace hopsan {
             addInputVariable("in", "<0.5 (closed), >0.5 (open)", "", 0.0, &mpXvIn);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f", "Spool Fraction of the Diameter", "-", 1.0, &mpF);
             addInputVariable("x_vmax", "Maximum Spool Displacement", "m", 0.01, &mpXvmax);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/DirectionalValves/Hydraulic42DirectionalValve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/DirectionalValves/Hydraulic42DirectionalValve.hpp
@@ -78,7 +78,7 @@ namespace hopsan {
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool circumference that is opening P-A", "-", 1.0, &mpF_pa);
             addInputVariable("f_bt", "Fraction of spool circumference that is opening B-T", "-", 1.0, &mpF_bt);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic22Valve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic22Valve.hpp
@@ -75,7 +75,7 @@ namespace hopsan {
             addOutputVariable("xv", "Spool position", "", 0.0, &mpOut_xv);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f", "Spool Fraction of the Diameter", "-", 1.0, &mpF);
             addInputVariable("x_vmax", "Maximum Spool Displacement", "m", 0.01, &mpXvmax);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic33Valve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic33Valve.hpp
@@ -74,7 +74,7 @@ namespace hopsan {
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool circumference that is opening P-A", "-", 1.0, &mpF_pa);
             addInputVariable("f_at", "Fraction of spool circumference that is opening A-T", "-", 1.0, &mpF_at);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic42Valve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic42Valve.hpp
@@ -76,7 +76,7 @@ namespace hopsan {
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool circumference that is opening P-A", "-", 1.0, &mpF_pa);
             addInputVariable("f_bt", "Fraction of spool circumference that is opening B-T", "-", 1.0, &mpF_bt);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic42Valve2.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic42Valve2.hpp
@@ -80,7 +80,7 @@ namespace hopsan {
 
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool circumference that is opening P-A", "-", 1.0, &mpF_pa);
             addInputVariable("f_pb", "Fraction of spool circumference that is opening P-B", "-", 1.0, &mpF_pb);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic43LoadSensingValve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic43LoadSensingValve.hpp
@@ -84,7 +84,7 @@ namespace hopsan {
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool circumference that is opening P-A", "-", 1.0, &mpF_pa);
             addInputVariable("f_pb", "Fraction of spool circumference that is opening P-B", "-", 1.0, &mpF_pb);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic43Valve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic43Valve.hpp
@@ -79,7 +79,7 @@ namespace hopsan {
 
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool circumference that is opening P-A", "-", 1.0, &mpF_pa);
             addInputVariable("f_pb", "Fraction of spool circumference that is opening P-B", "-", 1.0, &mpF_pb);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic43ValveNeutralSupplyToTank.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic43ValveNeutralSupplyToTank.hpp
@@ -80,7 +80,7 @@ namespace hopsan {
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("x_vmax", "Maximum Spool Displacement", "m", 0.01, &mpXvmax);
             addInputVariable("p_c",  "Fraction of displacement when central position is open", "-", 0.02, &mpP_c);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic43ValveNeutralToTank.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/Hydraulic43ValveNeutralToTank.hpp
@@ -80,7 +80,7 @@ namespace hopsan {
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("x_vmax", "Maximum Spool Displacement", "m", 0.01, &mpXvmax);
             addInputVariable("p_c",  "Fraction of displacement when central position is open", "-", 0.02, &mpP_c);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/HydraulicOpenCenterValve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/FlowControlValves/HydraulicOpenCenterValve.hpp
@@ -80,7 +80,7 @@ namespace hopsan {
             addInputVariable("in", "Desired spool position", "m", 0.0, &mpXvIn);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool circumference that is opening P-A", "-", 1.0, &mpF_pa);
             addInputVariable("f_pb", "Fraction of spool circumference that is opening B-T", "-", 1.0, &mpF_pb);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/Hydraulic22PoppetValve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/Hydraulic22PoppetValve.hpp
@@ -77,7 +77,7 @@ namespace hopsan {
             addOutputVariable("xv_out", "Spool position", "", 0.0, &mpXvout);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d_1", "Small diameter", "m", 10e-3, &mpD1);
             addInputVariable("d_2", "Big diameter", "m", 10e-3, &mpD2);
             addInputVariable("k", "Spring constant", "N/m", 1e4, &mpK);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/Hydraulic33ShuttleValve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/Hydraulic33ShuttleValve.hpp
@@ -76,7 +76,7 @@ namespace hopsan {
             addOutputVariable("xv_out", "Spool position", "", 0.0, &mpXvout);
 
             addInputVariable("C_q", "Flow Coefficient", "-", 0.67, &mpCq);
-            addInputVariable("rho", "Oil Density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool Diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool circumference that is opening P-A", "-", 1.0, &mpF_pa);
             addInputVariable("f_at", "Fraction of spool circumference that is opening A-T", "-", 1.0, &mpF_at);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/HydraulicPressureControlValve33.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/HydraulicPressureControlValve33.hpp
@@ -202,7 +202,7 @@ public:
             addInputVariable("pref","Reference pressure","Pa",1.e6,&mppref);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("Cq", "Flow coefficient.", "", 0.67,&mpCq);
             addInputVariable("Sd", "spool diameter", "m", 0.01,&mpSd);
             addInputVariable("Frap", "Spool cricle fraction(P-A)", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/HydraulicValve416.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/HydraulicValve416.hpp
@@ -211,7 +211,7 @@ public:
             addInputVariable("xvtb","Spool position","m",0.,&mpxvtb);
 
         //Add inputParammeters to the component
-            addInputVariable("rho", "oil density", "kg/m3", 860.,&mprho);
+            addInputVariable("rho", "Oil density", "kg/m3", 870, &mprho);
             addInputVariable("Cq", "Flow coefficient.", "", 0.67,&mpCq);
             addInputVariable("Sd", "spool diameter", "m", 0.001,&mpSd);
             addInputVariable("Frpa", "Spool cricle fraction(P-A)", "", \

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled22Valve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled22Valve.hpp
@@ -83,7 +83,7 @@ namespace hopsan {
             addInputVariable("Fs_min", "Minimum pressure for opening the valve", "Pa", 100000, &mpFs_min);
             addInputVariable("Fs_max", "Pressure for fully opening the valve", "Pa", 1000000, &mpFs_max);
             addInputVariable("C_q", "Flow coefficient", "-", 0.67, &mpC_q);
-            addInputVariable("rho", "Oil density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool diameter that is opening P-A ", "", 1, &mpF_pa);
             addInputVariable("f_bt", "Fraction of spool diameter that is opening B-T", "", 1, &mpF_bt);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled22Valve2.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled22Valve2.hpp
@@ -83,7 +83,7 @@ namespace hopsan {
             addInputVariable("Fs_min", "Minimum pressure for opening the valve", "Pa", 100000, &mpFs_min);
             addInputVariable("Fs_max", "Pressure for fully opening the valve", "Pa", 1000000, &mpFs_max);
             addInputVariable("C_q", "Flow coefficient", "-", 0.67, &mpC_q);
-            addInputVariable("rho", "Oil density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool diameter that is opening P-A ", "", 1, &mpF_pa);
             addInputVariable("f_bt", "Fraction of spool diameter that is opening B-T", "", 1, &mpF_bt);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled42Valve.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled42Valve.hpp
@@ -86,7 +86,7 @@ namespace hopsan {
             addInputVariable("Fs_min", "Minimum pressure for opening the valve", "Pa", 100000, &mpFs_min);
             addInputVariable("Fs_max", "Pressure for fully opening the valve", "Pa", 1000000, &mpFs_max);
             addInputVariable("C_q", "Flow coefficient", "-", 0.67, &mpC_q);
-            addInputVariable("rho", "Oil density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool diameter that is opening P-A ", "", 1, &mpF_pa);
             addInputVariable("f_bt", "Fraction of spool diameter that is opening B-T", "", 1, &mpF_bt);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled42Valve2.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled42Valve2.hpp
@@ -86,7 +86,7 @@ namespace hopsan {
             addInputVariable("Fs_min", "Minimum pressure for opening the valve", "Pa", 100000, &mpFs_min);
             addInputVariable("Fs_max", "Pressure for fully opening the valve", "Pa", 1000000, &mpFs_max);
             addInputVariable("C_q", "Flow coefficient", "-", 0.67, &mpC_q);
-            addInputVariable("rho", "Oil density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool diameter that is opening P-A ", "", 1, &mpF_pa);
             addInputVariable("f_bt", "Fraction of spool diameter that is opening B-T", "", 1, &mpF_bt);

--- a/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled42Valve3.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Valves/PressureControlled/HydraulicPressureControlled42Valve3.hpp
@@ -85,7 +85,7 @@ namespace hopsan {
             addInputVariable("Fs_min", "Minimum pressure for opening the valve", "Pa", 100000, &mpFs_min);
             addInputVariable("Fs_max", "Pressure for fully opening the valve", "Pa", 1000000, &mpFs_max);
             addInputVariable("C_q", "Flow coefficient", "-", 0.67, &mpC_q);
-            addInputVariable("rho", "Oil density", "kg/m^3", 890, &mpRho);
+            addInputVariable("rho", "Oil density", "kg/m^3", 870, &mpRho);
             addInputVariable("d", "Spool diameter", "m", 0.01, &mpD);
             addInputVariable("f_pa", "Fraction of spool diameter that is opening P-A", "", 1, &mpF_pa);
             addInputVariable("f_pb", "Fraction of spool diameter that is opening P-B", "", 1, &mpF_pb);

--- a/componentLibraries/defaultLibrary/Hydraulic/Volumes&Lines/HydraulicHose.hpp
+++ b/componentLibraries/defaultLibrary/Hydraulic/Volumes&Lines/HydraulicHose.hpp
@@ -82,7 +82,7 @@ namespace hopsan {
             mpP2 = addPowerPort("P2", "NodeHydraulic");
 
             //Register changeable parameters to the HOPSAN++ core
-            addInputVariable("rho",    "Density",                   "kg/m^3", 870.0, &mpRho);
+            addInputVariable("rho",    "Oil density",               "kg/m^3", 870.0, &mpRho);
             addInputVariable("eta",    "Dynamic oil viscosity",     "Ns/m^2", 0.03, &mpVisc);
             addInputVariable("d",      "Line diameter",             "m",      0.03, &mpD);
             addInputVariable("l",      "Line length",               "m",      1.0, &mpL);

--- a/componentLibraries/defaultLibrary/Special/AeroComponents/PneumaticTurboMachineJ.hpp
+++ b/componentLibraries/defaultLibrary/Special/AeroComponents/PneumaticTurboMachineJ.hpp
@@ -185,7 +185,7 @@ public:
 1.59,&mpbeta2);
             addInputVariable("A1", "inlet flow area", "m2", 0.0004,&mpA1);
             addInputVariable("A2", "outlet flow area", "m2", 0.0004,&mpA2);
-            addInputVariable("rho", "Fluid density", "kg/m2", 860,&mprho);
+            addInputVariable("rho", "Fluid density", "kg/m2", 870, &mprho);
             addInputVariable("Kcp", "Leakage coeff", "m3/s/Pa", \
 1.e-9,&mpKcp);
             addInputVariable("Bm", "Visc friction coeff", "N/m/s", 1.,&mpBm);


### PR DESCRIPTION
Set default value for oil density for 870 kg/m^3 for all components in default library. Only oil density is changed, not density of e.g. steel or jet fuel.

Some Mathematica files may need to be updated as well. Mathematica generated components are only modified directly in the generated code for now.

Resolves #2029