### PR TITLE
Check for minimum number of candidates in DE algorithm

### DIFF
--- a/Ops/src/OpsWorkerDifferentialEvolution.cpp
+++ b/Ops/src/OpsWorkerDifferentialEvolution.cpp
@@ -84,6 +84,10 @@ void WorkerDifferentialEvolution::run()
         mpMessageHandler->printMessage("Error: Differential evolution algorithm requires same number of candidates and points.");
         return;
     }
+    if(mNumCandidates < 5) {
+        mpMessageHandler->printMessage("Error: Differential evolution algorithm requires more than 4 candidates.");
+        return;
+    }
     mpMessageHandler->printMessage("Running optimization with differential evolution algorithm.");
 
     distributePoints();


### PR DESCRIPTION
Simple check to avoid a crash. DE algorithm requires four points in order to generate each new point.