### PR TITLE
Remember loading HMF components as internal systems when saving

### DIFF
--- a/HopsanGUI/Widgets/ModelWidget.cpp
+++ b/HopsanGUI/Widgets/ModelWidget.cpp
@@ -945,6 +945,7 @@ void ModelWidget::openCurrentContainerInNewTab()
             pContainer->setModelFile("");
             lockModelEditingFull(true);
             mpExternalSystemWarningWidget->setVisible(false);
+            pContainer->setSubTypeName("");
             break;
         }
     }


### PR DESCRIPTION
The problem was that the subsystem component kept its subtypename. When loading the model, the HMF component was then loaded as an external subsystem, ignoring the subsystem contents specified in the HMF file.

Resolves #2105.