### PR TITLE
Remove fade effect on red error flash in terminal

### DIFF
--- a/HopsanGUI/Widgets/HcomWidget.cpp
+++ b/HopsanGUI/Widgets/HcomWidget.cpp
@@ -239,8 +239,6 @@ TerminalConsole::TerminalConsole(TerminalWidget *pParent)
     mpCompleter->setCaseSensitivity(Qt::CaseInsensitive);
     QObject::connect(mpCompleter, SIGNAL(activated(QString)),
                      this, SLOT(insertCompletion(QString)));
-
-    connect(&mColorTimer, SIGNAL(timeout()), this, SLOT(updateBackgroundColor()));
 }
 
 
@@ -367,8 +365,8 @@ void TerminalConsole::printMessage(const GUIMessage &rMessage, bool timeStamp, b
         setOutputColor(UndefinedMessageType);
 
         if(Error == rMessage.mType) {
-            mColor = 100;               //Start red fading color
-            mColorTimer.start(6);
+            this->setStyleSheet(this->styleSheet()+"background: rgba(255, 100, 100, 255);");
+            mBackgroundColorTimer.singleShot(400, this, &TerminalConsole::resetBackgroundColor);
         }
     }
 }
@@ -633,13 +631,9 @@ void TerminalConsole::updateAutoCompleteList()
     mpCompleter->setModel(new QStringListModel(mpTerminal->mpHandler->getAutoCompleteWords(), mpCompleter));
 }
 
-void TerminalConsole::updateBackgroundColor()
+void TerminalConsole::resetBackgroundColor()
 {
-    mColor++;
-    this->setStyleSheet(this->styleSheet()+"background: rgba(255, "+QString::number(mColor)+", "+QString::number(mColor)+", 255);");
-    if(mColor >= 255) {
-        mColorTimer.stop(); //Stop timer when color is back to original
-    }
+    this->setStyleSheet(this->styleSheet()+"background: rgba(255, 255, 255, 255);");
 }
 
 

--- a/HopsanGUI/Widgets/HcomWidget.h
+++ b/HopsanGUI/Widgets/HcomWidget.h
@@ -115,7 +115,7 @@ protected:
 private slots:
     void insertCompletion(const QString& completion);
     void updateAutoCompleteList();
-    void updateBackgroundColor();
+    void resetBackgroundColor();
 
 private:
     //Output
@@ -156,8 +156,7 @@ private:
 
     QCompleter *mpCompleter;
 
-    QTimer mColorTimer;
-    int mColor=0;
+    QTimer mBackgroundColorTimer;
 };
 
 #endif // HCOMWIDGET_H


### PR DESCRIPTION
When an error occurs, show a solid red background for 400 ms instead of the fading effect. This should be more robust, instead of updating the background color once every 6 ms for ~1 s, as before. Now we only need to trigger a single event once.

Alternative solution could be to use a more coarse-grained fading effect, where the color is updated less often.

Please try and see what you think.

Resolves #2028.