### PR TITLE
Open HMF for subsystem components from library widget

### DIFF
--- a/HopsanGUI/Widgets/LibraryWidget.cpp
+++ b/HopsanGUI/Widgets/LibraryWidget.cpp
@@ -709,8 +709,7 @@ void LibraryWidget::handleItemClick(QTreeWidgetItem *item, int column)
 void LibraryWidget::handleItemDoubleClick(QTreeWidgetItem *item, int column)
 {
     if(item != nullptr &&
-        mItemToTypeNameMap.contains(item) &&
-        gpLibraryHandler->getEntry(mItemToTypeNameMap.find(item).value()).displayPath.startsWith(componentlibrary::roots::externalLibraries))
+        mItemToTypeNameMap.contains(item))
     {
         //Edit component source file
         auto appearance = gpLibraryHandler->getModelObjectAppearancePtr(mItemToTypeNameMap.find(item).value());


### PR DESCRIPTION
- Added "Open model file" option in right-click menu for subsystem components in library widget
- Hide "Open source code" option for components that have no source code specified
- Double-clicking on subsystem components opens model file