### PR TITLE
"Always visible" setting for GUI components

### DIFF
--- a/HopsanGUI/GUIObjects/GUIComponent.cpp
+++ b/HopsanGUI/GUIObjects/GUIComponent.cpp
@@ -263,6 +263,8 @@ QString Component::getHmfTagName() const
 //! @param[in] visible True or False
 void Component::setVisible(bool visible)
 {
+    visible |= mAlwaysVisible;
+
     // Hide show icon
     mpIcon->setVisible(visible);
 

--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -115,7 +115,7 @@ void SystemObject::commonConstructorCode()
     mIsCreatingConnector = false;
     mShowSubComponentPorts = gpMainWindow->mpTogglePortsAction->isChecked();
     mShowSubComponentNames = gpMainWindow->mpToggleNamesAction->isChecked();
-    mSignalsHidden = gpMainWindow->mpToggleSignalsAction->isChecked();
+    mSignalsHidden = !gpMainWindow->mpToggleSignalsAction->isChecked();
     mLossesVisible = false;
     mUndoEnabled = true;
     mGfxType = UserGraphics;

--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -115,7 +115,7 @@ void SystemObject::commonConstructorCode()
     mIsCreatingConnector = false;
     mShowSubComponentPorts = gpMainWindow->mpTogglePortsAction->isChecked();
     mShowSubComponentNames = gpMainWindow->mpToggleNamesAction->isChecked();
-    mSignalsHidden = !gpMainWindow->mpToggleSignalsAction->isChecked();
+    mSignalsVisible = gpMainWindow->mpToggleSignalsAction->isChecked();
     mLossesVisible = false;
     mUndoEnabled = true;
     mGfxType = UserGraphics;
@@ -239,7 +239,7 @@ void SystemObject::makeMainWindowConnectionsAndRefresh()
     // Update the main window menu and toolbar actions that are system specific
     gpMainWindow->mpTogglePortsAction->setChecked(mShowSubComponentPorts);
     gpMainWindow->mpToggleNamesAction->setChecked(mShowSubComponentNames);
-    gpMainWindow->mpToggleSignalsAction->setChecked(!mSignalsHidden);
+    gpMainWindow->mpToggleSignalsAction->setChecked(mSignalsVisible);
     gpMainWindow->mpEnableUndoAction->setChecked(mUndoEnabled);
     gpMainWindow->mpUndoAction->setEnabled(mUndoEnabled);
     gpMainWindow->mpRedoAction->setEnabled(mUndoEnabled);
@@ -2105,7 +2105,7 @@ void SystemObject::toggleNames(bool value)
 
 void SystemObject::toggleSignals(bool value)
 {
-    mSignalsHidden = !value;
+    mSignalsVisible = value;
     emit showOrHideSignals(value);
 }
 
@@ -2489,9 +2489,9 @@ bool SystemObject::areSubComponentNamesShown()
 
 
 //! @brief Tells whether or not signal components are hidden
-bool SystemObject::areSignalsHidden()
+bool SystemObject::areSignalsVisible()
 {
-    return mSignalsHidden;
+    return mSignalsVisible;
 }
 
 

--- a/HopsanGUI/GUIObjects/GUIContainerObject.h
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.h
@@ -358,7 +358,7 @@ public slots:
     GraphicsTypeEnumT getGfxType();
     bool areSubComponentPortsShown();
     bool areSubComponentNamesShown();
-    bool areSignalsHidden();
+    bool areSignalsVisible();
 
     //Properties slots
     void openPropertiesDialogSlot();
@@ -470,7 +470,7 @@ protected:
     //Contained object appearance members
     bool mShowSubComponentPorts;
     bool mShowSubComponentNames;
-    bool mSignalsHidden;
+    bool mSignalsVisible;
     GraphicsTypeEnumT mGfxType;
 
     //Undo-redo members

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -1057,7 +1057,7 @@ QDomElement ModelObject::saveGuiDataToDomElement(QDomElement &rDomElement)
     appendPoseTag(xmlGuiStuff, cpos.x(), cpos.y(), rotation(), this->mIsFlipped, 10);
 
     // Save the alwasys visible setting
-    xmlGuiStuff.setAttribute("visible", mAlwaysVisible);
+    xmlGuiStuff.setAttribute("alwaysvisible", mAlwaysVisible);
 
     // Save the text displaying the component name
     QDomElement nametext = appendDomElement(xmlGuiStuff, HMF_NAMETEXTTAG);

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -75,6 +75,7 @@ ModelObject::ModelObject(QPointF position, double rotation, const ModelObjectApp
     mpNameText = nullptr;
     mTextOffset = 5.0;
     mDragCopying = false;
+    mAlwaysVisible = false;
     mNameTextAlwaysVisible = false;
     mNameTextVisible = false;
     mpDialogParentWidget = new QWidget(gpMainWindowWidget);
@@ -1055,6 +1056,9 @@ QDomElement ModelObject::saveGuiDataToDomElement(QDomElement &rDomElement)
     QPointF cpos = this->getCenterPos();
     appendPoseTag(xmlGuiStuff, cpos.x(), cpos.y(), rotation(), this->mIsFlipped, 10);
 
+    // Save the alwasys visible setting
+    xmlGuiStuff.setAttribute("visible", mAlwaysVisible);
+
     // Save the text displaying the component name
     QDomElement nametext = appendDomElement(xmlGuiStuff, HMF_NAMETEXTTAG);
     nametext.setAttribute("position", getNameTextPos());
@@ -1339,6 +1343,11 @@ QAction *ModelObject::buildBaseContextMenu(QMenu &rMenu, QGraphicsSceneContextMe
         replaceMenu->setEnabled(allowFullEditing);
     }
 
+    QAction *pAlwaysVisbleAction = rMenu.addAction(tr("Always visible"));
+    pAlwaysVisbleAction->setCheckable(true);
+    pAlwaysVisbleAction->setChecked(mAlwaysVisible);
+    pAlwaysVisbleAction->setEnabled(allowLimitedEditing);
+
     QAction *pShowNameAction = rMenu.addAction(tr("Always show name"));
     pShowNameAction->setCheckable(true);
     pShowNameAction->setChecked(mNameTextAlwaysVisible);
@@ -1397,6 +1406,11 @@ QAction *ModelObject::buildBaseContextMenu(QMenu &rMenu, QGraphicsSceneContextMe
     {
         mpParentSystemObject->getUndoStackPtr()->newPost();
         this->flipHorizontal();
+    }
+    else if (selectedAction == pAlwaysVisbleAction)
+    {
+        mpParentSystemObject->getUndoStackPtr()->newPost();
+        setAlwaysVisible(pAlwaysVisbleAction->isChecked());
     }
     else if (selectedAction == pShowNameAction)
     {
@@ -1822,6 +1836,13 @@ bool ModelObject::isVisible()
 QGraphicsSvgItem *ModelObject::getIcon()
 {
     return mpIcon;
+}
+
+void ModelObject::setAlwaysVisible(const bool visible)
+{
+    mAlwaysVisible = visible;
+
+    mpIcon->setVisible(!mpParentSystemObject->areSignalsHidden());
 }
 
 void ModelObject::setNameTextAlwaysVisible(const bool isVisible)

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -1843,7 +1843,7 @@ void ModelObject::setAlwaysVisible(const bool visible, UndoStatusEnumT undoSetti
     bool previousStatus = mAlwaysVisible;
     mAlwaysVisible = visible;
 
-    mpIcon->setVisible(visible || !mpParentSystemObject->areSignalsHidden());
+    mpIcon->setVisible(visible || mpParentSystemObject->areSignalsVisible());
 
     if(undoSettings == Undo && previousStatus != visible)
     {

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -1838,11 +1838,17 @@ QGraphicsSvgItem *ModelObject::getIcon()
     return mpIcon;
 }
 
-void ModelObject::setAlwaysVisible(const bool visible)
+void ModelObject::setAlwaysVisible(const bool visible, UndoStatusEnumT undoSettings)
 {
+    bool previousStatus = mAlwaysVisible;
     mAlwaysVisible = visible;
 
     mpIcon->setVisible(visible || !mpParentSystemObject->areSignalsHidden());
+
+    if(undoSettings == Undo && previousStatus != visible)
+    {
+        mpParentSystemObject->getUndoStackPtr()->registerAlwaysVisibleChange(this->getName(), visible);
+    }
 }
 
 void ModelObject::setNameTextAlwaysVisible(const bool isVisible)

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -1842,7 +1842,7 @@ void ModelObject::setAlwaysVisible(const bool visible)
 {
     mAlwaysVisible = visible;
 
-    mpIcon->setVisible(!mpParentSystemObject->areSignalsHidden());
+    mpIcon->setVisible(visible || !mpParentSystemObject->areSignalsHidden());
 }
 
 void ModelObject::setNameTextAlwaysVisible(const bool isVisible)

--- a/HopsanGUI/GUIObjects/GUIModelObject.h
+++ b/HopsanGUI/GUIObjects/GUIModelObject.h
@@ -80,7 +80,7 @@ public:
     virtual const SharedModelObjectAppearanceT getLibraryAppearanceData() const;
     bool isVisible();
     QGraphicsSvgItem *getIcon();
-    void setAlwaysVisible(const bool visible);
+    void setAlwaysVisible(const bool visible, UndoStatusEnumT undoSettings=Undo);
     void setNameTextAlwaysVisible(const bool isVisible);
 
     // Help methods

--- a/HopsanGUI/GUIObjects/GUIModelObject.h
+++ b/HopsanGUI/GUIObjects/GUIModelObject.h
@@ -80,6 +80,7 @@ public:
     virtual const SharedModelObjectAppearanceT getLibraryAppearanceData() const;
     bool isVisible();
     QGraphicsSvgItem *getIcon();
+    void setAlwaysVisible(const bool visible);
     void setNameTextAlwaysVisible(const bool isVisible);
 
     // Help methods
@@ -198,6 +199,7 @@ protected:
     double mTextOffset;
     int mNameTextPos;
 
+    bool mAlwaysVisible;
     bool mNameTextAlwaysVisible;
     bool mNameTextVisible;
 

--- a/HopsanGUI/UndoStack.cpp
+++ b/HopsanGUI/UndoStack.cpp
@@ -322,6 +322,12 @@ void UndoStack::undoOneStep()
                 mpParentSystemObject->getModelObject(objectName)->showName(NoUndo);
             }
         }
+        else if(stuffElement.attribute("what") == UNDO_ALWAYSVISIBLECHANGE)
+        {
+            QString objectName = stuffElement.attribute("objectname");
+            bool isVisible = (stuffElement.attribute("isvisible").toInt() == 1);
+            mpParentSystemObject->getModelObject(objectName)->setAlwaysVisible(!isVisible, NoUndo);
+        }
         else if(stuffElement.attribute("what") == UNDO_ADDEDTEXTBOXWIDGET)
         {
             removeTextboxWidget(stuffElement);
@@ -657,6 +663,12 @@ void UndoStack::redoOneStep()
                 mpParentSystemObject->getModelObject(objectName)->hideName(NoUndo);
             }
         }
+        else if(stuffElement.attribute("what") == UNDO_ALWAYSVISIBLECHANGE)
+        {
+            QString objectName = stuffElement.attribute("objectname");
+            bool isVisible = (stuffElement.attribute("isvisible").toInt() == 1);
+            mpParentSystemObject->getModelObject(objectName)->setAlwaysVisible(isVisible, NoUndo);
+        }
         else if(stuffElement.attribute("what") == UNDO_ADDEDTEXTBOXWIDGET)
         {
             addTextboxwidget(stuffElement);
@@ -990,6 +1002,18 @@ void UndoStack::registerRemovedAliases(QStringList &aliases)
             QString fullName = mpParentSystemObject->getFullNameFromAlias(aliases[i]);
             appendDomTextNode(alias, "fullname",fullName );
         }
+    }
+}
+
+void UndoStack::registerAlwaysVisibleChange(QString objectName, bool isVisible)
+{
+    if(mEnabled) {
+        QDomElement currentPostElement = getCurrentPost();
+        QDomElement stuffElement = appendDomElement(currentPostElement, "stuff");
+        stuffElement.setAttribute("what", UNDO_ALWAYSVISIBLECHANGE);
+        stuffElement.setAttribute("objectname", objectName);
+        stuffElement.setAttribute("isvisible", isVisible);
+        gpUndoWidget->refreshList();
     }
 }
 

--- a/HopsanGUI/UndoStack.h
+++ b/HopsanGUI/UndoStack.h
@@ -58,6 +58,7 @@
 #define UNDO_VERTICALFLIP "verticalflip"
 #define UNDO_HORIZONTALFLIP "horizontalflip"
 #define UNDO_NAMEVISIBILITYCHANGE "namevisibilitychange"
+#define UNDO_ALWAYSVISIBLECHANGE "alwaysvisiblechange"
 #define UNDO_REMOVEDALIASES "removedaliases"
 #define UNDO_PASTE "paste"
 #define UNDO_MOVEDMULTIPLE "movedmultiple"
@@ -121,6 +122,7 @@ public:
     void registerChangedStartValue(QString objectName, QString portName, QString parameterName, QString oldValueTxt, QString newValueTxt);
     void registerNameVisibilityChange(QString objectName, bool isVisible);
     void registerRemovedAliases(QStringList &aliases);
+    void registerAlwaysVisibleChange(QString objectName, bool isVisible);
 
     void registerAddedWidget(Widget *item);
     void registerDeletedWidget(Widget *item);

--- a/HopsanGUI/Widgets/UndoWidget.cpp
+++ b/HopsanGUI/Widgets/UndoWidget.cpp
@@ -230,6 +230,7 @@ QString UndoWidget::translateTag(QString tag)
     tagMap.insert(UNDO_VERTICALFLIP,            "Flipped Vertical");
     tagMap.insert(UNDO_HORIZONTALFLIP,          "Flipped Horizontal");
     tagMap.insert(UNDO_NAMEVISIBILITYCHANGE,    "Changed Name Visibility");
+    tagMap.insert(UNDO_ALWAYSVISIBLECHANGE,     "Toggle Component Always Visible");
     tagMap.insert(UNDO_PASTE,                   "Paste");
     tagMap.insert(UNDO_MOVEDMULTIPLE,           "Moved Objects");
     tagMap.insert(UNDO_CUT,                     "Cut");

--- a/HopsanGUI/loadFunctions.cpp
+++ b/HopsanGUI/loadFunctions.cpp
@@ -280,7 +280,7 @@ ModelObject* loadModelObject(const QDomElement &domElement, SystemObject* pSyste
     parsePoseTag(guiData.firstChildElement(HMF_POSETAG), posX, posY, target_rotation, isFlipped);
     target_rotation = normDeg360(target_rotation); //Make sure target rotation between 0 and 359.999
 
-    bool alwaysVisible = parseAttributeBool(guiData, "visible", false);
+    bool alwaysVisible = parseAttributeBool(guiData, "alwaysvisible", false);
 
     int nameTextPos = guiData.firstChildElement(HMF_NAMETEXTTAG).attribute("position").toInt();
     bool nameTextVisible = parseAttributeBool(guiData.firstChildElement(HMF_NAMETEXTTAG), "visible", false);

--- a/HopsanGUI/loadFunctions.cpp
+++ b/HopsanGUI/loadFunctions.cpp
@@ -309,7 +309,9 @@ ModelObject* loadModelObject(const QDomElement &domElement, SystemObject* pSyste
         }
 
         ModelObject* pObj = pSystem->addModelObject(&appearanceData, QPointF(posX, posY), 0, Deselected, nameStatus, undoSettings);
-        pObj->setAlwaysVisible(alwaysVisible);
+        if(pObj->getTypeCQS() == "S") {
+            pObj->setAlwaysVisible(alwaysVisible, NoUndo);
+        }
         pObj->setNameTextPos(nameTextPos);
         pObj->setNameTextAlwaysVisible(nameTextVisible);
         pObj->setSubTypeName(subtype); //!< @todo is this really needed

--- a/HopsanGUI/loadFunctions.cpp
+++ b/HopsanGUI/loadFunctions.cpp
@@ -280,6 +280,8 @@ ModelObject* loadModelObject(const QDomElement &domElement, SystemObject* pSyste
     parsePoseTag(guiData.firstChildElement(HMF_POSETAG), posX, posY, target_rotation, isFlipped);
     target_rotation = normDeg360(target_rotation); //Make sure target rotation between 0 and 359.999
 
+    bool alwaysVisible = parseAttributeBool(guiData, "visible", false);
+
     int nameTextPos = guiData.firstChildElement(HMF_NAMETEXTTAG).attribute("position").toInt();
     bool nameTextVisible = parseAttributeBool(guiData.firstChildElement(HMF_NAMETEXTTAG), "visible", false);
 
@@ -307,6 +309,7 @@ ModelObject* loadModelObject(const QDomElement &domElement, SystemObject* pSyste
         }
 
         ModelObject* pObj = pSystem->addModelObject(&appearanceData, QPointF(posX, posY), 0, Deselected, nameStatus, undoSettings);
+        pObj->setAlwaysVisible(alwaysVisible);
         pObj->setNameTextPos(nameTextPos);
         pObj->setNameTextAlwaysVisible(nameTextVisible);
         pObj->setSubTypeName(subtype); //!< @todo is this really needed


### PR DESCRIPTION
This setting prevents signal components from being hidden when using the "toggle signal component visibility" feature.

Resolves #1958.