### PR TITLE
Issue 2053 autocomplete drives mrejster nuts

### DIFF
--- a/HopsanGUI/Widgets/HcomWidget.cpp
+++ b/HopsanGUI/Widgets/HcomWidget.cpp
@@ -653,21 +653,24 @@ void TerminalConsole::keyPressEvent(QKeyEvent *event)
     }
 }
 
-//! @brief Inserts a selected completion from autocompleter
-void TerminalConsole::insertCompletion(const QString& completion)
+//! @brief Inserts a selected completion from auto completer
+void TerminalConsole::insertCompletion(QString completionResult)
 {
-    QString temp = completion;
-    if(temp.endsWith("()"))
-        temp.chop(1);
-
-    if (mpCompleter->widget() != this)
+    if (mpCompleter->widget() != this) {
         return;
+    }
+
+    if(completionResult.endsWith("()")) {
+        completionResult.chop(1);
+    }
 
     QTextCursor tc = textCursor();
-    int extra = temp.length() - mpCompleter->completionPrefix().length();
+    // Put the cursor at the end, then move it to the left to create a selection over the prefix text
     tc.movePosition(QTextCursor::Left);
     tc.movePosition(QTextCursor::EndOfWord);
-    tc.insertText(temp.right(extra));
+    tc.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, mpCompleter->completionPrefix().length());
+    // Insert completion result, overwriting selected prefix text. This will ensure that character case is corrected in prefix text
+    tc.insertText(completionResult);
     setTextCursor(tc);
 }
 

--- a/HopsanGUI/Widgets/HcomWidget.cpp
+++ b/HopsanGUI/Widgets/HcomWidget.cpp
@@ -577,10 +577,10 @@ void TerminalConsole::keyPressEvent(QKeyEvent *event)
                 // Restore cursor position and anchor after extracting WordUnderCursor
                 tc.setPosition(curretPos);
 
-                // Move cursor to before the character before the prefix
-                tc.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, prefix.size()+1);
+                // Move cursor to before the character before the just extracted prefix word
+                tc.movePosition(QTextCursor::StartOfWord, QTextCursor::MoveAnchor);
+                tc.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor);
                 prevCharacter = tc.selectedText();
-                prevCharacter.chop(prefix.size());
 
                 // As long as the character preceding the WordUnderCursor is . keep collecting words until the complete name is included
                 if (prevCharacter == ".") {

--- a/HopsanGUI/Widgets/HcomWidget.h
+++ b/HopsanGUI/Widgets/HcomWidget.h
@@ -113,7 +113,7 @@ protected:
     virtual void keyPressEvent(QKeyEvent * event);
 
 private slots:
-    void insertCompletion(const QString& completion);
+    void insertCompletion(QString completionResult);
     void resetBackgroundColor();
 
 private:

--- a/HopsanGUI/Widgets/HcomWidget.h
+++ b/HopsanGUI/Widgets/HcomWidget.h
@@ -114,7 +114,6 @@ protected:
 
 private slots:
     void insertCompletion(const QString& completion);
-    void updateAutoCompleteList();
     void resetBackgroundColor();
 
 private:


### PR DESCRIPTION
Includes the following changes to auto-complete
But more work is required to make it better

- Do not trigger auto complete popup after @ 
- Always show the auto complete popup, but only activate (create selection), if the user press Tab, (or use arrow keys or mouse to select in the list). If you press enter without first pressing Tab (or selecting in some other way). It will be as if the auto complete list was not even there.
- Fix autocomplete not recognizing . in names such as Step.out.y. This greatly increase the usefulness for components with many ports.
- Autocomplete now replaces the entire completer prefix, to ensure that case is corrected. Example: step.out.y -> Step.out.y

Resolve #2053 