### PR TITLE
Highlight connected connectors when hovering a component

### DIFF
--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -1156,6 +1156,9 @@ void ModelObject::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 void ModelObject::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     WorkspaceObject::hoverEnterEvent(event);
+    for(auto *connector : getConnectorPtrs()) {
+        connector->setHovered();
+    }
     this->setZValue(HoveredModelobjectZValue);
     this->showPorts(true);
     mpNameText->show();
@@ -1166,6 +1169,9 @@ void ModelObject::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 void ModelObject::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
     WorkspaceObject::hoverLeaveEvent(event);
+    for(auto *connector : getConnectorPtrs()) {
+        connector->setUnHovered();
+    }
     this->setZValue(ModelobjectZValue);
     this->showPorts(false);
     // OK now lets hide the name text if text should be hidden or if icon is hidden

--- a/hopsan-default-configuration.xml
+++ b/hopsan-default-configuration.xml
@@ -36,10 +36,10 @@
     <style>
         <penstyle width="1" situation="Primary" capstyle="32" type="Undefined" style="1" color="#778899" gfxtype="Iso"/>
         <penstyle width="2" situation="Active" capstyle="32" type="Undefined" style="1" color="#ff0000" gfxtype="Iso"/>
-        <penstyle width="2" situation="Hover" capstyle="32" type="Undefined" style="1" color="#8b0000" gfxtype="Iso"/>
+	<penstyle width="2" situation="Hover" capstyle="32" type="Undefined" style="1" color="#db0000" gfxtype="Iso"/>
         <penstyle width="1.5" situation="Primary" capstyle="32" type="Undefined" style="1" color="#778899" gfxtype="User"/>
         <penstyle width="2" situation="Active" capstyle="32" type="Undefined" style="1" color="#ff0000" gfxtype="User"/>
-        <penstyle width="2" situation="Hover" capstyle="32" type="Undefined" style="1" color="#8b0000" gfxtype="User"/>
+	<penstyle width="2" situation="Hover" capstyle="32" type="Undefined" style="1" color="#db0000" gfxtype="User"/>
         <penstyle width="2" situation="Primary" capstyle="32" type="Broken" style="2" color="#F660AB" gfxtype="Iso"/>
         <penstyle width="4" situation="Active" capstyle="32" type="Broken" style="2" color="#F660AB" gfxtype="Iso"/>
         <penstyle width="3" situation="Hover" capstyle="32" type="Broken" style="2" color="#F660AB" gfxtype="Iso"/>
@@ -47,16 +47,16 @@
         <penstyle width="4" situation="Active" capstyle="32" type="Broken" style="2" color="#F660AB" gfxtype="User"/>
         <penstyle width="3" situation="Hover" capstyle="32" type="Broken" style="2" color="#F660AB" gfxtype="User"/>
         <penstyle width="2" situation="Active" capstyle="32" type="Power" style="1" color="#ff0000" gfxtype="Iso"/>
-        <penstyle width="2" situation="Hover" capstyle="32" type="Power" style="1" color="#8b0000" gfxtype="Iso"/>
+	<penstyle width="2" situation="Hover" capstyle="32" type="Power" style="1" color="#db0000" gfxtype="Iso"/>
         <penstyle width="1" situation="Primary" capstyle="32" type="Power" style="1" color="#000000" gfxtype="Iso"/>
         <penstyle width="2" situation="Active" capstyle="32" type="Power" style="1" color="#ff0000" gfxtype="User"/>
-        <penstyle width="2" situation="Hover" capstyle="32" type="Power" style="1" color="#8b0000" gfxtype="User"/>
+	<penstyle width="2" situation="Hover" capstyle="32" type="Power" style="1" color="#db0000" gfxtype="User"/>
         <penstyle width="1.5" situation="Primary" capstyle="32" type="Power" style="1" color="#000000" gfxtype="User"/>
         <penstyle width="2" situation="Active" capstyle="32" type="Signal" style="2" color="#ff0000" gfxtype="Iso"/>
-        <penstyle width="2" situation="Hover" capstyle="32" type="Signal" style="2" color="#8b0000" gfxtype="Iso"/>
+	<penstyle width="2" situation="Hover" capstyle="32" type="Signal" style="2" color="#db0000" gfxtype="Iso"/>
         <penstyle width="1" situation="Primary" capstyle="32" type="Signal" style="2" color="#0000bb" gfxtype="Iso"/>
         <penstyle width="1.5" situation="Active" capstyle="32" type="Signal" style="2" color="#ff0000" gfxtype="User"/>
-        <penstyle width="1.5" situation="Hover" capstyle="32" type="Signal" style="2" color="#8b0000" gfxtype="User"/>
+	<penstyle width="1.5" situation="Hover" capstyle="32" type="Signal" style="2" color="#db0000" gfxtype="User"/>
         <penstyle width="1" situation="Primary" capstyle="32" type="Signal" style="2" color="#0000cc" gfxtype="User"/>
         <palette windowText="0,0,0" button="0,0,255" light="173,216,230" dark="0,0,139" mid="0,0,255" text="0,0,0" bright_text="128,128,128" base="244,247,251" window="226,231,237"/>
         <font family="Calibri" size="9"/>


### PR DESCRIPTION
Resolves #2039.

All connectors connected to a component are highlighted whenever hovering the component. 

I was not sure about this at first, but it is actually really nice for complex models with e.g. overlapping connectors. It will also help students who sometimes tend to make really messy connections.