### PR TITLE
Replace feature in find widget

### DIFF
--- a/HopsanGUI/Widgets/FindWidget.h
+++ b/HopsanGUI/Widgets/FindWidget.h
@@ -34,6 +34,7 @@
 #include <QComboBox>
 #include <QPushButton>
 #include <QCheckBox>
+#include <QLabel>
 
 // Forward declaration
 class SystemObject;
@@ -57,6 +58,9 @@ public slots:
     void findSystemParameter(const QString &rName, const bool centerView=true, Qt::CaseSensitivity caseSensitivity=Qt::CaseInsensitive, bool wildcard=true);
     void findSystemParameter(const QStringList &rNames, const bool centerView=true, Qt::CaseSensitivity caseSensitivity=Qt::CaseInsensitive, bool wildcard=true);
     void findAny(const QString &rName);
+    void replace();
+    void replaceAndFind();
+    void replaceAll();
 
 public slots:
     virtual void setVisible(bool visible);
@@ -65,12 +69,17 @@ public slots:
 private:
     void clearHighlights();
     QLineEdit* mpFindLineEdit;
+    QLabel* mpReplaceLabel;
+    QLineEdit* mpReplaceLineEdit;
     QComboBox* mpFindWhatComboBox;
     QPushButton* mpFindButton;
     QCheckBox* mpCaseSensitivityCheckBox;
     QCheckBox* mpWildcardCheckBox;
     QPushButton *mpPreviousButton;
     QPushButton *mpNextButton;
+    QPushButton *mpReplaceButton;
+    QPushButton *mpReplaceAndFindButton;
+    QPushButton *mpReplaceAllButton;
 
     QPointer<SystemObject> mpContainer;
     QPointer<TextEditorWidget> mpTextEditor;

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -126,6 +126,11 @@ QString TextEditorWidget::getSelectedText()
     return mpEditor->textCursor().selectedText();
 }
 
+void TextEditorWidget::replaceSelectedText(QString newText)
+{
+    mpEditor->textCursor().insertText(newText);
+}
+
 void TextEditorWidget::find(QString text, QTextDocument::FindFlags flags)
 {
     mpEditor->find(text,flags);

--- a/HopsanGUI/Widgets/TextEditorWidget.h
+++ b/HopsanGUI/Widgets/TextEditorWidget.h
@@ -109,6 +109,7 @@ public:
     QFileInfo getFileInfo() const { return mFileInfo; }
     bool isSaved() const { return mIsSaved; }
     QString getSelectedText();
+    void replaceSelectedText(QString newText);
 
 public slots:
     void find(QString text, QTextDocument::FindFlags flags);


### PR DESCRIPTION
New features in find widget:
- Replace (text files only)
- Replace and find (text files only)
- Replace all (text files only)
- Pressing return key while typing will trigger "find next"
- Existing text from previous search is automatically selected when opening find widget