### PR TITLE
Some fixes to FMI wrapper component

### DIFF
--- a/HopsanCore/src/ComponentUtilities/TempDirectoryHandle.cpp
+++ b/HopsanCore/src/ComponentUtilities/TempDirectoryHandle.cpp
@@ -140,7 +140,8 @@ bool TempDirectoryHandle::createDir(const HString &rName) const
 #ifdef _WIN32
         return _mkdir(rName.c_str()) == 0;
 #else
-        return mkdir(rName.c_str(), 0777) == 0;
+        int ret = mkdir(rName.c_str(), 0777) == 0;
+        return (ret != 0);
 #endif
 }
 
@@ -160,7 +161,9 @@ bool TempDirectoryHandle::createPath(const HString &rPath) const
                 return false;
             }
         }
-        currentLevel += "/"; // don't forget to append a slash
+        if(currentLevel.empty() || currentLevel[currentLevel.size()-1] != '/') {
+            currentLevel += "/"; // don't forget to append a slash
+        }
     }
 #endif
     return directoryExists(rPath);
@@ -170,8 +173,13 @@ bool TempDirectoryHandle::createPath(const HString &rPath) const
 bool TempDirectoryHandle::directoryExists(const HString &rName) const
 {
     struct stat st;
-    stat(rName.c_str(), &st);
-    return st.st_mode & S_IFDIR;
+    if(stat(rName.c_str(), &st) != 0) {
+        return false;
+    }
+    else if(st.st_mode & S_IFDIR) {
+        return true;
+    }
+    return false;
 }
 
 bool TempDirectoryHandle::removeDirectory(const HString &rPath) const

--- a/HopsanGUI/GUIObjects/GUIComponent.cpp
+++ b/HopsanGUI/GUIObjects/GUIComponent.cpp
@@ -152,6 +152,7 @@ bool Component::setParameterValue(QString name, QString value, bool force)
 
     if(this->getTypeName() == "FMIWrapper" && name == "path") {
         //Get lists of input and output ports from core component
+        QStringList visibleOutputs = getParameterValue("visibleOutputs").split(",");
         QStringList inputs, outputs;
         for(const auto &port: mpParentSystemObject->getCoreSystemAccessPtr()->getPortNames(this->getName())) {
             QString type = mpParentSystemObject->getCoreSystemAccessPtr()->getPortType(this->getName(), port);
@@ -159,7 +160,7 @@ bool Component::setParameterValue(QString name, QString value, bool force)
             if("ReadPortType" == type) {
                 inputs << port;
             }
-            else if("WritePortType" == type) {
+            else if("WritePortType" == type && visibleOutputs.contains(port)) {
                 outputs << port;
             }
         }

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -358,13 +358,14 @@ public:
     void finalize()
     {
         if(fmu) {
-            fmistatus = fmi2_import_terminate(fmu);
+            fmistatus = fmi2_import_reset(fmu);
         }
     }
 
     void deconfigure()
     {
         if(fmu) {
+            fmistatus = fmi2_import_terminate(fmu);
             fmi2_import_free_instance(fmu);
             fmi2_import_destroy_dllfmu(fmu);
             fmi2_import_free(fmu);

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -453,8 +453,9 @@ public:
     }
 
 
-    //! @brief Removes all illegal characters from the string, so that it can be used as a variable name.
-    //! @param [in out] rName String that will be modified
+    //! @brief Replaces all illegal characters in the string with underscores, so that it can be used as a variable name.
+    //! @param [in] rName Input string
+    //! @returns Input string with illegal characters replaced with underscore
     //! @todo Check if variable/parameter exist in model already and append number if so
     HString toValidHopsanVarName(const HString &rName)
     {

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -278,7 +278,7 @@ public:
             {
                 addDebugMessage("Output: "+HString(name));
                 mPorts.push_back(addOutputVariable(toValidHopsanVarName(name), description, "", &mOutputs[vr]));
-                mVisibleOutputs.append(HString(name)+",");
+                mVisibleOutputs.append(toValidHopsanVarName(name)+",");
             }
             else if(causality == fmi2_causality_enu_local && type == fmi2_base_type_real) {
                 addDebugMessage("Local: "+HString(name));

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -125,7 +125,7 @@ private:
     fmi2_status_t fmistatus;
     fmi2_import_t* fmu;
     double mTolerance = 1e-4;
-
+    HString mVisibleOutputs;
 
 public:
     static Component *Creator()
@@ -270,8 +270,17 @@ public:
             {
                 addDebugMessage("Output: "+HString(name));
                 mPorts.push_back(addOutputVariable(name, description, "", &mOutputs[vr]));
+                mVisibleOutputs.append(HString(name)+",");
+            }
+            else if(causality == fmi2_causality_enu_local && type == fmi2_base_type_real) {
+                addDebugMessage("Local: "+HString(name));
+                mPorts.push_back(addOutputVariable(name, description, "", &mOutputs[vr]));
             }
         }
+        if(!mVisibleOutputs.empty() && mVisibleOutputs.back() == ',') {
+            mVisibleOutputs.erase(mVisibleOutputs.size()-1,1);  //Remove trailing comma
+        }
+        addConstant("visibleOutputs", "Visible output variables (hidden)", "", mVisibleOutputs, mVisibleOutputs);
 
         fmiCallbackFunctions.logger = fmiLogger;
         fmiCallbackFunctions.allocateMemory = calloc;

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -378,7 +378,7 @@ public:
         }
 
         //Take step
-        fmistatus = fmi2_import_do_step(fmu, mTime, mTimestep, true);
+        fmistatus = fmi2_import_do_step(fmu, mTime-mTimestep, mTimestep, true);
         if (fmistatus != fmi2_status_ok) {
             stopSimulation("fmi2_import_do_step failed");
             return;

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -232,22 +232,26 @@ public:
             if(causality == fmi2_causality_enu_parameter && type == fmi2_base_type_str)
             {
                 addDebugMessage("String parameter: "+HString(name));
-                addConstant(name, description, "", mStringParameters[vr]);
+                const char* startValue = fmi2_import_get_string_variable_start(fmi2_import_get_variable_as_string(pVar));
+                addConstant(name, description, "", startValue, mStringParameters[vr]);
             }
             else if(causality == fmi2_causality_enu_parameter && type == fmi2_base_type_bool)
             {
                 addDebugMessage("Boolean parameter: "+HString(name));
-                addConstant(name, description, "", mBoolParameters[vr]);
+                bool startValue = fmi2_import_get_boolean_variable_start(fmi2_import_get_variable_as_boolean(pVar));
+                addConstant(name, description, "", startValue, mBoolParameters[vr]);
             }
             else if(causality == fmi2_causality_enu_parameter && type == fmi2_base_type_int)
             {
                 addDebugMessage("Integer parameter: "+HString(name));
-                addConstant(name, description, "", mIntParameters[vr]);
+                int startValue = fmi2_import_get_integer_variable_start(fmi2_import_get_variable_as_integer(pVar));
+                addConstant(name, description, "", startValue, mIntParameters[vr]);
             }
             else if(causality == fmi2_causality_enu_parameter)
             {
                 addDebugMessage("Real parameter: "+HString(name));
-                addConstant(name, description, "", mRealParameters[vr]);
+                double startValue = fmi2_import_get_real_variable_start(fmi2_import_get_variable_as_real(pVar));
+                addConstant(name, description, "", startValue, mRealParameters[vr]);
             }
             else if(causality == fmi2_causality_enu_input && type == fmi2_base_type_real)
             {

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -306,9 +306,8 @@ public:
 
         //Instantiate FMU
         HString instanceName = getName();
-        HString resourceDir = "file://"+mpTempDir->path()+"/resources";
         fmi2_boolean_t visible = fmi2_false;
-        jm_status_enu_t jmstatus = fmi2_import_instantiate(fmu, instanceName.c_str(), fmi2_cosimulation, resourceDir.c_str(), visible);
+        jm_status_enu_t jmstatus = fmi2_import_instantiate(fmu, instanceName.c_str(), fmi2_cosimulation, 0, visible);
         if (jmstatus == jm_status_error) {
             stopSimulation("Failed to instantiate FMU");
             return;

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -124,6 +124,7 @@ private:
     fmi2_callback_functions_t fmiCallbackFunctions;
     fmi2_status_t fmistatus;
     fmi2_import_t* fmu;
+    double mTolerance = 1e-4;
 
 
 public:
@@ -213,6 +214,12 @@ public:
         if (fmuKind == fmi2_fmu_kind_me_and_cs) {
             fmuKind = fmi2_fmu_kind_cs;
         }
+
+        if(fmi2_import_get_default_experiment_has_tolerance(fmu)) {
+            mTolerance = fmi2_import_get_default_experiment_tolerance(fmu);
+        }
+
+        addConstant("tol", "Relative tolerance", "", mTolerance);
 
         //Loop through variables in FMU and generate the lists
         fmi2_import_variable_list_t *pVarList = fmi2_import_get_variable_list(fmu,0);
@@ -317,7 +324,7 @@ public:
         }
 
         //Setup experiment
-        fmistatus = fmi2_import_setup_experiment(fmu, fmi2_false, 0, mTime, fmi2_false, 10);
+        fmistatus = fmi2_import_setup_experiment(fmu, fmi2_true, mTolerance, mTime, fmi2_false, 0.0);
         if(fmistatus != fmi2_status_ok) {
             stopSimulation("fmi2_import_setup_experiment() failed");
             return;

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.xml
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.xml
@@ -5,6 +5,9 @@
             <icon scale="1" path="FMIWrapper.svg" iconrotation="ON" type="user"/>
         </icons>
         <ports/>
+        <defaultparameters>
+            <parameter name="visibleOutputs" hidden="true"></parameter>
+        </defaultparameters>
         <help/>
     </modelobject>
 </hopsanobjectappearance>


### PR DESCRIPTION
- Support all parameter types except enum
- Load start values for parameters
- Correct calling sequence (`fmi2_reset` in `finalize` and `fmi2_terminate` in `deconfigure`)
- Fix issue with temporary directories sometimes not being created on Linux