### PR TITLE
Correct rotation and flipping of replaced components

### DIFF
--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -1965,12 +1965,17 @@ void SystemObject::replaceComponent(QString name, QString newType)
 
     QPointF pos = obj->getCenterPos();
     double rot = obj->rotation();
+    bool flipped = obj->isFlipped();
 
     deleteModelObject(name);
 
     qDebug() << "Name = " << name;
 
-    ModelObject *newObj = addModelObject(newType, pos, rot);
+    ModelObject *newObj = addModelObject(newType, pos, 0);
+    newObj->rotate(rot);
+    if(flipped) {
+        newObj->flipHorizontal();
+    }
 
     if(!newObj)
     {


### PR DESCRIPTION
Preserve rotation and flipping when using replace component feature.

Resolves #1955.

**Note:** The `rotation` argument for the `Component` class constructor does not work properly, because it is propagated all the way to the base class (`WorkspaceObject`). This means that everything added by the inherited classes will not be affected by the rotation. I will leave this as it is for now.