### PR TITLE
Fix crash due to PR 2118, and add utility functions to cleanup code

### DIFF
--- a/HopsanGUI/Widgets/LibraryWidget.h
+++ b/HopsanGUI/Widgets/LibraryWidget.h
@@ -76,6 +76,13 @@ protected:
 private:
     void getAllSubTreeItems(QTreeWidgetItem *pParentItem, QList<QTreeWidgetItem *> &rSubItems);
     bool isComponentItem(QTreeWidgetItem *item);
+    bool isExternalLibrariesItem(QTreeWidgetItem *item);
+    bool isExternalLibraryItem(QTreeWidgetItem *item);
+    bool isFmuLibrariesItem(QTreeWidgetItem *item);
+    bool isExternalComponentItem(QTreeWidgetItem *item);
+    bool hasSourceCode(QTreeWidgetItem *item);
+    bool hasModelFile(QTreeWidgetItem *item);
+    bool isFmuLibraryItem(QTreeWidgetItem *item);
     QTreeWidgetItem *getLibraryItem(QSharedPointer<GUIComponentLibrary> pLibrary);
 
     //GUI Stuff


### PR DESCRIPTION
- Fix crash when right-clicking on an external library item
- Add utility functions for checking type of library items to avoid code repetition