### PR TITLE
Update default parameters when changing FMU in FMIWrapper component

### DIFF
--- a/HopsanGUI/GUIObjects/GUIComponent.cpp
+++ b/HopsanGUI/GUIObjects/GUIComponent.cpp
@@ -192,6 +192,11 @@ bool Component::setParameterValue(QString name, QString value, bool force)
 
         //Refresh appearance
         this->refreshAppearance();
+
+        QStringList defaultParameterNames = getParameterNames();
+        for(int i=0; i<defaultParameterNames.size(); ++i) {
+            mDefaultParameterValues.insert(defaultParameterNames.at(i), getParameterValue(defaultParameterNames.at(i)));
+        }
     }
 
     return retval;


### PR DESCRIPTION
This fix makes sure to add the default values of all FMU parameters in FMIWrapper component to the list with default parameter values. 