### PR TITLE
Make random generators static to avoid getting same random value on every call

### DIFF
--- a/HopsanCore/src/ComponentUtilities/TempDirectoryHandle.cpp
+++ b/HopsanCore/src/ComponentUtilities/TempDirectoryHandle.cpp
@@ -123,9 +123,9 @@ const HString TempDirectoryHandle::getTempDirectory() const {
 const HString TempDirectoryHandle::generateRandomNumericString() const
 {
 #if __cplusplus >= 201103L
-        std::random_device rd;
-        std::default_random_engine gen(rd());
-        std::uniform_int_distribution<> distrib(0, 999999999);
+        static std::random_device rd;
+        static std::mt19937 gen(rd());
+        static std::uniform_int_distribution<> distrib(0, 999999999);
         int random = distrib(gen);
 #else
         int random = rand() % 1000000000;

--- a/Ops/src/OpsWorker.cpp
+++ b/Ops/src/OpsWorker.cpp
@@ -365,9 +365,9 @@ size_t Worker::getCurrentNumberOfIterations()
 
 double Worker::opsRand()
 {
-    std::random_device device;
-    std::default_random_engine generator(device());
-    std::uniform_real_distribution<> distribution(0.0, 1.0);
+    static std::random_device device;
+    static std::mt19937 generator(device());
+    static std::uniform_real_distribution<> distribution(0.0, 1.0);
     return distribution(generator);
 }
 

--- a/Ops/src/OpsWorker.cpp
+++ b/Ops/src/OpsWorker.cpp
@@ -38,6 +38,7 @@
 #include <time.h>
 #include <algorithm>
 #include <random>
+#include <chrono>
 
 //#include <QDebug>
 #include "OpsWorker.h"
@@ -365,8 +366,12 @@ size_t Worker::getCurrentNumberOfIterations()
 
 double Worker::opsRand()
 {
-    static std::random_device device;
-    static std::mt19937 generator(device());
+#ifdef __MINGW32__
+    // "Bug" in MinGW (using constant seed) supposedly fixed in GCC 9.2, using current time as seed instead
+    static std::mt19937 generator(static_cast<long unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+#else
+    static std::mt19937 generator(std::random_device{}());
+#endif
     static std::uniform_real_distribution<> distribution(0.0, 1.0);
     return distribution(generator);
 }


### PR DESCRIPTION
- Make random generators static so that they are not reset on ever call
- Switch to mt19937 because its recommended everywhere (as @robbr48 initial intended)

I had problems with the same sequence of "random" values being generated every time the program was run, according to some stackoverflow post switching to mt19927 would solve that problem, (but I do not think that it did).


Resolves #2064 