### PR TITLE
HCOM: Support orphan variables with chpvx command

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -5819,7 +5819,18 @@ void HcomHandler::changePlotXVariable(const QString varExp)
     {
         bool found=false;
         QStringList variables;
-        getMatchingLogVariableNames(varExp, variables);
+
+        // Check if no generation is given, then specify "current" to avoid costly lookup in all generations
+        QString tempVarName = varExp;
+        bool parseOK;
+        int desiredGen = parseAndChopGenerationSpecifier(tempVarName, parseOK);
+        if (isValidGenerationValue(desiredGen)) {
+            getMatchingLogVariableNames(varExp, variables);
+        }
+        else if (mpModel && mpModel->getLogDataHandler()) {
+            getMatchingLogVariableNames(varExp, variables, false, mpModel->getLogDataHandler()->getCurrentGenerationNumber());
+        }
+
         if (variables.isEmpty())
         {
             evaluateExpression(varExp, DataVector);


### PR DESCRIPTION
Problem: Orphan variables cannot be used as X-variables with chpvx command
Example:
```
>> x=linspace(0,10,100)
>> y=linspace(0,1,100)
>> chpv x
>> chpvx y
```
Variable `x` is plotted correctly against samples, but variable `y` does not appear at the bottom axis. The problem seems to be that `getMatchingLogVariableNames` returns "y@0" instead of "y@-1". The problem only occurs on the first generation, so I guess the actual problem is that `toDisplayGeneration` converts generation from -1 to 0. 

My solution is to use the same code as for the `chpv` command, which should also provide better performance by only searching the desired generation.