### PR TITLE
Show HTML description in FMIWrapper component if available in FMU

### DIFF
--- a/HopsanGUI/Dialogs/ComponentPropertiesDialog3.h
+++ b/HopsanGUI/Dialogs/ComponentPropertiesDialog3.h
@@ -101,6 +101,7 @@ signals:
     void setLimitedModelEditingLock(bool);
 
 protected slots:
+    void showEvent(QShowEvent *event);
     void okPressed();
     void applyAndSimulatePressed();
     void applyPressed();

--- a/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/extensionLibrary/Connectivity/FMIWrapper.hpp
@@ -138,6 +138,7 @@ private:
     fmi2_import_t* fmu;
     double mTolerance = 1e-4;
     HString mVisibleOutputs;
+    HString mTempPath;
 
 public:
     static Component *Creator()
@@ -201,6 +202,9 @@ public:
         }
 
         addDebugMessage("Using temporary directory: "+mpTempDir->path());
+
+        mTempPath = mpTempDir->path();
+        addConstant("temppath", "", "", mTempPath, mTempPath);
 
         version = fmi_import_get_fmi_version(context, mFmuPath.c_str(), mpTempDir->path().c_str());
         if(version != fmi_version_2_0_enu) {


### PR DESCRIPTION
According to the FMI standard 2.0, the entry point for documentation is `/documentation/index.html`. If this file exists, it shall be used for HTML documentation in the component properties dialog.

It is not an ideal solution to give special treatment to certain components depending on their type name, but right now I don't really see an alternative solution. 