### PR TITLE
Use interpolation-based downsampling to reduce vector size

### DIFF
--- a/HopsanGUI/LogVariable.cpp
+++ b/HopsanGUI/LogVariable.cpp
@@ -740,8 +740,8 @@ SharedVectorVariableT VectorVariable::toFrequencySpectrum(const SharedVectorVari
             QString oldString, newString;
             oldString.setNum(data.size());
             newString.setNum(n);
-            reduceVectorSize(data, n);
-            reduceVectorSize(time, n);
+            resampleVector(data, n);
+            resampleVector(time, n);
         }
 
         //Apply window function
@@ -1619,8 +1619,8 @@ void createBodeVariables(const SharedVectorVariableT pInput, const SharedVectorV
         oldString.setNum(vRealOut.size());
         newString.setNum(n);
         //QMessageBox::information(gpMainWindowWidget, QWidget::tr("Wrong Vector Size"), "Size of data vector must be an even power of 2. Number of log samples was reduced from " + oldString + " to " + newString + ".");
-        reduceVectorSize(vRealOut, n);
-        reduceVectorSize(vRealIn, n);
+        resampleVector(vRealOut, n);
+        resampleVector(vRealIn, n);
     }
 
     //Apply window function

--- a/HopsanGUI/Utilities/GUIUtilities.cpp
+++ b/HopsanGUI/Utilities/GUIUtilities.cpp
@@ -508,18 +508,24 @@ void FFT(QVector< complex<double> > &data)
 }
 
 
-//! @brief Reduces number of log samples of a data vector to specified value
-//! @param vector Reference to vector that will be reduced
+//! @brief Resample a data vector to specified size using linear interpolation
+//! @param [in,out] vector Reference to vector that will be resampled
 //! @param newSize New size of vector
-void reduceVectorSize(QVector<double> &vector, int newSize)
+void resampleVector(QVector<double> &vector, int newSize)
 {
     int oldSize = vector.size();
 
-    QVector<double> tempVector;
+    QVector<double> tempVector(newSize);
 
-    for(int i=0; i<newSize; ++i)
-    {
-        tempVector.append(vector.at(oldSize/newSize*i));
+    for(int i=0; i<newSize; ++i) {
+        double pos = double(oldSize-1)/double(newSize-1)*double(i);
+        int prev = int(floor(pos)); //Previous index in original vector
+        int next = min(oldSize-1, int(ceil(pos)));  //Next index in original vector
+        double x = 0;
+        if(next != prev) {
+            x = (pos-prev)/(next-prev);  //Fraction
+        }
+        tempVector[i] = (1.0-x)*vector.at(prev) + x*vector.at(next);
     }
 
     vector = tempVector;

--- a/HopsanGUI/Utilities/GUIUtilities.h
+++ b/HopsanGUI/Utilities/GUIUtilities.h
@@ -71,7 +71,7 @@ QString parseVariableUnit(QString input);
 QVector< std::complex<double> > realToComplex(const QVector<double> &rRealVector);
 void windowFunction(QVector<double> &data, WindowingFunctionEnumT function, double &Ca, double &Cb);
 void FFT(QVector< std::complex<double> > &data);
-void reduceVectorSize(QVector<double> &vector, int newSize);
+void resampleVector(QVector<double> &vector, int newSize);
 void limitVectorToRange(QVector<double> &x, QVector<double> &y, double min, double max);
 void removeDir(QString path, qint64 age_seconds=-1);
 void copyDir(const QString fromPath, QString toPath);


### PR DESCRIPTION
There was an error in `reduceVectorSize` function due to integer division. This resovles the problem by replacing the previous closest-index method with a more accurate downsampling algorithm based on linear interpolation. It will affect all frequency analysis plots (spectrum, bode and nyquist).

Resolves #2068.