### PR TITLE
Replace foreach loops with range-based C++ loops

### DIFF
--- a/HopsanGUI/Configuration.cpp
+++ b/HopsanGUI/Configuration.cpp
@@ -857,8 +857,7 @@ QColor Configuration::getBackgroundColor() const
 QStringList Configuration::getUserLibs() const
 {
     QStringList ret;
-    Q_FOREACH(const QFileInfo &file, mUserLibs)
-    {
+    for(const QFileInfo &file : mUserLibs) {
         ret << file.absoluteFilePath();
     }
 

--- a/HopsanGUI/Dialogs/AnimatedIconPropertiesDialog.cpp
+++ b/HopsanGUI/Dialogs/AnimatedIconPropertiesDialog.cpp
@@ -401,8 +401,7 @@ void AnimatedIconPropertiesDialog::updateValues()
         mpStartThetaLineEdits[i]->setText(QString::number(mpData->movables[i].startTheta));
 
         QStringList tempStr1,tempStr2,tempStr3,tempStr4;
-        foreach(const ModelObjectAnimationMovementData &movement, mpData->movables[i].movementData)
-        {
+        for(const ModelObjectAnimationMovementData &movement : mpData->movables[i].movementData) {
             tempStr1.append(QString::number(movement.x));
             tempStr2.append(QString::number(movement.y));
             tempStr3.append(QString::number(movement.theta));
@@ -424,8 +423,7 @@ void AnimatedIconPropertiesDialog::updateValues()
         tempStr2.clear();
         tempStr3.clear();
         tempStr4.clear();
-        foreach(const ModelObjectAnimationResizeData &resize, mpData->movables[i].resizeData)
-        {
+        for(const ModelObjectAnimationResizeData &resize : mpData->movables[i].resizeData) {
             tempStr1.append(QString::number(resize.x));
             tempStr2.append(QString::number(resize.y));
             tempStr3.append(QString::number(resize.dataIdx1));
@@ -620,8 +618,7 @@ void AnimatedIconPropertiesDialog::resetValues()
 
     //Store icon paths (they are not included in saveToDomElement() )
     QStringList iconPaths;
-    foreach(const ModelObjectAnimationMovableData &m, mpData->movables)
-    {
+    for(const ModelObjectAnimationMovableData &m : mpData->movables) {
         iconPaths << m.iconPath;
     }
 

--- a/HopsanGUI/Dialogs/OptimizationScriptWizard.cpp
+++ b/HopsanGUI/Dialogs/OptimizationScriptWizard.cpp
@@ -1421,8 +1421,7 @@ bool OptimizationScriptWizard::loadObjectiveFunctions()
     }
     files.removeDuplicates();
 
-    Q_FOREACH(const QString fileName, files)
-    {
+    for(const QString &fileName : files) {
         QFile templateFile(fileName);
         templateFile.open(QFile::ReadOnly | QFile::Text);
         QString code = templateFile.readAll();

--- a/HopsanGUI/Dialogs/SensitivityAnalysisDialog.cpp
+++ b/HopsanGUI/Dialogs/SensitivityAnalysisDialog.cpp
@@ -330,7 +330,7 @@ void SensitivityAnalysisDialog::loadSettings()
     mpUniformDistributionRadioButton->setChecked(mpSettings->distribution == SensitivityAnalysisSettings::UniformDistribution);
     mpNormalDistributionRadioButton->setChecked(mpSettings->distribution == SensitivityAnalysisSettings::NormalDistribution);
 
-    foreach(SensitivityAnalysisParameter par, mpSettings->parameters)
+    for(const SensitivityAnalysisParameter &par : mpSettings->parameters)
     {
         QTreeWidgetItemIterator it(mpParametersList);
         while(*it)
@@ -349,8 +349,7 @@ void SensitivityAnalysisDialog::loadSettings()
         }
     }
 
-    foreach(SensitivityAnalysisVariable var, mpSettings->variables)
-    {
+    for(const SensitivityAnalysisVariable &var : mpSettings->variables) {
         QTreeWidgetItemIterator it(mpOutputList);
         while(*it)
         {

--- a/HopsanGUI/GUIConnector.cpp
+++ b/HopsanGUI/GUIConnector.cpp
@@ -1468,8 +1468,7 @@ void ConnectorLine::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         QMenu *pVolunectorComponentsMenu = new QMenu("Change Volunector Component");
         QStringList components;
         components << "HydraulicVolume" << "HydraulicTLMlossless" << "HydraulicHose";
-        foreach(const QString &component, components)
-        {
+        for(const QString &component : components) {
             QString name = gpLibraryHandler->getModelObjectAppearancePtr(component)->getTypeName();
             QIcon icon = gpLibraryHandler->getModelObjectAppearancePtr(component)->getIcon(UserGraphics);
             QAction *pComponentAction = pVolunectorComponentsMenu->addAction(icon, name);

--- a/HopsanGUI/GUIObjects/AnimatedComponent.cpp
+++ b/HopsanGUI/GUIObjects/AnimatedComponent.cpp
@@ -268,8 +268,7 @@ void AnimatedComponent::updateAnimation()
             double x = mpAnimationData->movables[m].startX;
             double y = mpAnimationData->movables[m].startY;
             double rot = mpAnimationData->movables[m].startTheta;
-            foreach(const ModelObjectAnimationMovementData &movement, mpAnimationData->movables[m].movementData)
-            {
+            for(const ModelObjectAnimationMovementData &movement : mpAnimationData->movables[m].movementData) {
                 int idx = movement.dataIdx;
                 x -= data[idx]*movement.x*movement.multiplierValue/movement.divisorValue;
                 y -= data[idx]*movement.y*movement.multiplierValue/movement.divisorValue;
@@ -302,8 +301,7 @@ void AnimatedComponent::updateAnimation()
 
                 bool xChanged = false;
                 bool yChanged = false;
-                foreach(const ModelObjectAnimationResizeData &resize, mpAnimationData->movables[m].resizeData)
-                {
+                for(const ModelObjectAnimationResizeData &resize : mpAnimationData->movables[m].resizeData) {
                     int idx1 = resize.dataIdx1;
                     int idx2 = resize.dataIdx2;
                     double scaleData;

--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -784,12 +784,10 @@ void SystemObject::deleteModelObject(const QString &rObjectName, UndoStatusEnumT
             //First save aliases for component to remove (if any)
             QStringList aliasesToSave;
             QStringList aliases = this->getAliasNames();
-            foreach(const QString &alias, aliases)
-            {
+            for(const QString &alias : aliases) {
                 QString fullName = getFullNameFromAlias(alias);
                 QString compName = fullName.section("#",0,0);
-                if(compName == pModelObject->getName())
-                {
+                if(compName == pModelObject->getName()) {
                     aliasesToSave.append(alias);
                 }
             }

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -456,8 +456,7 @@ void ModelObject::showLosses()
         }
         QStringList nodeTypes;
         NodeInfo::getNodeTypes(nodeTypes);
-        Q_FOREACH(const QString &type, nodeTypes)
-        {
+        for(const QString &type : nodeTypes) {
             if(mPortListPtrs[p]->getNodeType() == type && portType != "ReadPortType")
             {
                 //Power port, so we must cycle all connected ports and ask for their data
@@ -1373,12 +1372,10 @@ QAction *ModelObject::buildBaseContextMenu(QMenu &rMenu, QGraphicsSceneContextMe
     }
 
     // Now select which action was triggered
-    if (selectedAction == parameterAction)
-    {
+    if (selectedAction == parameterAction) {
         openPropertiesDialog();
     }
-    else if(selectedAction == sourceCodeAction)
-    {
+    else if(selectedAction == sourceCodeAction) {
         auto appearance = gpLibraryHandler->getModelObjectAppearancePtr(mModelObjectAppearance.getTypeName());
         QString basePath = appearance->getBasePath();
         if(!basePath.isEmpty()) {
@@ -1387,49 +1384,39 @@ QAction *ModelObject::buildBaseContextMenu(QMenu &rMenu, QGraphicsSceneContextMe
         QString fileName = appearance->getSourceCodeFile();
         gpModelHandler->loadTextFile(basePath+fileName);
     }
-    else if (selectedAction == pRotateRightAction)
-    {
+    else if (selectedAction == pRotateRightAction) {
         mpParentSystemObject->getUndoStackPtr()->newPost();
         this->rotate90cw();
     }
-    else if (selectedAction == pRotateLeftAction)
-    {
+    else if (selectedAction == pRotateLeftAction) {
         mpParentSystemObject->getUndoStackPtr()->newPost();
         this->rotate90ccw();
     }
-    else if (selectedAction == pFlipVerticalAction)
-    {
+    else if (selectedAction == pFlipVerticalAction) {
         mpParentSystemObject->getUndoStackPtr()->newPost();
         this->flipVertical();
     }
-    else if (selectedAction == pFlipHorizontalAction)
-    {
+    else if (selectedAction == pFlipHorizontalAction) {
         mpParentSystemObject->getUndoStackPtr()->newPost();
         this->flipHorizontal();
     }
-    else if (selectedAction == pAlwaysVisbleAction)
-    {
+    else if (selectedAction == pAlwaysVisbleAction) {
         mpParentSystemObject->getUndoStackPtr()->newPost();
         setAlwaysVisible(pAlwaysVisbleAction->isChecked());
     }
-    else if (selectedAction == pShowNameAction)
-    {
+    else if (selectedAction == pShowNameAction) {
         mpParentSystemObject->getUndoStackPtr()->newPost();
         setNameTextAlwaysVisible(pShowNameAction->isChecked());
     }
-    else if(selectedAction == pLockedAction)
-    {
+    else if(selectedAction == pLockedAction) {
         this->setIsLocked(pLockedAction->isChecked());
-        foreach(ModelObject *pObj, mpParentSystemObject->getSelectedModelObjectPtrs())
-        {
+        for(ModelObject *pObj : mpParentSystemObject->getSelectedModelObjectPtrs()) {
             pObj->setIsLocked(pLockedAction->isChecked());
         }
     }
-    else if(selectedAction == pDisabledAction)
-    {
+    else if(selectedAction == pDisabledAction) {
       this->setDisabled(pDisabledAction->isChecked());
-      foreach(ModelObject *pObj, mpParentSystemObject->getSelectedModelObjectPtrs())
-      {
+      for(ModelObject *pObj : mpParentSystemObject->getSelectedModelObjectPtrs()) {
           pObj->setDisabled(pDisabledAction->isChecked());
       }
     }

--- a/HopsanGUI/GUIObjects/GUIModelObjectAppearance.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObjectAppearance.cpp
@@ -294,8 +294,7 @@ void ModelObjectAnimationData::saveToDomElement(QDomElement &rDomElement)
     rDomElement.setAttribute(CAF_FLOWSPEED, flowSpeed);
     rDomElement.setAttribute(CAF_HYDRAULICMINPRESSURE, hydraulicMinPressure);
     rDomElement.setAttribute(CAF_HYDRAULICMAXPRESSURE, hydraulicMaxPressure);
-    foreach(const ModelObjectAnimationMovableData &m, movables)
-    {
+    for(const ModelObjectAnimationMovableData &m : movables) {
         QDomElement movableElement = appendDomElement(rDomElement, CAF_MOVABLE);
 
         //! @note Saving icons is disabled, because it probably makes no sense (paths will not work if moving hmf to other location)

--- a/HopsanGUI/GUIPort.cpp
+++ b/HopsanGUI/GUIPort.cpp
@@ -777,8 +777,7 @@ QStringList Port::getFullVariableNames()
 {
     QStringList names = getVariableNames();
     QStringList names2;
-    Q_FOREACH(QString name, names)
-    {
+    for(const QString &name : names) {
         names2.append(makeFullVariableName(mpParentModelObject->getParentSystemNameHieararchy(), getParentModelObjectName(), getName(), name));
     }
     return names2;

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -1404,8 +1404,7 @@ void HcomHandler::executeCommand(QString cmd)
     if(cmd.contains(";"))
     {
         QStringList cmdList = cmd.split(";");
-        foreach(const QString &tempCmd, cmdList)
-        {
+        for(const QString &tempCmd : cmdList) {
             executeCommand(tempCmd);
         }
         return;
@@ -2201,8 +2200,7 @@ void HcomHandler::executeChangeParameterCommand(const QString cmd)
                 nameFromAlias = nameFromAlias.split("$").last();
                 QString compName = nameFromAlias.section("#",0,0);
                 QString parName = nameFromAlias.right(nameFromAlias.size()-compName.size()-1);
-                foreach(const QString &subsystem, subsystems)
-                {
+                for(const QString &subsystem : subsystems) {
                     pSystem = qobject_cast<SystemObject*>(pSystem->getModelObject(subsystem));
                 }
 
@@ -2393,8 +2391,7 @@ void HcomHandler::executeHelpCommand(QString arg)
 
         QStringList helpLines = help.split("\n");
         int helpLength=0;
-        Q_FOREACH(const QString &line, helpLines)
-        {
+        for(const QString &line : helpLines) {
             if(line.size() > helpLength)
                 helpLength = line.size();
         }
@@ -2415,8 +2412,7 @@ void HcomHandler::executeHelpCommand(QString arg)
     {
         QStringList helpLines = mCmdList[commandId].help.split("\n");
         int helpLength=0;
-        Q_FOREACH(const QString &line, helpLines)
-        {
+        for(const QString &line : helpLines) {
             if(line.size() > helpLength)
                 helpLength = line.size();
         }
@@ -3960,8 +3956,7 @@ void HcomHandler::executeDisableLoggingCommand(const QString cmd)
     //If alias shall be ignored, we must enable all nodes with alias variables again
     if(noAlias)
     {
-        foreach(const QString &aliasName, mpModel->getViewContainerObject()->getAliasNames())
-        {
+        for(const QString &aliasName : mpModel->getViewContainerObject()->getAliasNames()) {
             QString var = mpModel->getViewContainerObject()->getFullNameFromAlias(aliasName);
             QString comp = var.section("#",0,0);
             QString port = var.section("#",1,1);
@@ -3977,14 +3972,13 @@ void HcomHandler::executeEnableLoggingCommand(const QString cmd)
     QStringList args = cmd.split(" ");
 
     QList<Port*> vPortPtrs;
-    foreach(const QString &arg, args)
-    {
+    for(const QString &arg : args) {
         getPorts(arg, vPortPtrs);
     }
 
-    for(int p=0; p<vPortPtrs.size(); ++p)
+    for(const auto &pPort : vPortPtrs)
     {
-        mpModel->getViewContainerObject()->getCoreSystemAccessPtr()->setLoggingEnabled(vPortPtrs.at(p)->getParentModelObjectName(), vPortPtrs.at(p)->getName(), true);
+        mpModel->getViewContainerObject()->getCoreSystemAccessPtr()->setLoggingEnabled(pPort->getParentModelObjectName(), pPort->getName(), true);
     }
 }
 
@@ -4603,8 +4597,7 @@ void HcomHandler::executeLoadModelCommand(const QString cmd)
     QString wildcard = path.right(path.size()-path.lastIndexOf("/")-1);
     QStringList files = QDir(dir).entryList(QStringList() << wildcard,QDir::Files);
 
-    foreach(const QString &file, files)
-    {
+    for(const QString &file : files) {
         path = dir+"/"+file;
         gpModelHandler->loadModel(path);
     }
@@ -4845,18 +4838,14 @@ void HcomHandler::executeCloseModelCommand(const QString cmd)
     }
     bool force=false;
     bool all=false;
-    foreach(const QString &arg, args)
-    {
-        if(arg == "all")
-        {
+    for(const QString &arg : args) {
+        if(arg == "all") {
             all = true;
         }
-        else if(arg == "-f")
-        {
+        else if(arg == "-f") {
             force = true;
         }
-        else
-        {
+        else {
             HCOMERR("Unknown argument: "+args[0]);
             return;
         }
@@ -8000,10 +7989,8 @@ void HcomHandler::getPorts(const QString &rStr, QList<Port*> &rPorts) const
     if (rStr.contains("*"))
     {
         QStringList compNames = pCurrentSystem->getModelObjectNames();
-        Q_FOREACH(const QString &compName, compNames)
-        {
-            for(int p=0; p<pCurrentSystem->getModelObject(compName)->getPortListPtrs().size(); ++p)
-            {
+        for(const QString &compName : compNames) {
+            for(int p=0; p<pCurrentSystem->getModelObject(compName)->getPortListPtrs().size(); ++p) {
                 Port *pPort = pCurrentSystem->getModelObject(compName)->getPortListPtrs().at(p);
                 QString testStr = compName+"."+pPort->getName();
                 QRegExp rx(rStr);
@@ -8028,15 +8015,12 @@ void HcomHandler::getPorts(const QString &rStr, QList<Port*> &rPorts) const
         }
 
         QStringList compNames = pCurrentSystem->getModelObjectNames();
-        Q_FOREACH(const QString &compName, compNames)
-        {
+        for(const QString &compName : compNames) {
             ModelObject *pModel = pCurrentSystem->getModelObject(compName);
             QMapIterator<QString,QString> it(pModel->getVariableAliases());
-            while(it.hasNext())
-            {
+            while(it.hasNext()) {
                 it.next();
-                if(it.value() == rStr)
-                {
+                if(it.value() == rStr) {
                     rPorts.append(pModel->getPort(it.key().section("#",0,0)));
                 }
             }
@@ -8176,21 +8160,17 @@ QString HcomHandler::getParameterValue(QString parameterName, QString &rParamete
 
         // Seek into the correct system
         SystemObject *pContainer;
-        if(searchFromTopLevel)
-        {
+        if(searchFromTopLevel) {
             pContainer = mpModel->getTopLevelSystemContainer();
         }
-        else
-        {
+        else {
             pContainer = mpModel->getViewContainerObject();
         }
-        foreach(const QString &subsystem, subsystems)
-        {
+        for(const QString &subsystem: subsystems) {
             pContainer = qobject_cast<SystemObject*>(pContainer->getModelObject(subsystem));
         }
 
-        if(!pContainer)
-        {
+        if(!pContainer) {
             return "NaN";
         }
 
@@ -8248,23 +8228,20 @@ void HcomHandler::getMatchingLogVariableNamesWithoutLogDataHandler(QString patte
     QStringList unFilteredVariables;
 
     QStringList components = mpModel->getViewContainerObject()->getModelObjectNames();
-    Q_FOREACH(const QString &component, components)
+    for(const QString &component : components)
     {
         ModelObject *pComponent = mpModel->getViewContainerObject()->getModelObject(component);
         QList<Port*> portPtrs = pComponent->getPortListPtrs();
         QStringList ports;
-        Q_FOREACH(const Port *pPort, portPtrs)
-        {
+        for(const Port *pPort : portPtrs) {
             ports.append(pPort->getName());
         }
-        Q_FOREACH(const QString &port, ports)
-        {
+        for(const QString &port : ports) {
             Port *pPort = pComponent->getPort(port);
             NodeInfo nodeInfo(pPort->getNodeType());
             QStringList vars = nodeInfo.shortNames;
 
-            Q_FOREACH(const QString &var, vars)
-            {
+            for(const QString &var : vars) {
                 unFilteredVariables.append(component+"."+port+"."+var);
             }
         }

--- a/HopsanGUI/LibraryHandler.cpp
+++ b/HopsanGUI/LibraryHandler.cpp
@@ -1518,8 +1518,7 @@ bool LibraryHandler::isTypeNamesOkToUnload(const QStringList &typeNames)
     {
         bool hasUnloadingComponent=false;
         SystemObject *pSystem = gpModelHandler->getTopLevelSystem(m);
-        Q_FOREACH(const QString &comp, pSystem->getModelObjectNames())
-        {
+        for(const QString &comp : pSystem->getModelObjectNames()) {
             if(typeNames.contains(pSystem->getModelObject(comp)->getTypeName()))
             {
                 hasUnloadingComponent = true;
@@ -1534,8 +1533,7 @@ bool LibraryHandler::isTypeNamesOkToUnload(const QStringList &typeNames)
     if(!models.isEmpty())
     {
         QString msg = "The following models are using components from the library:\n\n";
-        Q_FOREACH(const QString &model, models)
-        {
+        for(const QString &model : models) {
             msg.append(model+"\n");
         }
         msg.append("\nThey must be closed before unloading.");

--- a/HopsanGUI/LogDataHandler2.cpp
+++ b/HopsanGUI/LogDataHandler2.cpp
@@ -143,61 +143,48 @@ void LogDataHandler2::exportToPlo(const QString &rFilePath, QList<SharedVectorVa
     QList<SharedVectorVariableT> timeVectors;
     QList<SharedVectorVariableT> freqVectors;
     int minLength=INT_MAX;
-    foreach(SharedVectorVariableT var, variables)
-    {
+    for(SharedVectorVariableT var : variables) {
         const int g = var->getGeneration();
-        if (gens.isEmpty() || (gens.last() != g))
-        {
+        if (gens.isEmpty() || (gens.last() != g)) {
             gens.append(g);
         }
 
         const int l = var->getDataSize();
-        if (lengths.isEmpty() || (lengths.last() != l))
-        {
+        if (lengths.isEmpty() || (lengths.last() != l)) {
             lengths.append(l);
             minLength = qMin(minLength, l);
         }
 
         SharedVectorVariableT pToF = var->getSharedTimeOrFrequencyVector();
-        if (pToF)
-        {
-            if (pToF->getDataName() == TIMEVARIABLENAME )
-            {
-                if (timeVectors.isEmpty() || (timeVectors.last() != pToF))
-                {
+        if (pToF) {
+            if (pToF->getDataName() == TIMEVARIABLENAME) {
+                if (timeVectors.isEmpty() || (timeVectors.last() != pToF)) {
                     timeVectors.append(pToF);
                 }
             }
-            else if (pToF->getDataName() == FREQUENCYVARIABLENAME)
-            {
-                if (freqVectors.isEmpty() || (freqVectors.last() != pToF))
-                {
+            else if (pToF->getDataName() == FREQUENCYVARIABLENAME) {
+                if (freqVectors.isEmpty() || (freqVectors.last() != pToF)) {
                     freqVectors.append(pToF);
                 }
             }
         }
     }
 
-    if ( (timeVectors.size() > 0) && (freqVectors.size() > 0) )
-    {
+    if ( (timeVectors.size() > 0) && (freqVectors.size() > 0) ) {
         gpMessageHandler->addErrorMessage(QString("In export PLO: You are mixing time and frequency variables, this is not supported!"));
     }
-    if (gens.size() > 1)
-    {
+    if (gens.size() > 1) {
         gpMessageHandler->addWarningMessage(QString("In export PLO: Data had different generations, time vector may not be correct for all exported data!"));
     }
-    if (lengths.size() > 1)
-    {
+    if (lengths.size() > 1) {
         gpMessageHandler->addWarningMessage(QString("In export PLO: Data had different lengths, truncating to shortest data!"));
     }
 
     // We insert time or frequency last when we know what generation the data had, (to avoid taking last time generation that may belong to imported data)
-    if (timeVectors.size() > 0)
-    {
+    if (timeVectors.size() > 0) {
         variables.prepend(timeVectors.first());
     }
-    else if (freqVectors.size() > 0)
-    {
+    else if (freqVectors.size() > 0) {
         variables.prepend(freqVectors.first());
     }
 
@@ -1211,8 +1198,7 @@ bool LogDataHandler2::collectLogDataFromSystem(SystemObject *pCurrentSystem, con
 
     // Iterate components
     QList<ModelObject*> currentLevelModelObjects = pCurrentSystem->getModelObjects();
-    foreach(ModelObject* pModelObject, currentLevelModelObjects)
-    {
+    for(ModelObject* pModelObject : currentLevelModelObjects) {
         // Ignore "system port model objects" they are not actually a component and will be listed anyway
         if (pModelObject->getTypeName() == HOPSANGUISYSTEMPORTTYPENAME)
         {

--- a/HopsanGUI/MainWindow.cpp
+++ b/HopsanGUI/MainWindow.cpp
@@ -378,8 +378,7 @@ void MainWindow::initializeWorkspace()
     autoLibsDir.setPath(autoLibsPath);
     if(autoLibsDir.exists())
     {
-        foreach(const QString &libPath, autoLibsDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot))
-        {
+        for(const QString &libPath : autoLibsDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot)) {
             qDebug() << "Loading library: " << autoLibsPath+"/"+libPath;
             gpLibraryHandler->loadLibrary(autoLibsPath+"/"+libPath);
         }

--- a/HopsanGUI/ModelHandler.cpp
+++ b/HopsanGUI/ModelHandler.cpp
@@ -239,8 +239,7 @@ void ModelHandler::loadModel()
     QStringList modelFileNames = QFileDialog::getOpenFileNames(gpMainWindowWidget, tr("Choose Model File"),
                                                          gpConfig->getStringSetting(CFG_LOADMODELDIR),
                                                          tr("Hopsan Model Files (*.hmf *.xml)"));
-    foreach(const QString &modelFileName, modelFileNames)
-    {
+    for(const QString &modelFileName : modelFileNames) {
         loadModel(modelFileName);
         QFileInfo fileInfo = QFileInfo(modelFileName);
         gpConfig->setStringSetting(CFG_LOADMODELDIR, fileInfo.absolutePath());

--- a/HopsanGUI/OptimizationHandler.cpp
+++ b/HopsanGUI/OptimizationHandler.cpp
@@ -200,10 +200,8 @@ void OptimizationHandler::initModels(ModelWidget *pModel, int nModels, QString &
         // Make sure logging is disabled/enabled for same ports as in original model
         //! @todo This code only deals with top-level components and ports and ignores contents of subsystems /Peter
         CoreSystemAccess *pCore = pModel->getTopLevelSystemContainer()->getCoreSystemAccessPtr();
-        foreach(const QString &compName, pModel->getTopLevelSystemContainer()->getModelObjectNames())
-        {
-            foreach(const Port *port, pModel->getTopLevelSystemContainer()->getModelObject(compName)->getPortListPtrs())
-            {
+        for(const QString &compName : pModel->getTopLevelSystemContainer()->getModelObjectNames()) {
+            for(const Port *port : pModel->getTopLevelSystemContainer()->getModelObject(compName)->getPortListPtrs()) {
                 QString portName = port->getName();
                 if (portName.contains(' '))
                 {
@@ -1344,10 +1342,8 @@ void OptimizationHandler::reInitialize(int nModels)
 
         //Make sure logging is disabled/enabled for same ports as in original model
         CoreSystemAccess *pCore = mModelPtrs.first()->getTopLevelSystemContainer()->getCoreSystemAccessPtr();
-        foreach(const QString &compName, mModelPtrs.first()->getTopLevelSystemContainer()->getModelObjectNames())
-        {
-            foreach(const Port *port, mModelPtrs.first()->getTopLevelSystemContainer()->getModelObject(compName)->getPortListPtrs())
-            {
+        for(const QString &compName : mModelPtrs.first()->getTopLevelSystemContainer()->getModelObjectNames()) {
+            for(const Port *port : mModelPtrs.first()->getTopLevelSystemContainer()->getModelObject(compName)->getPortListPtrs()) {
                 QString portName = port->getName();
                 bool enabled = pCore->isLoggingEnabled(compName, portName);
                 SystemObject *pOptSystem = mModelPtrs.last()->getTopLevelSystemContainer();

--- a/HopsanGUI/PlotArea.cpp
+++ b/HopsanGUI/PlotArea.cpp
@@ -1399,7 +1399,7 @@ void PlotArea::contextMenuEvent(QContextMenuEvent *event)
     {
         mBottomAxisShowOnlySamples = !mBottomAxisShowOnlySamples;
 
-        Q_FOREACH(PlotCurve *pCurve, mPlotCurves)
+        for(PlotCurve *pCurve : mPlotCurves)
         {
             pCurve->setShowVsSamples(mBottomAxisShowOnlySamples);
         }
@@ -2830,11 +2830,9 @@ void PlotArea::updateWindowtitleModelName()
 {
     //! @todo instead of string, maybe should use shared pointers (in the data variables to avoid duplicating the string for variables from same model) /Peter
     mModelPaths.clear();
-    foreach(PlotCurve *pCurve, mPlotCurves)
-    {
+    for(PlotCurve *pCurve : mPlotCurves) {
         const QString &name = pCurve->getSharedVectorVariable()->getModelPath();
-        if (!mModelPaths.contains(name) && !name.isEmpty())
-        {
+        if (!mModelPaths.contains(name) && !name.isEmpty()) {
             mModelPaths.append(name);
         }
     }
@@ -2913,7 +2911,7 @@ void PlotArea::setBackgroundColor(const QColor &rColor)
 void PlotArea::resetXDataVector()
 {
     // Remove any custom x-data
-    Q_FOREACH(PlotCurve *pCurve, mPlotCurves)
+    for(PlotCurve *pCurve : mPlotCurves)
     {
         if (pCurve->hasCustomXData())
         {

--- a/HopsanGUI/PlotTab.cpp
+++ b/HopsanGUI/PlotTab.cpp
@@ -144,9 +144,7 @@ void PlotTab::openTimeOffsetDialog()
 //! @brief Toggles the axis lock on/off for the enabled axis
 void PlotTab::toggleAxisLock()
 {
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->toggleAxisLock();
     }
 }
@@ -154,9 +152,7 @@ void PlotTab::toggleAxisLock()
 void PlotTab::openLegendSettingsDialog()
 {
     //! @todo solve in some smarter way
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->openLegendSettingsDialog();
     }
 }
@@ -193,9 +189,7 @@ void PlotTab::addBarChart(QStandardItemModel *pItemModel)
 //! @brief Rescales the axes and the zoomers so that all plot curves will fit
 void PlotTab::rescaleAxesToCurves()
 {
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->rescaleAxesToCurves();
     }
 }
@@ -274,11 +268,8 @@ bool PlotTab::isGridVisible() const
 
 void PlotTab::resetXTimeVector()
 {
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
-        if (pArea->hasCustomXData())
-        {
+    for(PlotArea *pArea : mPlotAreas) {
+        if (pArea->hasCustomXData()) {
             pArea->resetXDataVector();
         }
     }
@@ -289,7 +280,6 @@ void PlotTab::resetXTimeVector()
 //! @brief Slot that opens a dialog from where user can export current plot tab to a XML file
 void PlotTab::exportToXml()
 {
-
     //Open a dialog where text and font can be selected
     mpExportXmlDialog = new QDialog(this);
     mpExportXmlDialog->setWindowTitle("Export Plot Tab To XML");
@@ -765,8 +755,7 @@ void PlotTab::exportToHDF5()
     QList<SharedVectorVariableT> xvariables;
     QList<SharedVectorVariableT> timevariables;
     QList<PlotCurve*> curves = getCurves(0);
-    for(PlotCurve *pCurve : curves)
-    {
+    for(PlotCurve *pCurve : curves) {
         SharedVectorVariableT pVar, pToF, pCX;
         pVar = pCurve->getSharedVectorVariable();
         pToF = pCurve->getSharedTimeOrFrequencyVariable();
@@ -793,16 +782,14 @@ void PlotTab::exportToHDF5()
 
 void PlotTab::shiftAllGenerationsDown()
 {
-    Q_FOREACH(PlotArea *pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->shiftModelGenerationsDown();
     }
 }
 
 void PlotTab::shiftAllGenerationsUp()
 {
-    Q_FOREACH(PlotArea *pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->shiftModelGenerationsUp();
     }
 }
@@ -810,8 +797,7 @@ void PlotTab::shiftAllGenerationsUp()
 void PlotTab::updateWindowtitleModelNames()
 {
     QStringList names;
-    foreach(PlotArea *pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         names.append(pArea->getModelPaths());
     }
     mpParentPlotWindow->setModelPaths(names);
@@ -820,14 +806,11 @@ void PlotTab::updateWindowtitleModelNames()
 
 void PlotTab::enableZoom(bool value)
 {
-    if(value)
-    {
+    if(value) {
         mpParentPlotWindow->mpArrowButton->setChecked(false);
         mpParentPlotWindow->mpPanButton->setChecked(false);
 
-        PlotArea *pArea;
-        Q_FOREACH(pArea, mPlotAreas)
-        {
+        for(PlotArea *pArea : mPlotAreas) {
             pArea->enableZoom();
         }
     }
@@ -836,22 +819,17 @@ void PlotTab::enableZoom(bool value)
 void PlotTab::resetZoom()
 {
     //! @todo only the one selected
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->resetZoom();
     }
 }
 
 void PlotTab::enableArrow(bool value)
 {
-    if(value)
-    {
+    if(value) {
         mpParentPlotWindow->mpZoomButton->setChecked(false);
         mpParentPlotWindow->mpPanButton->setChecked(false);
-        PlotArea *pArea;
-        Q_FOREACH(pArea, mPlotAreas)
-        {
+        for(PlotArea *pArea : mPlotAreas) {
             pArea->enableArrow();
         }
     }
@@ -860,13 +838,10 @@ void PlotTab::enableArrow(bool value)
 
 void PlotTab::enablePan(bool value)
 {
-    if(value)
-    {
+    if(value) {
         mpParentPlotWindow->mpArrowButton->setChecked(false);
         mpParentPlotWindow->mpZoomButton->setChecked(false);
-        PlotArea *pArea;
-        Q_FOREACH(pArea, mPlotAreas)
-        {
+        for(PlotArea *pArea : mPlotAreas) {
             pArea->enablePan();
         }
 
@@ -876,9 +851,7 @@ void PlotTab::enablePan(bool value)
 
 void PlotTab::enableGrid(bool value)
 {
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->enableGrid(value);
     }
 }
@@ -887,11 +860,8 @@ void PlotTab::enableGrid(bool value)
 void PlotTab::setBackgroundColor()
 {
     QColor color = QColorDialog::getColor(mPlotAreas.first()->getQwtPlot()->canvasBackground().color(), this);
-    if (color.isValid())
-    {
-        PlotArea *pArea;
-        Q_FOREACH(pArea, mPlotAreas)
-        {
+    if (color.isValid()) {
+        for(PlotArea *pArea : mPlotAreas) {
             pArea->setBackgroundColor(color);
         }
     }
@@ -912,16 +882,14 @@ HopQwtPlot *PlotTab::getQwtPlot(const int subPlotId)
 
 void PlotTab::addCurve(PlotCurve *pCurve, const int subPlotId)
 {
-    if (subPlotId < mPlotAreas.size())
-    {
+    if (subPlotId < mPlotAreas.size()) {
         mPlotAreas[subPlotId]->addCurve(pCurve);
     }
 }
 
 void PlotTab::addCurve(PlotCurve *pCurve, PlotCurveStyle style, const int subPlotId)
 {
-    if (subPlotId < mPlotAreas.size())
-    {
+    if (subPlotId < mPlotAreas.size()) {
         mPlotAreas[subPlotId]->addCurve(pCurve, style);
     }
 }
@@ -929,8 +897,7 @@ void PlotTab::addCurve(PlotCurve *pCurve, PlotCurveStyle style, const int subPlo
 
 int PlotTab::getNumberOfCurves(const int subPlotId) const
 {
-    if (subPlotId < mPlotAreas.size())
-    {
+    if (subPlotId < mPlotAreas.size()) {
         return mPlotAreas[subPlotId]->getNumberOfCurves();
     }
     return 0;
@@ -940,9 +907,7 @@ bool PlotTab::isEmpty() const
 {
     //! @todo this needs to be overloaded for other types of plots that have no curves
     int sum=0;
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         sum+=pArea->getNumberOfCurves();
     }
     return sum==0;
@@ -966,9 +931,7 @@ bool PlotTab::isPanEnabled() const
 
 void PlotTab::update()
 {
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->replot();
     }
 }
@@ -1066,11 +1029,8 @@ bool PlotTab::isBarPlot() const
 
 bool PlotTab::hasCustomXData() const
 {
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
-        if (pArea->hasCustomXData())
-        {
+    for(PlotArea *pArea : mPlotAreas) {
+        if (pArea->hasCustomXData()) {
             return true;
         }
     }
@@ -1080,9 +1040,7 @@ bool PlotTab::hasCustomXData() const
 
 void PlotTab::setLegendsVisible(bool value)
 {
-    PlotArea *pArea;
-    Q_FOREACH(pArea, mPlotAreas)
-    {
+    for(PlotArea *pArea : mPlotAreas) {
         pArea->setLegendsVisible(value);
     }
 }
@@ -1195,7 +1153,7 @@ void PlotTab::exportImage()
     QwtPlotRenderer renderer;
     renderer.setDiscardFlag(QwtPlotRenderer::DiscardBackground,true);
     renderer.setDiscardFlag(QwtPlotRenderer::DiscardCanvasFrame,true);
-    renderer.renderDocument(getQwtPlot(0), mGraphicsExporter.imageFilename(), mGraphicsExporter.calcSizeMM(), mGraphicsExporter.dpi());
+    renderer.renderDocument(getQwtPlot(0), mGraphicsExporter.imageFilename(), mGraphicsExporter.calcSizeMM(), int(mGraphicsExporter.dpi()));
     //! @todo should work for all subplots in plot
 
     // The QwtPlotRenderer code does not check if the file was successfully written, so we can not know for sure.
@@ -1219,7 +1177,7 @@ void PlotTab::exportImageSelectFile()
 void PlotTab::updateMaximumBodeFreqHz(int value)
 {
     mpMaxFrequencyHzSpinBox->blockSignals(true);
-    mpMaxFrequencyHzSpinBox->setValue(value/(2*M_PI));
+    mpMaxFrequencyHzSpinBox->setValue(int(value/(2.0*M_PI)));
     mpMaxFrequencyHzSpinBox->blockSignals(false);
 }
 
@@ -1228,7 +1186,7 @@ void PlotTab::updateMaximumBodeFreqHz(int value)
 void PlotTab::updateMaximumBodeFreqRadSec(int value)
 {
     mpMaxFrequencyRadSecSpinBox->blockSignals(true);
-    mpMaxFrequencyRadSecSpinBox->setValue(value*2*M_PI);
+    mpMaxFrequencyRadSecSpinBox->setValue(int(value*2.0*M_PI));
     mpMaxFrequencyRadSecSpinBox->blockSignals(false);
 }
 
@@ -1268,10 +1226,8 @@ void PlotTab::removePlotArea(const int id)
 
 int PlotTab::getPlotIDForCurve(PlotCurve *pCurve)
 {
-    for (int i=0; i<mPlotAreas.size(); ++i)
-    {
-        if (mPlotAreas[i]->getCurves().contains(pCurve))
-        {
+    for(int i=0; i<mPlotAreas.size(); ++i) {
+        if (mPlotAreas[i]->getCurves().contains(pCurve)) {
             return i;
         }
     }
@@ -1400,7 +1356,7 @@ void PlotTab::openFrequencyAnalysisDialog(PlotCurve *pCurve)
 
     double xdiff = maxX-minX;
     if(0 == xdiff) {
-        gpMessageHandler->addErrorMessage("Minimum and maximum value of X-vector must not be equal when creating frequency spectrum");
+            gpMessageHandler->addErrorMessage("Minimum and maximum value of X-vector must not be equal when creating frequency spectrum");
         return;
     }
 
@@ -1592,13 +1548,13 @@ void PlotTab::openCreateBodePlotDialog()
         QLabel *pMaxFrequencyRadSecUnit = new QLabel("rad/s");
         mpMaxFrequencyHzSpinBox = new QSpinBox(this);
         mpMaxFrequencyHzSpinBox->setMinimum(0);
-        mpMaxFrequencyHzSpinBox->setMaximum(maxFreq);
-        mpMaxFrequencyHzSpinBox->setValue(maxFreq);
+        mpMaxFrequencyHzSpinBox->setMaximum(int(maxFreq));
+        mpMaxFrequencyHzSpinBox->setValue(int(maxFreq));
         mpMaxFrequencyHzSpinBox->setSingleStep(1);
         mpMaxFrequencyRadSecSpinBox = new QSpinBox(this);
         mpMaxFrequencyRadSecSpinBox->setMinimum(0);
-        mpMaxFrequencyRadSecSpinBox->setMaximum(maxFreq*2*M_PI);
-        mpMaxFrequencyRadSecSpinBox->setValue(maxFreq*2*M_PI);
+        mpMaxFrequencyRadSecSpinBox->setMaximum(int(maxFreq*2.0*M_PI));
+        mpMaxFrequencyRadSecSpinBox->setValue(int(maxFreq*2.0*M_PI));
         mpMaxFrequencyRadSecSpinBox->setSingleStep(1);
         connect(mpMaxFrequencyHzSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateMaximumBodeFreqRadSec(int)));
         connect(mpMaxFrequencyRadSecSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateMaximumBodeFreqHz(int)));
@@ -1651,7 +1607,7 @@ void PlotTab::openCreateBodePlotDialog()
         int rc = pBodeDialog->exec();
         if (rc == QDialog::Accepted)
         {
-            PlotCurve *pInputCurve=0, *pOutputCurve=0;
+            PlotCurve *pInputCurve=nullptr, *pOutputCurve=nullptr;
             QMap<QRadioButton *, PlotCurve *>::iterator it;
             for(it=bodeInputButtonToCurveMap.begin(); it!=bodeInputButtonToCurveMap.end(); ++it)
             {
@@ -1670,7 +1626,7 @@ void PlotTab::openCreateBodePlotDialog()
                 }
             }
             //! @todo maybe check that both are time vectors and that both have same time
-            if(pInputCurve == 0 || pOutputCurve == 0)
+            if(pInputCurve == nullptr || pOutputCurve == nullptr)
             {
                 QMessageBox::warning(this, tr("Transfer Function Analysis Failed"), tr("Both input and output vectors must be selected."));
             }
@@ -1687,7 +1643,7 @@ void PlotTab::openCreateBodePlotDialog()
                 else if(pWindowingComboBox->currentIndex() == 1) {
                     function = HannWindow;
                 }
-                else if(pWindowingComboBox->currentIndex() == 2) {
+                else/* if(pWindowingComboBox->currentIndex() == 2)*/ {
                     function = FlatTopWindow;
                 }
 
@@ -1785,8 +1741,7 @@ void PlotGraphicsExporter::openExportDialog()
 
     mpSetImageFormat = new QComboBox(mpDialog);
     mpSetImageFormat->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    foreach(QString format, mSupportedFormats)
-    {
+    for(const QString &format : mSupportedFormats) {
         mpSetImageFormat->addItem(format);
     }
     mpSetImageFormat->setCurrentIndex(mpSetImageFormat->findText(mImageFormat, Qt::MatchExactly));

--- a/HopsanGUI/Utilities/GUIUtilities.cpp
+++ b/HopsanGUI/Utilities/GUIUtilities.cpp
@@ -583,22 +583,12 @@ void removeDir(QString path, qint64 age_seconds)
     }
 
     QDir dir(path);
-    Q_FOREACH(QFileInfo entryInfo, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
-    {
-        if (entryInfo.isDir())
-        {
+    for(const QFileInfo &entryInfo : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
+        if (entryInfo.isDir()) {
             removeDir(entryInfo.absoluteFilePath(), age_seconds);
         }
-        else
-        {
-//#ifdef _WIN32
-//            QStringList s;
-//            s << "del "+info.absoluteFilePath();
-//            QProcess browser;
-//            browser.start("cmd", s);
-//#else
+        else {
             QFile::remove(entryInfo.absoluteFilePath());
-//#endif
         }
     }
     dir.rmdir(path);
@@ -612,20 +602,16 @@ void copyDir(const QString fromPath, QString toPath)
 {
     QDir toDir(toPath);
     toDir.mkpath(toPath);
-    if (toPath.endsWith('/'))
-    {
+    if (toPath.endsWith('/')) {
         toPath.chop(1);
     }
 
     QDir fromDir(fromPath);
-    foreach(QFileInfo info, fromDir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
-    {
-        if (info.isDir())
-        {
+    for(QFileInfo info : fromDir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
+        if (info.isDir()) {
             copyDir(info.absoluteFilePath(), toPath+"/"+info.fileName());
         }
-        else
-        {
+        else {
             QFile::copy(info.absoluteFilePath(), toPath+"/"+info.fileName());
         }
     }

--- a/HopsanGUI/Widgets/AnimationWidget.cpp
+++ b/HopsanGUI/Widgets/AnimationWidget.cpp
@@ -616,8 +616,7 @@ void AnimationWidget::resetAllAnimationDataToDefault()
 
         //Store icon paths (they are not included in saveToDomElement() )
         QStringList iconPaths;
-        foreach(const ModelObjectAnimationMovableData &m, pComp->getAnimationDataPtr()->movables)
-        {
+        for(const ModelObjectAnimationMovableData &m : pComp->getAnimationDataPtr()->movables) {
             iconPaths << m.iconPath;
         }
 

--- a/HopsanGUI/Widgets/DebuggerWidget.cpp
+++ b/HopsanGUI/Widgets/DebuggerWidget.cpp
@@ -197,8 +197,7 @@ void DebuggerWidget::updatePortsList(QString component)
     mpPortsList->clear();
     mpVariablesList->clear();
     QList<Port*> ports = mpModel->getTopLevelSystemContainer()->getModelObject(component)->getPortListPtrs();
-    Q_FOREACH(const Port *port, ports)
-    {
+    for(const Port *port : ports) {
         mpPortsList->addItem(port->getName());
     }
     mpPortsList->sortItems();
@@ -352,8 +351,7 @@ void DebuggerWidget::logLastData()
     mpTraceTable->insertRow(mpTraceTable->rowCount());
     QTableWidgetItem *pItem = new QTableWidgetItem(QString::number(getCurrentStep())+": "+QString::number(getCurrentTime()));
     mpTraceTable->setVerticalHeaderItem(mpTraceTable->rowCount()-1, pItem);
-    Q_FOREACH(const QString &var, mVariables)
-    {
+    for(const QString &var : mVariables) {
         QString component = var.split("#").at(0);
         QString port = var.split("#").at(1);
         QString data = var.split("#").at(2);

--- a/HopsanGUI/Widgets/FindWidget.cpp
+++ b/HopsanGUI/Widgets/FindWidget.cpp
@@ -159,24 +159,19 @@ void FindWidget::findComponent(const QString &rName, const bool centerView, Qt::
         int nFound=0;
         QStringList compNames = mpContainer->getModelObjectNames();
         //!  @todo what about searching in subsystems
-        foreach(QString comp, compNames)
-        {
+        for(QString comp : compNames) {
             bool match;
-            if(wildcard)
-            {
+            if(wildcard) {
                 QRegExp re(rName, caseSensitivity, QRegExp::Wildcard);
                 match = re.exactMatch(comp);
             }
-            else
-            {
+            else {
                 match = comp.contains(rName, caseSensitivity);
             }
 
-            if (match)
-            {
+            if (match) {
                 ModelObject *pMO = mpContainer->getModelObject(comp);
-                if (pMO)
-                {
+                if (pMO) {
                     ++nFound;
                     pMO->highlight();
                     mean += pMO->pos();
@@ -203,29 +198,24 @@ void FindWidget::findAlias(const QString &rName, const bool centerView, Qt::Case
         int nFound=0;
         QStringList aliasNames = mpContainer->getAliasNames();
         //!  @todo what about searching in subsystems
-        foreach(QString alias, aliasNames)
-        {
+        for(QString alias : aliasNames) {
             bool match;
-            if(wildcard)
-            {
+            if(wildcard) {
                 QRegExp re(rName, caseSensitivity, QRegExp::Wildcard);
                 match = re.exactMatch(alias);
             }
-            else
-            {
+            else {
                 match = alias.contains(rName, caseSensitivity);
             }
 
-            if (match)
-            {
+            if (match) {
                 QString fullName = mpContainer->getFullNameFromAlias(alias);
                 QString comp, port, var;
                 QStringList sysHierarchy;
                 splitFullVariableName(fullName, sysHierarchy, comp, port, var);
                 ModelObject *pMO = mpContainer->getModelObject(comp);
                 //! @todo we should actually highlight the port also (and center on the port)
-                if (pMO)
-                {
+                if (pMO) {
                     ++nFound;
                     pMO->highlight();
                     mean += pMO->pos();
@@ -234,8 +224,7 @@ void FindWidget::findAlias(const QString &rName, const bool centerView, Qt::Case
         }
 
         // Now center view over found model objects
-        if (nFound > 0 && centerView)
-        {
+        if (nFound > 0 && centerView) {
             mean /= double(nFound);
             mpContainer->mpModelWidget->getGraphicsView()->centerOn(mean);
         }
@@ -263,13 +252,11 @@ void FindWidget::findSystemParameter(const QStringList &rNames, const bool cente
         QPointF mean;
         int nFound=0;
         const QList<ModelObject*> mops = mpContainer->getModelObjects();
-        foreach(ModelObject* pMO, mops)
-        {
+        for(ModelObject* pMO : mops) {
             bool hasPar = false;
             QVector<CoreParameterData> pars;
             pMO->getParameters(pars);
-            foreach(CoreParameterData par, pars)
-            {
+            for(CoreParameterData par : pars) {
                 QString expression = removeAllSpaces(par.mValue);
 
                 // OK, I cant figure out how to write the regexp to solve this, so I am splitting the string instead

--- a/HopsanGUI/Widgets/LibraryWidget.cpp
+++ b/HopsanGUI/Widgets/LibraryWidget.cpp
@@ -336,20 +336,14 @@ void LibraryWidget::update()
     }
 
     //Expand previously expanded folders
-    foreach(const QStringList &list, expandedItems)
-    {
-        for(int i=0; i<mpTree->topLevelItemCount(); ++i)
-        {
-            if(mpTree->topLevelItem(i)->text(0) == list[0])
-            {
+    for(const QStringList &list : expandedItems) {
+        for(int i=0; i<mpTree->topLevelItemCount(); ++i) {
+            if(mpTree->topLevelItem(i)->text(0) == list[0]) {
                 QTreeWidgetItem *pItem = mpTree->topLevelItem(i);
                 pItem->setExpanded(true);
-                for(int j=1; j<list.size(); ++j)
-                {
-                    for(int k=0; k<pItem->childCount(); ++k)
-                    {
-                        if(pItem->child(k)->text(0) == list[j])
-                        {
+                for(int j=1; j<list.size(); ++j) {
+                    for(int k=0; k<pItem->childCount(); ++k) {
+                        if(pItem->child(k)->text(0) == list[j]) {
                             pItem = pItem->child(k);
                             pItem->setExpanded(true);
                             break;

--- a/HopsanGUI/Widgets/PlotWidget2.cpp
+++ b/HopsanGUI/Widgets/PlotWidget2.cpp
@@ -962,12 +962,9 @@ void VariableTree::getExpandedImportFiles(QStringList &rList)
 
 void VariableTree::expandImportFileItems(const QStringList &rList)
 {
-    QString fName;
-    Q_FOREACH(fName, rList)
-    {
-        QTreeWidgetItem* pItem = mImportedFileItemMap.value(fName,0);
-        if (pItem)
-        {
+    for(const QString &fName : rList) {
+        QTreeWidgetItem* pItem = mImportedFileItemMap.value(fName, nullptr);
+        if (pItem) {
             pItem->setExpanded(true);
         }
     }
@@ -975,10 +972,8 @@ void VariableTree::expandImportFileItems(const QStringList &rList)
 
 void VariableTree::expandFullVariableItems(const QStringList &rList)
 {
-    QString cName;
-    Q_FOREACH(cName, rList)
-    {
-        QTreeWidgetItem* pItem = mFullVariableItemMap.value(cName,0);
+    for(const QString &cName : rList) {
+        QTreeWidgetItem* pItem = mFullVariableItemMap.value(cName, nullptr);
         if (pItem)
         {
             pItem->setExpanded(true);

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -844,21 +844,22 @@ void TextEditor::updateAutoCompleteList()
         int bracketCounter=-1;
 
         QStringList variables;
-        foreach(const QString &line, lines)
-        {
-            if(line.simplified().startsWith("class "))
+        for(const QString &line : lines) {
+            if(line.simplified().startsWith("class ")) {
                 bracketCounter = 0;
+            }
 
             bracketCounter += line.count("{");
             bracketCounter -= line.count("}");
-            if(bracketCounter != 1)
+            if(bracketCounter != 1) {
                 continue;
+            }
 
-            if(line.contains("()")) //Ignore functions
+            if(line.contains("()")) { //Ignore functions
                 continue;
+            }
 
-            if(dataTypes.contains(line.simplified().section(" ",0,0)))
-            {
+            if(dataTypes.contains(line.simplified().section(" ",0,0))) {
                 variables.append(line.section("//",0,0).simplified().split(","));
             }
         }

--- a/HopsanGenerator/include/GeneratorTypes.h
+++ b/HopsanGenerator/include/GeneratorTypes.h
@@ -186,9 +186,9 @@ class GeneratorNodeInfo
         QStringList cVariables;
         QStringList variableLabels;
         QStringList shortNames;
-        QList<size_t> varIdx;
-        QList<size_t> qVariableIds;
-        QList<size_t> cVariableIds;
+        QList<int> varIdx;
+        QList<int> qVariableIds;
+        QList<int> cVariableIds;
 };
 
 class ParameterSpecification

--- a/HopsanGenerator/src/GeneratorTypes.cpp
+++ b/HopsanGenerator/src/GeneratorTypes.cpp
@@ -410,7 +410,7 @@ GeneratorNodeInfo::GeneratorNodeInfo(QString nodeType)
         isValidNode = true;
         niceName = pNode->getNiceName().c_str();
         QStringList qVariableLabels, cVariableLabels;
-        QList<size_t> qVarIdx, cVarIdx;
+        QList<int> qVarIdx, cVarIdx;
         for(size_t i=0; i<pNode->getDataDescriptions()->size(); ++i)
         {
             const hopsan::NodeDataDescription *pVarDesc = pNode->getDataDescription(i);
@@ -443,8 +443,7 @@ void GeneratorNodeInfo::getNodeTypes(QStringList &nodeTypes)
     //! @todo this will only be able to list the default included nodes (which may be a problem in the future)
     hopsan::HopsanEssentials hopsanCore;
     std::vector<hopsan::HString> types = hopsanCore.getRegisteredNodeTypes();
-    Q_FOREACH(const hopsan::HString &type, types)
-    {
+    for(const hopsan::HString &type : types) {
         nodeTypes << type.c_str();
     }
 }
@@ -459,7 +458,7 @@ InterfacePortSpec::InterfacePortSpec(InterfaceTypesEnumT type, QString component
 
     QStringList inputDataNames;
     QStringList outputDataNames;
-    QList<size_t> inputDataIds, outputDataIds;
+    QList<int> inputDataIds, outputDataIds;
 
     switch(type)
     {
@@ -581,12 +580,10 @@ InterfacePortSpec::InterfacePortSpec(InterfaceTypesEnumT type, QString component
         break;
     }
 
-    foreach(const QString &dataName, inputDataNames)
-    {
+    for(const QString &dataName : inputDataNames) {
         vars.append(InterfaceVarSpec(dataName, inputDataIds.takeFirst(), InterfaceVarSpec::Input));
     }
-    foreach(const QString &dataName, outputDataNames)
-    {
+    for(const QString &dataName : outputDataNames) {
         vars.append(InterfaceVarSpec(dataName, outputDataIds.takeFirst(), InterfaceVarSpec::Output));
     }
 }

--- a/HopsanGenerator/src/GeneratorUtilities.cpp
+++ b/HopsanGenerator/src/GeneratorUtilities.cpp
@@ -84,20 +84,15 @@ bool removeDir(QString path)
 {
     QDir dir;
     dir.setPath(path);
-    Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
-    {
-        if (info.isDir())
-        {
+    for(const QFileInfo &info : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
+        if (info.isDir()) {
             removeDir(info.absoluteFilePath());
         }
-        else
-        {
-            if(QFile::remove(info.absoluteFilePath()))
-            {
+        else {
+            if(QFile::remove(info.absoluteFilePath())) {
                 qDebug() << "Successfully removed " << info.absoluteFilePath();
             }
-            else
-            {
+            else {
                 qDebug() << "Failed to remove " << info.absoluteFilePath();
             }
         }

--- a/HopsanGenerator/src/generators/HopsanExeGenerator.cpp
+++ b/HopsanGenerator/src/generators/HopsanExeGenerator.cpp
@@ -155,8 +155,7 @@ bool HopsanExeGenerator::compileAndLinkExe(const QString &buildPath, const QStri
     compileCppBatchStream << "@echo on\n";
     compileCppBatchStream << "g++ -pipe -std=c++11 -c -DHOPSAN_INTERNALDEFAULTCOMPONENTS -DHOPSAN_INTERNAL_EXTRACOMPONENTS " << "exe_main.cpp exe_utilities.cpp " << mExtraSourceFiles.join(" ");
     QStringList srcFiles = listHopsanCoreSourceFiles(buildPath) + listInternalLibrarySourceFiles(buildPath);
-    Q_FOREACH(const QString &srcFile, srcFiles)
-    {
+    for(const QString &srcFile : srcFiles) {
         compileCppBatchStream << " " << srcFile;
     }
     // Add HopsanCore (and necessary dependency) include paths
@@ -182,8 +181,7 @@ bool HopsanExeGenerator::compileAndLinkExe(const QString &buildPath, const QStri
     QTextStream compileCppBatchStream(&compileCppBatchFile);
     compileCppBatchStream << mCompilerSelection.path+"g++ -pipe -std=c++11 -c -DHOPSAN_INTERNALDEFAULTCOMPONENTS -DHOPSAN_INTERNAL_EXTRACOMPONENTS " << "exe_main.cpp exe_utilities.cpp " << mExtraSourceFiles.join(" ");
     QStringList srcFiles = listHopsanCoreSourceFiles(buildPath) + listInternalLibrarySourceFiles(buildPath);
-    Q_FOREACH(const QString &srcFile, srcFiles)
-    {
+    for(const QString &srcFile : srcFiles) {
         compileCppBatchStream << " " << srcFile;
     }
     // Add HopsanCore (and necessary dependency) include paths
@@ -248,8 +246,7 @@ bool HopsanExeGenerator::compileAndLinkExe(const QString &buildPath, const QStri
     linkBatchStream << "PATH=" << mCompilerSelection.path << ";%PATH%\n";
     linkBatchStream << "@echo on\n";
     linkBatchStream << "g++ -w -static -static-libgcc";
-    Q_FOREACH(const QString &objFile, objectFiles)
-    {
+    for(const QString &objFile : objectFiles) {
         linkBatchStream << " " << objFile;
     }
     linkBatchStream << " -o \""+outputExecutableFile+"\"\n";
@@ -274,8 +271,7 @@ bool HopsanExeGenerator::compileAndLinkExe(const QString &buildPath, const QStri
     //Write the compilation script file
     QTextStream linkBatchStream(&linkBatchFile);
     linkBatchStream << mCompilerSelection.path+"g++ -pthread -w";
-    Q_FOREACH(const QString &objFile, objectFiles)
-    {
+    for(const QString &objFile : objectFiles) {
         linkBatchStream << " " << objFile;
     }
     for(const QString& linkPaths : mLinkPaths) {

--- a/HopsanGenerator/src/generators/HopsanGeneratorBase.cpp
+++ b/HopsanGenerator/src/generators/HopsanGeneratorBase.cpp
@@ -1481,8 +1481,7 @@ bool HopsanGeneratorBase::copyBoostIncludeFilesToDir(const QString &path) const
     saveDir.cd("bin");
     QStringList binFiles = saveDir.entryList(QDir::Files | QDir::NoDotAndDotDot);
 
-    Q_FOREACH(const QString &fileName, binFiles)
-    {
+    for(const QString &fileName : binFiles) {
         QFile file(path+"/include/boost/bin/"+fileName);
         //qDebug() << "File: " << path+"/include/boost/bin/"+fileName;
         file.copy(path+"/"+fileName);
@@ -1542,12 +1541,10 @@ void HopsanGeneratorBase::cleanUp(const QString &path, const QStringList &files,
     printMessage("Cleaning up directory: " + path);
 
     QDir cleanDir(path);
-    Q_FOREACH(const QString &file, files)
-    {
+    for(const QString &file : files) {
         cleanDir.remove(file);
     }
-    Q_FOREACH(const QString &subDir, subDirs)
-    {
+    for(const QString &subDir : subDirs) {
         removeDir(path+"/"+subDir);
     }
 }

--- a/HopsanGenerator/src/generators/HopsanModelicaGenerator.cpp
+++ b/HopsanGenerator/src/generators/HopsanModelicaGenerator.cpp
@@ -1244,11 +1244,9 @@ bool HopsanModelicaGenerator::generateComponentObject(ComponentSpecification &co
 bool HopsanModelicaGenerator::sortEquationByVariables(QList<Expression> &equations, QList<Expression> &variables, QList<Expression> &knowns)
 {
     //Generate list of variables in equations
-    Q_FOREACH(const Expression &equation, equations)
-    {
+    for(const Expression &equation : equations) {
         QList<Expression> tempVars = equation.getVariables();
-        Q_FOREACH(const Expression var, tempVars)
-        {
+        for(const Expression var : tempVars) {
             if(!variables.contains(var) && !knowns.contains(var))
                 variables.append(var);
         }
@@ -1262,13 +1260,10 @@ bool HopsanModelicaGenerator::sortEquationByVariables(QList<Expression> &equatio
 
     //Generate list of dependencies (i.e. which state variable derivatives exist in each equation)
     QList<QList<Expression> > dependencies;
-    Q_FOREACH(const Expression &equation, equations)
-    {
+    for(const Expression &equation : equations) {
         dependencies.append(QList<Expression>());
-        Q_FOREACH(const Expression &var, variables)
-        {
-            if(equation.contains(var))
-            {
+        for(const Expression &var : variables) {
+            if(equation.contains(var)) {
                 dependencies[equations.indexOf(equation)].append(Expression(var));
             }
         }

--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -180,28 +180,18 @@ Expression::Expression(QStringList symbols, const ExpressionSimplificationT simp
 //FIXED
 Expression::Expression(const double value)
 {
-    mpLeft = 0;
-    mpRight = 0;
-    mpBase = 0;
-    mpPower = 0;
-    mpDividend = 0;
+    mpLeft = nullptr;
+    mpRight = nullptr;
+    mpBase = nullptr;
+    mpPower = nullptr;
+    mpDividend = nullptr;
 
-    if(value < 0)
-    {
+    if(value < 0) {
         this->replaceBy(Expression::fromTwoFactors(Expression("-1"), Expression(-1*value)));
         return;
     }
     mString = QString::number(value, 'f', 20);
     while(mString.endsWith("00")) { mString.chop(1); }
-
-    //Make sure numerical symbols have double precision
-//    bool isInt;
-//    mString.toInt(&isInt);
-//    if(isInt)
-//    {
-//        //mString.append(".0");
-//        mString = QString::number(mString.toDouble(), 'f', 20);
-    //    }
 }
 
 
@@ -219,31 +209,31 @@ void Expression::cleanUp()
     {
         mpLeft->cleanUp();
         delete mpLeft;
-        mpLeft = 0;
+        mpLeft = nullptr;
     }
     if(mpRight)
     {
         mpRight->cleanUp();
         delete mpRight;
-        mpRight = 0;
+        mpRight = nullptr;
     }
     if(mpBase)
     {
         mpBase->cleanUp();
         delete mpBase;
-        mpBase = 0;
+        mpBase = nullptr;
     }
     if(mpPower)
     {
         mpPower->cleanUp();
         delete mpPower;
-        mpPower = 0;
+        mpPower = nullptr;
     }
     if(mpDividend)
     {
         mpDividend->cleanUp();
         delete mpDividend;
-        mpDividend = 0;
+        mpDividend = nullptr;
     }
 }
 
@@ -256,11 +246,11 @@ void Expression::commonConstructorCode(QStringList symbols, bool &ok, const Expr
 {
     ok = true;
 
-    mpLeft = 0;
-    mpRight = 0;
-    mpBase = 0;
-    mpPower = 0;
-    mpDividend = 0;
+    mpLeft = nullptr;
+    mpRight = nullptr;
+    mpBase = nullptr;
+    mpPower = nullptr;
+    mpDividend = nullptr;
 
     //Only one symbol, so parse it as a string
     if(symbols.size() == 1)
@@ -526,7 +516,6 @@ void Expression::commonConstructorCode(QStringList symbols, bool &ok, const Expr
 
 
 //! @brief Equality operator for expressions
-//FIXED
 bool Expression::operator==(const Expression &other) const
 {
     bool functionOk = false;
@@ -561,12 +550,9 @@ bool Expression::operator==(const Expression &other) const
     }
     bool dividendOk = (!mpDividend && !other.getDividends()) || (mpDividend && other.getDividends() && *mpDividend == (*other.getDividends()));
     bool termsOk=true;
-    if(this->isAdd() && other.isAdd())
-    {
-        Q_FOREACH(const Expression &term, mTerms)
-        {
-            if(other.getTerms().count(term) != mTerms.count(term))
-            {
+    if(this->isAdd() && other.isAdd()) {
+        for(const Expression &term : mTerms) {
+            if(other.getTerms().count(term) != mTerms.count(term)) {
                 termsOk=false;
             }
         }
@@ -575,24 +561,18 @@ bool Expression::operator==(const Expression &other) const
     bool stringOk = (mString == other.mString);
 
     bool factorOk = (mFactors.size() == other.mFactors.size());
-    if(this->isMultiplyOrDivide() && other.isMultiplyOrDivide() && factorOk)
-    {
-        Q_FOREACH(const Expression &factor, mFactors)
-        {
-            if(other.getFactors().count(factor) != mFactors.count(factor))
-            {
+    if(this->isMultiplyOrDivide() && other.isMultiplyOrDivide() && factorOk) {
+        for(const Expression &factor : mFactors) {
+            if(other.getFactors().count(factor) != mFactors.count(factor)) {
                 factorOk=false;
             }
         }
     }
 
     bool divisorOk = true;
-    if(this->isMultiplyOrDivide() && other.isMultiplyOrDivide())
-    {
-        Q_FOREACH(const Expression &divisor, mDivisors)
-        {
-            if(other.getDivisors().count(divisor) != mDivisors.count(divisor))
-            {
+    if(this->isMultiplyOrDivide() && other.isMultiplyOrDivide()) {
+        for(const Expression &divisor : mDivisors) {
+            if(other.getDivisors().count(divisor) != mDivisors.count(divisor)) {
                 divisorOk=false;
             }
         }
@@ -769,43 +749,37 @@ Expression Expression::fromEquation(const Expression left, const Expression righ
 //! @returns Evaluated value of expression
 double Expression::evaluate(const QMap<QString, double> &variables, const QMap<QString, SymHopFunctionoid*> *functions, bool *ok) const
 {
-    if(!ok)
+    if(!ok) {
         ok = new bool;
+    }
 
     *ok=true;
 
-    if(isAdd())
-    {
+    if(isAdd()) {
         double retval = 0;
         bool allOk = true;
-        Q_FOREACH(const Expression &term, mTerms)
-        {
+        for(const Expression &term : mTerms) {
             bool thisOk;
             retval += term.evaluate(variables, functions, &thisOk);
             allOk *= thisOk;
         }
-        if(allOk)
-        {
+        if(allOk) {
             return retval;
         }
     }
-    else if(isMultiplyOrDivide())
-    {
+    else if(isMultiplyOrDivide()) {
         double retval = 1;
         bool allOk = true;
         bool thisOk;
-        Q_FOREACH(const Expression &factor, mFactors)
-        {
+        for(const Expression &factor : mFactors) {
             retval *= factor.evaluate(variables, functions, &thisOk);
             allOk *= thisOk;
         }
-        Q_FOREACH(const Expression &divisor, mDivisors)
-        {
+        for(const Expression &divisor : mDivisors) {
             retval /= divisor.evaluate(variables, functions, &thisOk);
             allOk *= thisOk;
         }
-        if(allOk)
-        {
+        if(allOk) {
             return retval;
         }
     }
@@ -846,15 +820,13 @@ double Expression::evaluate(const QMap<QString, double> &variables, const QMap<Q
         if(mArguments.size() == 0)
         {
             bool ok1=true;
-            if(mFunction == "pi") { retval = M_PI; }
-            else
-            {
-                ok1=false;
-            }
-
-            if(ok1)
-            {
+            if(mFunction == "pi") {
+                retval = M_PI;
                 return retval;
+            }
+            else {
+                ok1=false;
+                return 0;
             }
         }
         else if(mArguments.size() == 1)
@@ -891,6 +863,7 @@ double Expression::evaluate(const QMap<QString, double> &variables, const QMap<Q
             else
             {
                 ok1=false;
+                return 0;
             }
 
             if(ok1)
@@ -972,6 +945,7 @@ double Expression::evaluate(const QMap<QString, double> &variables, const QMap<Q
             else
             {
                 ok1=false;
+                return 0;
             }
 
             if(ok1 && ok2)
@@ -1000,6 +974,7 @@ double Expression::evaluate(const QMap<QString, double> &variables, const QMap<Q
             else
             {
                 ok1=false;
+                return 0;
             }
 
             if(ok1 && ok2 && ok3)
@@ -1021,12 +996,13 @@ double Expression::evaluate(const QMap<QString, double> &variables, const QMap<Q
     {
         double retval;
         bool ok1, ok2;
-        if(mpLeft->evaluate(variables, functions, &ok1) == mpRight->evaluate(variables, functions, &ok2))
+        if(mpLeft->evaluate(variables, functions, &ok1) == mpRight->evaluate(variables, functions, &ok2)) {
             retval = 1;
-        else
+        }
+        else {
             retval = 0;
-        if(ok1 && ok2)
-        {
+        }
+        if(ok1 && ok2) {
             return retval;
         }
     }
@@ -1047,7 +1023,6 @@ void Expression::replaceByCopy(const Expression expr)
 
 //! @brief Replaces this expression by another one
 //! @param expr Expression to replace by
-//FIXED
 void Expression::replaceBy(const Expression &expr)
 {
     mString = expr.mString;
@@ -1081,11 +1056,11 @@ void Expression::replaceBy(const Expression &expr)
     }
     mTerms.swap(tempTerms);
 
-    mpBase = 0;
-    mpPower = 0;
-    mpLeft = 0;
-    mpRight = 0;
-    mpDividend = 0;
+    mpBase = nullptr;
+    mpPower = nullptr;
+    mpLeft = nullptr;
+    mpRight = nullptr;
+    mpDividend = nullptr;
     if(expr.getBase())
     {
         //! @todo here (and below) we might have two problems,  first a potential memory leak, we just zero the pointers above
@@ -1129,7 +1104,6 @@ void Expression::divideBy(const Expression div)
 
 //! @brief Multiplies the expression by specified divisor
 //! @param fac Factor expression
-//FIXED
 void Expression::multiplyBy(const Expression fac)
 {
     this->replaceBy(Expression::fromTwoFactors(*this, fac));
@@ -1139,7 +1113,6 @@ void Expression::multiplyBy(const Expression fac)
 
 //! @brief Adds the expression with specified tern
 //! @param tern Term expression
-//FIXED
 void Expression::addBy(const Expression term)
 {
     this->replaceBy(Expression::fromTwoTerms(*this, term));
@@ -1149,7 +1122,6 @@ void Expression::addBy(const Expression term)
 
 //! @brief Subtracts the expression by specified term
 //! @param tern Term expression
-//FIXED
 void Expression::subtractBy(const Expression term)
 {
     Expression subTerm = term;
@@ -1160,17 +1132,14 @@ void Expression::subtractBy(const Expression term)
 
 
 //! @brief Returns the expression converted to a string
-//FIXED
 QString Expression::toString() const
 {
     QString ret;
 
-    if(this->isSymbol())
-    {
+    if(this->isSymbol()) {
         ret = mString;
     }
-    else if(this->isFunction())
-    {
+    else if(this->isFunction()) {
         ret = mFunction+"(";
         for(int i=0; i<mArguments.size(); ++i)
         {
@@ -1181,16 +1150,13 @@ QString Expression::toString() const
         }
         ret.append(")");
     }
-    else if(this->isEquation())
-    {
+    else if(this->isEquation()) {
         QString leftStr =mpLeft->toString();
         QString rightStr = mpRight->toString();
         ret = leftStr + "=" + rightStr;
     }
-    else if(this->isAdd())
-    {
-        Q_FOREACH(const Expression &term, mTerms)
-        {
+    else if(this->isAdd()) {
+        for(const Expression &term : mTerms) {
             Expression tempTerm = term;
             QString termString;
             if(tempTerm.isNegative())
@@ -1208,13 +1174,11 @@ QString Expression::toString() const
         }
         ret.chop(1);
     }
-    else if(this->isMultiplyOrDivide())
-    {
+    else if(this->isMultiplyOrDivide()) {
         int numMinus = mFactors.count(Expression("-1"))+mDivisors.count(Expression("-1"));
         bool isOdd = (numMinus%2 != 0);
 
-        Q_FOREACH(const Expression &factor, mFactors)
-        {
+        for(const Expression &factor : mFactors) {
             QString factString = factor.toString();
             if(factor.isAdd())
             {
@@ -1224,18 +1188,15 @@ QString Expression::toString() const
             ret.append(factString);
             ret.append("*");
         }
-        if(mFactors.isEmpty())
-        {
+        if(mFactors.isEmpty()) {
             ret.append("1");
         }
-        else
-        {
+        else {
             ret.chop(1);
         }
         if(!mDivisors.isEmpty()) { ret.append("/"); }
         if(mDivisors.size() > 1) { ret.append("("); }
-        Q_FOREACH(const Expression &divisor, mDivisors)
-        {
+        for(const Expression &divisor : mDivisors) {
             QString divString = divisor.toString();
             if(divisor.isAdd())
             {
@@ -1377,8 +1338,6 @@ void Expression::toDelayForm(QList<Expression> &rDelayTerms, QStringList &rDelay
     //Simplify
     this->_simplify(Expression::FullSimplification, Recursive);
 
-
-
     if(mpLeft) { mpLeft->toDelayForm(rDelayTerms, rDelaySteps); }
     if(mpRight) { mpRight->toDelayForm(rDelayTerms, rDelaySteps); }
     if(mpBase) { mpBase->toDelayForm(rDelayTerms, rDelaySteps); }
@@ -1395,19 +1354,15 @@ void Expression::toDelayForm(QList<Expression> &rDelayTerms, QStringList &rDelay
 
 //! @brief Converts expression to double if possible
 //! @param ok True if success, false if failed (= not a numerical symbol)
-//FIXED
 double Expression::toDouble(bool *ok) const
 {
-    if(this->isSymbol())
-    {
+    if(this->isSymbol()) {
         return mString.toDouble(ok);
     }
-    else if(this->isMultiplyOrDivide() && mFactors.size() == 2 && mFactors.contains(Expression("-1")))
-    {
+    else if(this->isMultiplyOrDivide() && mFactors.size() == 2 && mFactors.contains(Expression("-1"))) {
         double retval = 1;
         if(ok) { *ok = true; }
-        Q_FOREACH(const Expression &factor, mFactors)
-        {
+        for(const Expression &factor : mFactors) {
             bool ok2;
             retval *= factor.toDouble(&ok2);
             if(!ok2)
@@ -1417,25 +1372,23 @@ double Expression::toDouble(bool *ok) const
         }
         return retval;
     }
-    else
-    {
-        if(ok) { *ok = false; }
+    else {
+        if(ok) {
+            *ok = false;
+        }
         return 0.0;
     }
 }
 
 
-
 //! @brief Tells whether or not this is a power operator
-//FIXED
 bool Expression::isPower() const
 {
-    return !(mpPower == 0);
+    return !(mpPower == nullptr);
 }
 
 
 //! @brief Tells whether or not this is a multiplication or division
-//FIXED
 bool Expression::isMultiplyOrDivide() const
 {
     return !mFactors.isEmpty();
@@ -1443,14 +1396,13 @@ bool Expression::isMultiplyOrDivide() const
 
 
 //! @brief Tells whether or not this is an addition
-//FIXED
 bool Expression::isAdd() const
 {
     return !mTerms.isEmpty();
 }
 
 
-//FIXED
+//! @brief Tells wheter or not this is a function
 bool Expression::isFunction() const
 {
     return !mFunction.isEmpty();
@@ -1458,7 +1410,6 @@ bool Expression::isFunction() const
 
 
 //! @brief Tells whether or not this is a symbol
-//FIXED
 bool Expression::isSymbol() const
 {
     return (!mString.isEmpty());
@@ -1466,7 +1417,6 @@ bool Expression::isSymbol() const
 
 
 //! @brief Tells whether or not this is a numerical symbol
-//FIXED
 bool Expression::isNumericalSymbol() const
 {
     return (!mString.isEmpty() && (mString[0].isNumber() || mString == "-1.0"));
@@ -1474,7 +1424,6 @@ bool Expression::isNumericalSymbol() const
 
 
 //! @brief Tells whether or not this is a variable
-//FIXED
 bool Expression::isVariable() const
 {
     return (!mString.isEmpty() && mString[0].isLetter());
@@ -1482,7 +1431,6 @@ bool Expression::isVariable() const
 
 
 //! @brief Tells whether or not this is an assignment
-//FIXED
 bool Expression::isAssignment() const
 {
     return (this->isEquation() && (mpLeft->isSymbol()));
@@ -1490,15 +1438,13 @@ bool Expression::isAssignment() const
 
 
 //! @brief Tells whether or not this is an equation
-//FIXED
 bool Expression::isEquation() const
 {
-    return (mpLeft != 0);
+    return (mpLeft != nullptr);
 }
 
 
 //! @brief Tells whether or not this is a negative symbol
-//FIXED
 bool Expression::isNegative() const
 {
     if(this->isSymbol() && mString == "-1")
@@ -1513,7 +1459,6 @@ bool Expression::isNegative() const
 }
 
 
-//FIXED
 void Expression::changeSign()
 {
     if(this->isNegative())
@@ -1545,7 +1490,6 @@ void Expression::changeSign()
 //! @brief Returns the derivative of the expression
 //! @param x Expression to differentiate with
 //! @param ok True if successful, otherwise false
-//FIXED
 Expression Expression::derivative(const Expression x, bool &ok) const
 {
     ok = true;
@@ -1837,8 +1781,7 @@ Expression Expression::derivative(const Expression x, bool &ok) const
     else if(isAdd())
     {
         QList<Expression> derSet;
-        Q_FOREACH(const Expression &term, mTerms)
-        {
+        for(const Expression &term : mTerms) {
             derSet << term.derivative(x, ok);
         }
         ret = Expression::fromTerms(derSet);
@@ -1963,60 +1906,45 @@ QStringList Expression::readErrorMessages()
 
 //! @brief Returns whether or not expression contains a sub expression
 //! @param expr Expression to check for
-//FIXED
 bool Expression::contains(const Expression expr) const
 {
-    if(*this == expr)
-    {
+    if(*this == expr) {
         return true;
     }
 
-    Q_FOREACH(const Expression &term, mTerms)
-    {
-        if(term.contains(expr))
-        {
+    for(const Expression &term : mTerms) {
+        if(term.contains(expr)) {
             return true;
         }
     }
-    for(int i=0; i<mArguments.size(); ++i)
-    {
-        if(mArguments[i].contains(expr))
-        {
+    for(int i=0; i<mArguments.size(); ++i) {
+        if(mArguments[i].contains(expr)) {
             return true;
         }
     }
-    Q_FOREACH(const Expression &factor, mFactors)
-    {
-        if(factor.contains(expr))
-        {
+    for(const Expression &factor : mFactors) {
+        if(factor.contains(expr)) {
             return true;
         }
     }
-    Q_FOREACH(const Expression &divisor, mDivisors)
-    {
-        if(divisor.contains(expr))
-        {
+    for(const Expression &divisor : mDivisors) {
+        if(divisor.contains(expr)) {
             return true;
         }
     }
-    if(mpBase && mpBase->contains(expr))
-    {
+    if(mpBase && mpBase->contains(expr)) {
         return true;
     }
-    if(mpPower && mpPower->contains(expr))
-    {
+    if(mpPower && mpPower->contains(expr)) {
         return true;
     }
-    if(mpLeft && mpLeft->contains(expr))
-    {
+    if(mpLeft && mpLeft->contains(expr)) {
         return true;
     }
-    if(mpRight && mpRight->contains(expr))
-    {
+    if(mpRight && mpRight->contains(expr)) {
         return true;
     }
-    if(mpDividend && mpDividend->contains(expr))
-    {
+    if(mpDividend && mpDividend->contains(expr)) {
         return true;
     }
 
@@ -2025,7 +1953,6 @@ bool Expression::contains(const Expression expr) const
 
 
 //! @brief Converts time derivatives (der) in the expression to Z operators with bilinear transform
-//FIXED
 Expression Expression::bilinearTransform() const
 {
     Expression retExpr;
@@ -2105,7 +2032,6 @@ Expression Expression::inlineTransform(const InlineTransformT transform, bool &o
     }
     else if(transform == AdamsMoulton3) {
         transformStr = "(1.0-Z)/(5.0/12.0 + 2.0/3.0*Z - 1.0/12.0*Z*Z)/mTimestep*(%1)";
-                      //(1.0-Z)/(5.0/12.0 + 2.0/3.0*Z - 1.0/12.0*Z*Z)/mTimestep
     }
     else if(transform == AdamsMoulton4) {
         transformStr = "(1.0-Z)/(9.0/24.0 + 19.0/24.0*Z - 5.0/24.0*Z*Z + 1.0/24.0*Z*Z*Z)/mTimestep*(%1)";
@@ -2120,12 +2046,10 @@ Expression Expression::inlineTransform(const InlineTransformT transform, bool &o
     retExpr.replaceBy(*this);
     QStringList res;
 
-    if(this->isAdd())
-    {
+    if(this->isAdd()) {
         QList<Expression> newTerms = mTerms;
         QList<Expression>::iterator it;
-        for(it=newTerms.begin(); it!=newTerms.end(); ++it)
-        {
+        for(it=newTerms.begin(); it!=newTerms.end(); ++it) {
             (*it) = (*it).inlineTransform(transform, ok);
             if(!ok) {
                 return (*this);
@@ -2133,8 +2057,7 @@ Expression Expression::inlineTransform(const InlineTransformT transform, bool &o
         }
         retExpr = Expression::fromTerms(newTerms);
     }
-    else if(this->isEquation())
-    {
+    else if(this->isEquation()) {
         Expression newLeft = *mpLeft;
         Expression newRight = *mpRight;
         newLeft = newLeft.inlineTransform(transform, ok);
@@ -2148,20 +2071,17 @@ Expression Expression::inlineTransform(const InlineTransformT transform, bool &o
 
         retExpr = Expression::fromEquation(newLeft, newRight);
     }
-    else if(this->isMultiplyOrDivide())
-    {
+    else if(this->isMultiplyOrDivide()) {
         QList<Expression> newFactors = mFactors;
         QList<Expression>::iterator it;
-        for(it=newFactors.begin(); it!=newFactors.end(); ++it)
-        {
+        for(it=newFactors.begin(); it!=newFactors.end(); ++it) {
             (*it) = (*it).inlineTransform(transform, ok);
             if(!ok) {
                 return (*this);
             }
         }
         QList<Expression> newDivisors = mDivisors;
-        for(it=newDivisors.begin(); it!=newDivisors.end(); ++it)
-        {
+        for(it=newDivisors.begin(); it!=newDivisors.end(); ++it) {
             (*it) = (*it).inlineTransform(transform, ok);
             if(!ok) {
                 return (*this);
@@ -2169,8 +2089,7 @@ Expression Expression::inlineTransform(const InlineTransformT transform, bool &o
         }
         retExpr = Expression::fromFactorsDivisors(newFactors, newDivisors);
     }
-    else if(this->isFunction())
-    {
+    else if(this->isFunction()) {
         if(mFunction == "delay" && mArguments.size() == 2) {
             QString funcArg = retExpr.getArgument(0).toString();
             int steps = int(retExpr.getArgument(1).toDouble());
@@ -2180,8 +2099,7 @@ Expression Expression::inlineTransform(const InlineTransformT transform, bool &o
             }
             retExpr = retExpr.inlineTransform(transform, ok);
         }
-        if(mFunction == "der")
-        {
+        if(mFunction == "der") {
             QString funcArg = retExpr.getArgument(0).toString();
             retExpr = Expression(transformStr.arg(funcArg));
             retExpr = retExpr.inlineTransform(transform, ok);
@@ -2199,43 +2117,33 @@ QList<Expression> Expression::getVariables() const
 {
     QList<Expression> retval;
 
-    if(this->isAdd())
-    {
-        Q_FOREACH(const Expression &term, mTerms)
-        {
+    if(this->isAdd()) {
+        for(const Expression &term : mTerms) {
             retval.append(term.getVariables());
         }
     }
-    else if(this->isEquation())
-    {
+    else if(this->isEquation()) {
         retval.append(mpLeft->getVariables());
         retval.append(mpRight->getVariables());
     }
-    else if(this->isMultiplyOrDivide())
-    {
-        Q_FOREACH(const Expression &factor, mFactors)
-        {
+    else if(this->isMultiplyOrDivide()) {
+        for(const Expression &factor : mFactors) {
             retval.append(factor.getVariables());
         }
-        Q_FOREACH(const Expression &divisor, mDivisors)
-        {
+        for(const Expression &divisor : mDivisors) {
             retval.append(divisor.getVariables());
         }
     }
-    else if(this->isFunction())
-    {
-        Q_FOREACH(const Expression &argument, mArguments)
-        {
+    else if(this->isFunction()) {
+        for(const Expression &argument : mArguments) {
             retval.append(argument.getVariables());
         }
     }
-    else if(this->isPower())
-    {
+    else if(this->isPower()) {
         retval.append(mpBase->getVariables());
         retval.append(mpPower->getVariables());
     }
-    else if(this->isVariable() && !reservedSymbols.contains(mString))
-    {
+    else if(this->isVariable() && !reservedSymbols.contains(mString)) {
         retval.append(*this);
     }
 
@@ -2250,39 +2158,31 @@ QStringList Expression::getFunctions() const
 {
     QStringList retval;
 
-    if(this->isAdd())
-    {
+    if(this->isAdd()) {
         QList<Expression>::iterator it;
-        Q_FOREACH(const Expression &term, mTerms)
-        {
+        for(const Expression &term : mTerms) {
             retval.append(term.getFunctions());
         }
     }
-    else if(this->isEquation())
-    {
+    else if(this->isEquation()) {
         retval.append(mpLeft->getFunctions());
         retval.append(mpRight->getFunctions());
     }
-    else if(this->isMultiplyOrDivide())
-    {
-        Q_FOREACH(const Expression &factor, mFactors)
-        {
+    else if(this->isMultiplyOrDivide()) {
+        for(const Expression &factor : mFactors) {
             retval.append(factor.getFunctions());
         }
-        Q_FOREACH(const Expression &divisor, mDivisors)
-        {
+        for(const Expression &divisor : mDivisors) {
             retval.append(divisor.getFunctions());
         }
     }
-    else if(this->isPower())
-    {
+    else if(this->isPower()) {
         retval.append(mpBase->getFunctions());
         retval.append(mpPower->getFunctions());
     }
-    else if(this->isFunction())
-    {
+    else if(this->isFunction()) {
         retval.append(mFunction);
-        Q_FOREACH(const Expression &argument, mArguments) {
+        for(const Expression &argument : mArguments) {
             retval.append(argument.getFunctions());
         }
     }
@@ -2476,14 +2376,14 @@ void Expression::expand(const ExpressionSimplificationT simplifications)
     if(!this->isMultiplyOrDivide()) { return; }
 
     bool hasParentheses = false;
-    Q_FOREACH(const Expression &factor, mFactors)
-    {
-        if(factor.isAdd())
-        {
+    for(const Expression &factor : mFactors) {
+        if(factor.isAdd()) {
             hasParentheses=true;
         }
     }
-    if(!hasParentheses) { return; }
+    if(!hasParentheses) {
+        return;
+    }
 
     QList<Expression>::iterator it;
     while(mFactors.size() > 1)
@@ -2507,10 +2407,8 @@ void Expression::expand(const ExpressionSimplificationT simplifications)
         terms2 = factor2.getTerms();
 
         //Multiply each term in the first set with each term in the second set
-        Q_FOREACH(const Expression &exp1, terms1)
-        {
-            Q_FOREACH(const Expression &exp2, terms2)
-            {
+        for(const Expression &exp1 : terms1) {
+            for(const Expression &exp2 : terms2) {
                 Expression newTerm = Expression::fromFactorsDivisors(QList<Expression>() << exp1 << exp2, QList<Expression>());    //Multiplication!
                 newTerm.expand();       //Recurse sub terms
                 multipliedTerms << newTerm;
@@ -2572,7 +2470,6 @@ void Expression::expandPowers()
 
 //! @brief Linearizes the expression by multiplying with all divisors until no divisors remains
 //! @note Should only be used on equations (obviously)
-//FIXED
 void Expression::linearize()
 {
     if(!this->isEquation()) {
@@ -2589,19 +2486,14 @@ void Expression::linearize()
 
     //Generate list with all divisors from all terms
     QList<Expression> allDivisors;
-    Q_FOREACH(const Expression &term, allTerms)
-    {
+    for(const Expression &term : allTerms) {
         QList<Expression> divisors = term.getDivisors();
-        Q_FOREACH(const Expression &exp, divisors)
-        {
-            if(!allDivisors.contains(exp))
-            {
+        for(const Expression &exp : divisors) {
+            if(!allDivisors.contains(exp)) {
                 allDivisors << exp;
             }
-            else
-            {
-                while(allDivisors.count(exp) < divisors.count(exp))     //Make sure the all divisors vector contains at least the same amount of each divisor as the term
-                {
+            else {
+                while(allDivisors.count(exp) < divisors.count(exp)) {    //Make sure the all divisors vector contains at least the same amount of each divisor as the term
                     allDivisors << exp;
                 }
             }
@@ -2639,7 +2531,6 @@ void Expression::linearize()
 
 
 //! @brief Moves all right side expressions to the left side, if this is an equation
-//FIXED
 void Expression::toLeftSided()
 {
     if(!this->isEquation()) {
@@ -3052,15 +2943,19 @@ void Expression::_simplify(ExpressionSimplificationT type, const ExpressionRecur
         bool removedFactorOrDivisor=false;
 
         //Cancel out same factors and divisors
-        restart:
-        Q_FOREACH(const Expression &factor, mFactors)
-        {
-            if(mDivisors.contains(factor))
+        bool didSomething = true;
+        while(didSomething) {
+            didSomething = false;
+            for(const Expression &factor : mFactors)
             {
-                mDivisors.removeOne(factor);
-                mFactors.removeOne(factor);
-                removedFactorOrDivisor = true;
-                goto restart;
+                if(mDivisors.contains(factor))
+                {
+                    mDivisors.removeOne(factor);
+                    mFactors.removeOne(factor);
+                    removedFactorOrDivisor = true;
+                    didSomething = true;
+                    break;
+                }
             }
         }
 
@@ -3068,30 +2963,34 @@ void Expression::_simplify(ExpressionSimplificationT type, const ExpressionRecur
         else if(removedFactorOrDivisor && mFactors.isEmpty()) { mFactors.append(Expression(1)); }
 
         //Join multiple factors to powers
-        restart2:
-        Q_FOREACH(const Expression &factor, mFactors)
-        {
-            int n = mFactors.count(factor);
-            if(n > 1)
-            {
-                mFactors.removeAll(factor);
-                mFactors.append(Expression::fromBasePower(factor, Expression(n)));
-                goto restart2;
+        didSomething = true;
+        while(didSomething) {
+            didSomething = false;
+            for(const Expression &factor : mFactors) {
+                int n = mFactors.count(factor);
+                if(n > 1) {
+                    mFactors.append(Expression::fromBasePower(factor, Expression(n)));
+                    mFactors.removeAll(factor);
+                    didSomething = true;
+                    break;
+                }
             }
         }
 
         if(mFactors.size() == 1 && mDivisors.isEmpty()) { replaceByCopy(mFactors.first()); }
 
         //Join multiple divisors to powers
-        restart3:
-        Q_FOREACH(const Expression &divisor, mDivisors)
-        {
-            int n = mDivisors.count(divisor);
-            if(n > 1)
-            {
-                mDivisors.removeAll(divisor);
-                mDivisors.append(Expression::fromBasePower(divisor, Expression(n)));
-                goto restart3;
+        didSomething = true;
+        while(didSomething) {
+            didSomething = false;
+            for(const Expression &divisor : mDivisors) {
+                int n = mDivisors.count(divisor);
+                if(n > 1) {
+                    mDivisors.append(Expression::fromBasePower(divisor, Expression(n)));
+                    mDivisors.removeAll(divisor);
+                    didSomething = true;
+                    break;
+                }
             }
         }
     }
@@ -3111,7 +3010,6 @@ void Expression::_simplify(ExpressionSimplificationT type, const ExpressionRecur
 }
 
 
-//FIXED
 bool Expression::splitAtSeparator(const QString sep, const QStringList subSymbols, const ExpressionSimplificationT simplifications)
 {
     if(subSymbols.contains(sep) || (sep == "*" && subSymbols.contains("/")))
@@ -3526,15 +3424,12 @@ bool Expression::splitAtSeparator(const QString sep, const QStringList subSymbol
 }
 
 
-//FIXED
 double Expression::countTerm(const Expression &expr) const
 {
     Expression pureTerm = expr.removeNumericalFactors();
     double ret=0;
-    Q_FOREACH(const Expression &term, mTerms)
-    {
-        if(term.removeNumericalFactors() == pureTerm)
-        {
+    for(const Expression &term : mTerms) {
+        if(term.removeNumericalFactors() == pureTerm) {
             ret += term.getNumericalFactor();
         }
     }
@@ -3562,26 +3457,21 @@ void Expression::removeTerm(const Expression &term)
     }
 }
 
-//FIXED
+
 Expression Expression::removeNumericalFactors() const
 {
-    if(!isMultiplyOrDivide())
-    {
+    if(!isMultiplyOrDivide()) {
         return *this;
     }
     Expression ret;
 
-    Q_FOREACH(const Expression &factor, mFactors)
-    {
-        if(!factor.isNumericalSymbol())
-        {
+    for(const Expression &factor : mFactors) {
+        if(!factor.isNumericalSymbol()) {
             ret.mFactors.append(factor);
         }
     }
     ret.mDivisors.append(mDivisors);
 
-    //qDebug() << "ret.toString(): " << ret.toString();
-    //qDebug() << "Ret factors: " << ret.mFactors.size();
     if(ret.mFactors.size() == 1 && ret.mDivisors.isEmpty())
     {
         //Expression expr = Expression(ret.mFactors.first());
@@ -3600,20 +3490,16 @@ Expression Expression::removeNumericalFactors() const
 }
 
 
-//FIXED
 double Expression::getNumericalFactor() const
 {
-    if(!isMultiplyOrDivide())
-    {
+    if(!isMultiplyOrDivide()) {
         return 1;
     }
 
     double ret=1;
 
-    Q_FOREACH(const Expression &factor, mFactors)
-    {
-        if(factor.isNumericalSymbol())
-        {
+    for(const Expression &factor : mFactors) {
+        if(factor.isNumericalSymbol()) {
             ret *= factor.toDouble();
         }
     }
@@ -3650,7 +3536,6 @@ QString SymHop::getFunctionDerivative(const QString &key)
 
 
 //! @brief Returns a list with supported functions for equation-based model generation
-//FIXED
 QStringList SymHop::getSupportedFunctionsList()
 {
     return QStringList() << "div" << "rem" << "mod" << "tan" << "cos" << "sin" << "atan" << "acos" << "asin" << "atan2" << "sinh" << "cosh" << "tanh" << "log" << "exp" << "sqrt" << "sign" << "abs" << "der" << "onPositive" << "onNegative" << "signedSquareL" << "limit" << "integer" << "floor" << "ceil" << "pow" << "min" << "max" << "nonZero" << "turbulentFlow" << "delay" << "equal" << "notEqual" << "greaterThan" << "smallerThan" << "greaterThanOrEqual" << "smallerThanOrEqual";
@@ -3658,7 +3543,6 @@ QStringList SymHop::getSupportedFunctionsList()
 
 
 //! @brief Returns a list of custom Hopsan functions that need to be allowed in the symbolic library
-//FIXED
 QStringList SymHop::getCustomFunctionList()
 {
     return QStringList() << "hopsanLimit" << "hopsanDxLimit" << "onPositive" << "onNegative" << "signedSquareL" << "limit" << "nonZero" << "turbulentFlow" << "ifElse";
@@ -3666,7 +3550,6 @@ QStringList SymHop::getCustomFunctionList()
 
 
 //! @brief Finds the first path through a matrix of dependencies, used to sort jacobian matrices
-//FIXED
 bool SymHop::findPath(QList<int> &order, QList<QList<int> > dependencies, int level, QList<int> preferredPath)
 {
     if(level > dependencies.size()-1)
@@ -3717,7 +3600,6 @@ bool SymHop::findPath(QList<int> &order, QList<QList<int> > dependencies, int le
 //! @param stateVars List of state variables
 //! @param limitedVariableEquations Reference to list with indexes for limitation functions
 //! @param limitedDerivativeEquations Reference to list with indexes for derivative limitation functions
-//FIXED
 bool SymHop::sortEquationSystem(QList<Expression> &equations, QList<QList<Expression> > &jacobian, QList<Expression> stateVars, QList<int> &limitedVariableEquations, QList<int> &limitedDerivativeEquations, QList<int> preferredOrder)
 {
 //    qDebug() << "Jacobian:";
@@ -3747,8 +3629,6 @@ bool SymHop::sortEquationSystem(QList<Expression> &equations, QList<QList<Expres
         }
     }
 
-    //qDebug() << "Dependencies: " << dependencies;
-
     //Recurse dependency tree to find a good sorting order
     QList<int> order;
     if(!findPath(order, dependencies, 0, preferredOrder))
@@ -3756,8 +3636,6 @@ bool SymHop::sortEquationSystem(QList<Expression> &equations, QList<QList<Expres
         gSymHopMessages << "In sortEquationSystem(): Failed to find sorting path.";
         return false;
     }
-
-    //qDebug() << "Order: " << order;
 
     //Sort equations to new order
     QList<Expression> sortedEquations;
@@ -3791,14 +3669,11 @@ bool SymHop::sortEquationSystem(QList<Expression> &equations, QList<QList<Expres
 
 //! @brief Removes all duplicates in a list of expressions
 //! @param rList Reference to the list
-//FIXED
 void SymHop::removeDuplicates(QList<Expression> &rSet)
 {
     QList<Expression> tempSet;
-    Q_FOREACH(const Expression &item, rSet)
-    {
-        if(!tempSet.contains(item))
-        {
+    for(const Expression &item : rSet) {
+        if(!tempSet.contains(item)) {
             tempSet.append(item);
         }
     }
@@ -3807,7 +3682,6 @@ void SymHop::removeDuplicates(QList<Expression> &rSet)
 }
 
 
-//FIXED
 bool SymHop::isWhole(const double value)
 {
     return (static_cast<int>(value) == value);
@@ -3816,7 +3690,6 @@ bool SymHop::isWhole(const double value)
 
 //! @brief Checks whether or no the parentheses are correct in a string
 //! @param str String to verify
-//FIXED
 bool Expression::verifyParantheses(const QString str)
 {
     int balance = 0;
@@ -3839,7 +3712,6 @@ bool Expression::verifyParantheses(const QString str)
 //! @brief Splits a string at specified character, but does not split inside parentheses
 //! @param str String to split
 //! @param c Character to split at
-//FIXED
 QStringList Expression::splitWithRespectToParentheses(const QString str, const QChar c)
 {
     if(str.isEmpty())

--- a/UnitTests/GeneratorTest/tst_generatortest.cpp
+++ b/UnitTests/GeneratorTest/tst_generatortest.cpp
@@ -65,14 +65,11 @@ void removeDir(QString path)
 {
     QDir dir;
     dir.setPath(path);
-    Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
-    {
-        if (info.isDir())
-        {
+    for(QFileInfo info : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
+        if (info.isDir()) {
             removeDir(info.absoluteFilePath());
         }
-        else
-        {
+        else {
             QFile::remove(info.absoluteFilePath());
         }
     }


### PR DESCRIPTION
We need to remove  the Qt foreach loops since they are deprecated and will be removed in future Qt versions. 
This is probably hard to review, but most changes are only syntactic. The only functional changes are actually the goto expressions in SymHop.

- Replace all `Q_FOREACH` loops with range-based C++ loops
- Replace all `foreach` loops with range-based C++ loops
- Make some regular loops range-based
- Fix some bracket styles
- Remove some comments
- Replace some goto expressions with loops
- Some minor fixes (e.g. replace `size_t` with `int` to avoid warnings)