### PR TITLE
Support elseif and nested if-statements in HCOM

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -3032,7 +3032,10 @@ void HcomHandler::executeDefineAliasCommand(const QString cmd)
     QString alias = splitCmd[1];
     variable.remove("\"");
     toLongDataNames(variable);
-    if(mpModel->getViewContainerObject()->setVariableAlias(variable, alias))
+    QStringList hierarchy = variable.section("#",0).split("$");
+    hierarchy.removeLast();
+    SystemObject *pSystem = searchIntoSubsystem(mpModel->getViewContainerObject(),hierarchy);
+    if(pSystem->setVariableAlias(variable, alias))
     {
         HCOMINFO(QString("Sucessfully assigned variable alias %1").arg(alias));
     }

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -7900,7 +7900,7 @@ QString HcomHandler::runScriptCommands(QStringList &lines, bool *pAbort)
                     break;
                 }
             }
-            if(!oneConditionWasTrue)
+            if(!oneConditionWasTrue && !elseCode.isEmpty())
             {
                 QString gotoLabel = runScriptCommands(elseCode, pAbort);
                 if(*pAbort)
@@ -8903,7 +8903,7 @@ void HcomHandler::executeLtBuiltInFunction(QString fnc_call)
             return;
         }
         // Handle arg1 is double
-        else if (arg1IsDouble && pVar2)
+        else if (arg1IsDouble && pVar2 && pLogDataHandler)
         {
             QVector<double> res;
             pVar2->elementWiseGt(res, arg1AsDouble);
@@ -8913,7 +8913,7 @@ void HcomHandler::executeLtBuiltInFunction(QString fnc_call)
             return;
         }
         // Handle arg2 is double
-        else if (arg2IsDouble && pVar1)
+        else if (arg2IsDouble && pVar1 && pLogDataHandler)
         {
             QVector<double> res;
             pVar1->elementWiseLt(res, arg2AsDouble);
@@ -8923,7 +8923,7 @@ void HcomHandler::executeLtBuiltInFunction(QString fnc_call)
             return;
         }
         // Handle both vectors
-        else if (pVar1 && pVar2)
+        else if (pVar1 && pVar2 && pLogDataHandler)
         {
             //! @todo this assumes that both vectors have the same type
             if (pVar1->getDataSize() != pVar2->getDataSize())

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -7900,16 +7900,21 @@ QString HcomHandler::runScriptCommands(QStringList &lines, bool *pAbort)
                     break;
                 }
             }
-            if(!oneConditionWasTrue && !elseCode.isEmpty())
+            if(!oneConditionWasTrue)
             {
-                QString gotoLabel = runScriptCommands(elseCode, pAbort);
-                if(*pAbort)
-                {
-                    return "";
+                if(!elseCode.isEmpty()) {
+                    QString gotoLabel = runScriptCommands(elseCode, pAbort);
+                    if(*pAbort)
+                    {
+                        return QString();
+                    }
+                    if(!gotoLabel.isEmpty())
+                    {
+                        return gotoLabel;
+                    }
                 }
-                if(!gotoLabel.isEmpty())
-                {
-                    return gotoLabel;
+                else {
+                    return QString();
                 }
             }
         }

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -8881,7 +8881,9 @@ void HcomHandler::executeLtBuiltInFunction(QString fnc_call)
             pVar2 = mAnsVector;
         }
 
-        LogDataHandler2 *pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler().data();
+        LogDataHandler2 *pLogDataHandler = 0;
+        if(mpModel)
+            pLogDataHandler = mpModel->getViewContainerObject()->getLogDataHandler().data();
 
         // Handle both scalars
         if (arg1IsDouble && arg2IsDouble)
@@ -9066,7 +9068,7 @@ void HcomHandler::executeEqBuiltInFunction(QString fnc_call)
     }
     else
     {
-        HCOMERR(QString("Wrong number of arguments provided for lt function.\n"+mLocalFunctionDescriptions.find("lt").value().second));
+        HCOMERR(QString("Wrong number of arguments provided for eq function.\n"+mLocalFunctionDescriptions.find("lt").value().second));
         mAnsType = Undefined;
         return;
     }

--- a/HopsanGUI/HcomTest.hpp
+++ b/HopsanGUI/HcomTest.hpp
@@ -106,27 +106,40 @@ private slots:
     void testControlFlowIf() {
         QString script = R"(
                 if (a > 4)
-                  b = 1
+                  if (b > 2)
+                    c = 1
+                  elseif (b < 0)
+                    c = 2
+                  endif
                 else
-                  b = 0
+                  c = 3
                 endif
                 )";
 
         mpHcom->executeCommand("a = 5");
+        mpHcom->executeCommand("b = 3");
         bool abort=false;
         QStringList lines = script.split("\n");
         mpHcom->runScriptCommands(lines, &abort);
-        mpHcom->executeCommand("b");
+        mpHcom->executeCommand("c");
         QCOMPARE(mpHcom->mAnsType, HcomHandler::Scalar);
         QCOMPARE(mpHcom->mAnsScalar, 1.0);
+
+        mpHcom->executeCommand("b = -1");
+        abort=false;
+        lines = script.split("\n");
+        mpHcom->runScriptCommands(lines, &abort);
+        mpHcom->executeCommand("c");
+        QCOMPARE(mpHcom->mAnsType, HcomHandler::Scalar);
+        QCOMPARE(mpHcom->mAnsScalar, 2.0);
 
         mpHcom->executeCommand("a = 3");
         abort=false;
         lines = script.split("\n");
         mpHcom->runScriptCommands(lines, &abort);
-        mpHcom->executeCommand("b");
+        mpHcom->executeCommand("c");
         QCOMPARE(mpHcom->mAnsType, HcomHandler::Scalar);
-        QCOMPARE(mpHcom->mAnsScalar, 0.0);
+        QCOMPARE(mpHcom->mAnsScalar, 3.0);
     }
 
     void testControlFlowForeach() {


### PR DESCRIPTION
Enables writing if-statements in this format in HCOM scripts:
```
if(x<1)
  if(y>42)
    print "Condition 1a"
  elseif(y<40)
    print "Condition 1b"
  else
    print "Condition 1c"  
  endif
elseif(x>3)
  print "Condition 2a"
else
  print "Condition 2c"
endif
```

This PR also includes minor bugfixes to `alias()` and `lt()` functions.