### PR TITLE
Monitor text files for external changes

### DIFF
--- a/HopsanGUI/MainWindow.cpp
+++ b/HopsanGUI/MainWindow.cpp
@@ -574,8 +574,8 @@ void MainWindow::createActions()
     mpOpenFindWidgetAction->setToolTip("Open the Find Widget (Ctrl+Shift+f)");
     connect(mpOpenFindWidgetAction, SIGNAL(triggered()), this, SLOT(openFindWidget()));
 
-    mpRevertModelAction = new QAction(tr("&Revert model"), this);
-    mpRevertModelAction->setToolTip("Revert model to original state");
+    mpRevertModelAction = new QAction(tr("&Reload file from disk"), this);
+    mpRevertModelAction->setToolTip("Reloads current file from disk");
     connect(mpRevertModelAction, SIGNAL(triggered()), this, SLOT(revertModel()));
 
     mpNumHopAction = new QAction(tr("&NumHop Script"), this);
@@ -990,6 +990,8 @@ void MainWindow::createMenus()
     mpFileMenu->addAction(mpPropertiesAction);
     mpFileMenu->addAction(mpOpenSystemParametersAction);
     mpFileMenu->addSeparator();
+    mpFileMenu->addAction(mpRevertModelAction);
+    mpFileMenu->addSeparator();
     mpFileMenu->addAction(mpCloseAction);
 
     mpSimulationMenu->addAction(mpSimulateAction);
@@ -1030,7 +1032,6 @@ void MainWindow::createMenus()
     mpToolsMenu->addAction(mpOpenDataExplorerAction);
     mpToolsMenu->addAction(mpOpenFindWidgetAction);
     mpToolsMenu->addAction(mpNumHopAction);
-    mpToolsMenu->addAction(mpRevertModelAction);
 
     mpImportMenu->addAction(mpImportDataFileAction);
     mpImportMenu->addAction(mpLoadModelParametersAction);

--- a/HopsanGUI/ModelHandler.cpp
+++ b/HopsanGUI/ModelHandler.cpp
@@ -852,6 +852,16 @@ void ModelHandler::restoreState()
 
 void ModelHandler::revertCurrentModel()
 {
+    QMessageBox warningBox(QMessageBox::Warning, QObject::tr("Warning"),
+                                QObject::tr("All changes made to current model or text file will be lost. Do you want to continue?"),
+                                QMessageBox::NoButton, gpMainWindowWidget);
+    warningBox.addButton("Yes", QMessageBox::AcceptRole);
+    warningBox.addButton("No", QMessageBox::RejectRole);
+    warningBox.setWindowIcon(gpMainWindowWidget->windowIcon());
+    if(warningBox.exec() != QMessageBox::AcceptRole) {
+        return;
+    }
+
     ModelWidget *pModel = gpModelHandler->getCurrentModel();
     if (pModel)
     {

--- a/HopsanGUI/ModelHandler.cpp
+++ b/HopsanGUI/ModelHandler.cpp
@@ -858,6 +858,12 @@ void ModelHandler::revertCurrentModel()
         pModel->revertModel();
         refreshMainWindowConnections();
     }
+
+    TextEditorWidget *pTextEditor = qobject_cast<TextEditorWidget*>(gpMainWindow->mpCentralTabs->currentWidget());
+    if(pTextEditor)
+    {
+        pTextEditor->reload();
+    }
 }
 
 void ModelHandler::createLabviewWrapperFromCurrentModel()

--- a/HopsanGUI/ModelHandler.h
+++ b/HopsanGUI/ModelHandler.h
@@ -37,6 +37,7 @@
 #include <QObject>
 #include <QDomElement>
 #include <QAction>
+#include <QFileSystemWatcher>
 
 #include "GraphicsViewPort.h"
 
@@ -157,6 +158,8 @@ private:
     int mStateInfoIndex;
 
     DebuggerWidget *mpDebugger;
+
+    QFileSystemWatcher *mpFileWatcher;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ModelHandler::LoadOptions)

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -136,9 +136,11 @@ void TextEditorWidget::fileChanged(QString filePath)
     qDebug() << "File changed: " << filePath;
     //We need to add the path again, because some text editors removes the actual file and
     //creates a new one when saving (e.g. gedit). This makes the watcher stop watching.
-    qobject_cast<QFileSystemWatcher*>(sender())->addPath(filePath);
-
-    mpFileChangeNotificationWidget->setVisible(true);
+    QFileSystemWatcher *pWatcher = qobject_cast<QFileSystemWatcher*>(sender());
+    if(pWatcher != nullptr) {
+        pWatcher->addPath(filePath);
+        mpFileChangeNotificationWidget->setVisible(true);
+    }
 }
 
 

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -136,6 +136,10 @@ void TextEditorWidget::fileChanged(QString filePath)
     qDebug() << "File changed: " << filePath;
     //We need to add the path again, because some text editors removes the actual file and
     //creates a new one when saving (e.g. gedit). This makes the watcher stop watching.
+    if(QFileInfo(filePath) != mFileInfo) {
+        return;
+    }
+
     QFileSystemWatcher *pWatcher = qobject_cast<QFileSystemWatcher*>(sender());
     if(pWatcher != nullptr) {
         pWatcher->addPath(filePath);

--- a/HopsanGUI/Widgets/TextEditorWidget.h
+++ b/HopsanGUI/Widgets/TextEditorWidget.h
@@ -145,10 +145,10 @@ public slots:
     void zoomOut();
     void print();
     void save(SaveTargetEnumT saveAsFlag=ExistingFile);
+    void reload();
 
 private slots:
     void hasChanged();
-    void reload();
 };
 
 #endif // SCRIPTEDITOR_H

--- a/HopsanGUI/Widgets/TextEditorWidget.h
+++ b/HopsanGUI/Widgets/TextEditorWidget.h
@@ -111,7 +111,8 @@ public:
     QString getSelectedText();
 
 public slots:
-    void  find(QString text, QTextDocument::FindFlags flags);
+    void find(QString text, QTextDocument::FindFlags flags);
+    void fileChanged(QString filePath);
 
 protected:
     void wheelEvent(QWheelEvent* event);
@@ -130,6 +131,7 @@ private:
     XmlHighlighter *mpXmlHighlighter;
     ModelicaHighlighter *mpModelicaHighlighter;
     PythonHighlighter *mpPythonXmlHighlighter;
+    QWidget *mpFileChangeNotificationWidget;
 
 public slots:
     void saveAs();
@@ -146,6 +148,7 @@ public slots:
 
 private slots:
     void hasChanged();
+    void reload();
 };
 
 #endif // SCRIPTEDITOR_H


### PR DESCRIPTION
- Monitor text files for external changes
- Let user choose to reload file or ignore changes
- Support text files with existing revert action
- Add warning dialog before reverting a file

Resolves #2059.

Possible future work would be to also monitor hmf files for changes, but that is both less important and more complicated.