### PR TITLE
Ignore file change warning after saving the file

### DIFF
--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -133,7 +133,11 @@ void TextEditorWidget::find(QString text, QTextDocument::FindFlags flags)
 
 void TextEditorWidget::fileChanged(QString filePath)
 {
-    qDebug() << "File changed: " << filePath;
+    if(mIgnoreNextFileChangeNotification) {
+        mIgnoreNextFileChangeNotification = false;
+        return;
+    }
+
     //We need to add the path again, because some text editors removes the actual file and
     //creates a new one when saving (e.g. gedit). This makes the watcher stop watching.
     if(QFileInfo(filePath) != mFileInfo) {
@@ -223,6 +227,9 @@ void TextEditorWidget::save(SaveTargetEnumT saveAsFlag)
     gpCentralTabWidget->setTabText(gpCentralTabWidget->indexOf(this), mFileInfo.fileName());
 
     mIsSaved = true;
+
+    //This will ignore the next warning that the file has changed on disk - it has obviously changed since we just saved it :)
+    mIgnoreNextFileChangeNotification = true;
 }
 
 void TextEditorWidget::hasChanged()

--- a/HopsanGUI/Widgets/TextEditorWidget.h
+++ b/HopsanGUI/Widgets/TextEditorWidget.h
@@ -125,6 +125,7 @@ private:
     TextEditor *mpEditor;
     QFileInfo mFileInfo;
     bool mIsSaved = true;
+    bool mIgnoreNextFileChangeNotification = false;
     QString mSavedText;
     HcomHighlighter *mpHcomHighlighter;
     CppHighlighter *mpCppHighlighter;


### PR DESCRIPTION
Not an ideal solution, but this will make sure the "file has changed on disk" warning does not appear when the file has been saved by Hopsan itself. 

Disconnecting the signal from the slot before saving and then reconnecting afterwards does not work, since there may be a small time delay before Hopsan is notified of the change by the file system.