### PR TITLE
Clarify plot curve invert UI elements and tooltips

### DIFF
--- a/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
+++ b/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
@@ -885,7 +885,7 @@ VariableTableWidget::VariableTableWidget(ModelObject *pModelObject, QWidget *pPa
     columnHeaders.append("Unit");
     columnHeaders.append("Value");
     columnHeaders.append("Quantity");
-    columnHeaders.append("PlotSettings");
+    columnHeaders.append("PlotLabel");
     columnHeaders.append("Port");
     this->setHorizontalHeaderLabels(columnHeaders);
 
@@ -2155,14 +2155,14 @@ PlotSettingsWidget::PlotSettingsWidget(const CoreVariameterDescription &rData, M
     QHBoxLayout *pLayout = new QHBoxLayout(this);
     QMargins margins = pLayout->contentsMargins(); margins.setBottom(0); margins.setTop(0);
     pLayout->setContentsMargins(margins);
-    QCheckBox *pInverCheckbox = new QCheckBox(this);
-    pInverCheckbox->setToolTip("Invert plot");
+    QCheckBox *pInverCheckbox = new QCheckBox("Inv", this);
+    pInverCheckbox->setToolTip("Invert plot curve");
     pInverCheckbox->setChecked(mOrigInverted);
     mpPlotLabel = new QLineEdit(mOriginalPlotLabel,this);
     mpPlotLabel->setFrame(false);
-    mpPlotLabel->setToolTip("Custom label");
-    pLayout->addWidget(pInverCheckbox);
+    mpPlotLabel->setToolTip("Custom plot curve label");
     pLayout->addWidget(mpPlotLabel);
+    pLayout->addWidget(pInverCheckbox);
 
     connect(pInverCheckbox, SIGNAL(toggled(bool)), this, SLOT(invertPlot(bool)));
     connect(mpPlotLabel, SIGNAL(textChanged(QString)), this, SLOT(setPlotLabel(QString)));

--- a/HopsanGUI/LogDataHandler2.cpp
+++ b/HopsanGUI/LogDataHandler2.cpp
@@ -1258,7 +1258,8 @@ bool LogDataHandler2::collectLogDataFromSystem(SystemObject *pCurrentSystem, con
                         pVarDesc->mDataDescription = varDesc.mDescription;
                         pVarDesc->mAliasName  = varDesc.mAlias;
                         pVarDesc->mVariableSourceType = ModelVariableType;
-                        pVarDesc->mInvertData = pModelObject->getInvertPlotVariable(pPort->getName()+"#"+varDesc.mName);
+                        pVarDesc->mModelInvertPlot = pModelObject->getInvertPlotVariable(pPort->getName()+"#"+varDesc.mName);
+                        pVarDesc->mLocalInvertInvertPlot = false;
                         pVarDesc->mCustomLabel = pModelObject->getVariablePlotLabel(pPort->getName()+"#"+varDesc.mName);
 
                         SharedVectorVariableT pNewData;

--- a/HopsanGUI/LogVariable.cpp
+++ b/HopsanGUI/LogVariable.cpp
@@ -420,13 +420,20 @@ QString VectorVariable::getImportedFileName() const
 
 bool VectorVariable::isPlotInverted() const
 {
-    return mpVariableDescription->mInvertData;
+    return mpVariableDescription->mLocalInvertInvertPlot ?
+                !mpVariableDescription->mModelInvertPlot :
+                 mpVariableDescription->mModelInvertPlot;
+}
+
+void VectorVariable::setPlotInverted(bool tf)
+{
+    mpVariableDescription->mLocalInvertInvertPlot = (mpVariableDescription->mModelInvertPlot != tf);
+    emit dataChanged();
 }
 
 void VectorVariable::togglePlotInverted()
 {
-    mpVariableDescription->mInvertData = !mpVariableDescription->mInvertData;
-    emit dataChanged();
+    setPlotInverted(!isPlotInverted());
 }
 
 

--- a/HopsanGUI/LogVariable.h
+++ b/HopsanGUI/LogVariable.h
@@ -95,7 +95,8 @@ public:
     QString mModelPath;
     VariableSourceTypeT mVariableSourceType;
 
-    bool mInvertData=false;
+    bool mModelInvertPlot=false;
+    bool mLocalInvertInvertPlot=false;
 
     QString getFullName() const;
     QString getFullNameWithSeparator(const QString sep) const;
@@ -153,6 +154,7 @@ public:
 
     // Data plot scaling
     bool isPlotInverted() const;
+    void setPlotInverted(bool tf);
     void togglePlotInverted();
     double getGenerationPlotOffsetIfTime() const;
 

--- a/HopsanGUI/PlotCurveControlBox.cpp
+++ b/HopsanGUI/PlotCurveControlBox.cpp
@@ -83,12 +83,12 @@ PlotCurveControlBox::PlotCurveControlBox(PlotCurve *pPlotCurve, PlotArea *pParen
     mpSourceLable->setText("U");
     mpSourceLable->setToolTip(variableSourceTypeAsShortString(UndefinedVariableSourceType));
 
-    mpAutoUpdateCheckBox = new QCheckBox("AU");
-    mpAutoUpdateCheckBox->setToolTip("Auto Update");
+    mpAutoUpdateCheckBox = new QCheckBox("Auto");
+    mpAutoUpdateCheckBox->setToolTip("Auto update");
     mpAutoUpdateCheckBox->setChecked(mpPlotCurve->isAutoUpdating());
 
-    mpInvertCurveCheckBox = new QCheckBox("IV");
-    mpInvertCurveCheckBox->setToolTip("Invert Plot Curve");
+    mpInvertCurveCheckBox = new QCheckBox("Inv");
+    mpInvertCurveCheckBox->setToolTip("Invert this plot curve (use model properties for persistence)");
     mpInvertCurveCheckBox->setChecked(mpPlotCurve->isInverted());
 
     QToolButton *pColorButton = new QToolButton(this);


### PR DESCRIPTION
- For updates to latest generation, remember previous plot curve invert setting
- If there is a gap in the generations use toggle state from model (forget local state)
- If model toggle state changes, use that to override local choice (forget local state)
- If you toggle invert in one plot all curves for that generation will also be toggled in other plots (like Hopsan was already doing). This is to prevent confusion when plotting the same data in different plots.

Resolve #2057 