### PR TITLE
Support SSV parameter sets for components

### DIFF
--- a/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
+++ b/HopsanGUI/Dialogs/ComponentPropertiesDialog3.cpp
@@ -289,6 +289,10 @@ void ComponentPropertiesDialog3::applyParameterSet()
     readFromSsv(mpModelObject->getAppearanceData()->getBasePath()+"/"+fileName, ssvParameters);
 
     for(const auto &ssvParameter : ssvParameters) {
+        if(!mpModelObject->hasParameter(ssvParameter.name)) {
+            gpMessageHandler->addWarningMessage("Parameter not found in component: "+ssvParameter.name+" (ignored)");
+            continue;
+        }
         CoreParameterData parameter;
         mpModelObject->getParameter(ssvParameter.name, parameter);
         QString hopsanUnit = mpVariableTableWidget->getSelectedUnit(ssvParameter.name);
@@ -1276,6 +1280,7 @@ QString VariableTableWidget::getSelectedUnit(const QString &rName)
             return pValueWidget->getUnitSelectionWidget()->getSelectedUnit();
         }
     }
+    return QString();   //Parameter not found, return empty string
 }
 
 bool VariableTableWidget::focusNextPrevChild(bool next)

--- a/HopsanGUI/Dialogs/ComponentPropertiesDialog3.h
+++ b/HopsanGUI/Dialogs/ComponentPropertiesDialog3.h
@@ -74,6 +74,8 @@ public:
     bool setStartValues();
     //bool setCustomPlotScaleValues();
     bool setAliasNames();
+    void setValue(const QString &rName, const QString &rValue);
+    QString getSelectedUnit(const QString &rName);
 
 protected:
     virtual bool focusNextPrevChild(bool next);
@@ -109,6 +111,7 @@ protected slots:
     void editPortPos();
     virtual void reject();
     void openDescription();
+    void applyParameterSet();
 
 protected:
     bool setAliasNames();
@@ -128,6 +131,7 @@ private:
     VariableTableWidget *mpVariableTableWidget;
     SystemProperties *mpSystemProperties=nullptr;
     bool mAllowEditing=false;
+    QComboBox *mpSetsComboBox;
 };
 
 // Help class declarations

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -689,6 +689,13 @@ void ModelObject::loadParameterValuesFromFile(QString parameterFile)
     // Nothing by default
 }
 
+//! @brief Returns a list of available parameter sets for model object
+//! @returns Map with names and corresponding SSV file paths
+QMap<QString, QString> ModelObject::getParameterSets() const
+{
+    return mModelObjectAppearance.getParameterSets();
+}
+
 bool ModelObject::isLossesDisplayVisible()
 {
     return mpLossesDisplay->isVisible();

--- a/HopsanGUI/GUIObjects/GUIModelObject.h
+++ b/HopsanGUI/GUIObjects/GUIModelObject.h
@@ -111,6 +111,8 @@ public:
     void saveParameterValuesToFile(QString parameterFile = {});
     virtual void loadParameterValuesFromFile(QString parameterFile = {});
 
+    virtual QMap<QString, QString> getParameterSets() const;
+
     // VariableAlias method
     //! @todo parameters and port variables should be more similar in the future, so that we do not need handle them separately
     virtual QMap<QString, QString> getVariableAliases(const QString &rPortName="") const;

--- a/HopsanGUI/GUIObjects/GUIModelObjectAppearance.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObjectAppearance.cpp
@@ -73,6 +73,12 @@
 #define CAF_HELPHTML "html"
 #define CAF_HELPMARKDOWN "md"
 
+namespace caf {
+    constexpr auto name = "name";
+    constexpr auto path = "path";
+    constexpr auto parametersets = "parametersets";
+    constexpr auto parameterset = "parameterset";
+}
 
 #define CAF_PARAMETERS "defaultparameters"
 #define CAF_PARAMETER "parameter"
@@ -475,6 +481,7 @@ ModelObjectAppearance &ModelObjectAppearance::operator=(const ModelObjectAppeara
     mDefaultMissingIconPath = other.mDefaultMissingIconPath;
     mNameTextPos = other.mNameTextPos;
     mReplacementObjects = other.mReplacementObjects;
+    mParameterSets = other.mParameterSets;
 
     // OK, this is a hack, the port appearance map is actually a map of shared pointers,
     // but we want a "deep copy" so lets fix that
@@ -756,6 +763,13 @@ bool ModelObjectAppearance::isRecompilable() const
     return mIsRecompilable;
 }
 
+//! @brief Returns a list of available parameter sets for model object
+//! @returns Map with names and corresponding SSV file paths
+QMap<QString, QString> ModelObjectAppearance::getParameterSets() const
+{
+    return mParameterSets;
+}
+
 
 ModelObjectAnimationData *ModelObjectAppearance::getAnimationDataPtr()
 {
@@ -895,6 +909,20 @@ void ModelObjectAppearance::readFromDomElement(QDomElement domElement)
         if (!xmlHelpMD.isNull())
         {
             mHelpHtmlPath = xmlHelpMD.text();
+        }
+    }
+
+    //Read parameter sets (name and .ssv file)
+    QDomElement xmlParameterSets = domElement.firstChildElement(caf::parametersets);
+    if(!xmlParameterSets.isNull())
+    {
+        QDomElement xmlParameterSet = xmlParameterSets.firstChildElement(caf::parameterset);
+        while(!xmlParameterSet.isNull())
+        {
+            QString name = xmlParameterSet.attribute(caf::name);
+            QString path = xmlParameterSet.attribute(caf::path);
+            mParameterSets.insert(name, path);
+            xmlParameterSet = xmlParameterSet.nextSiblingElement(caf::parameterset);
         }
     }
 

--- a/HopsanGUI/GUIObjects/GUIModelObjectAppearance.h
+++ b/HopsanGUI/GUIObjects/GUIModelObjectAppearance.h
@@ -259,6 +259,7 @@ public:
     QString getSourceCodeFile() const;
     QString getLibPath() const;
     bool isRecompilable() const;
+    QMap<QString, QString> getParameterSets() const;
 
     ModelObjectAnimationData *getAnimationDataPtr();
 
@@ -296,6 +297,7 @@ private:
     QString mDefaultMissingIconPath;
     QPointF mNameTextPos;
     QStringList mReplacementObjects;
+    QMap<QString, QString> mParameterSets;
 
     PortAppearanceMapT mPortAppearanceMap;
     ModelObjectAnimationData mAnimationData;

--- a/HopsanGUI/Utilities/XMLUtilities.h
+++ b/HopsanGUI/Utilities/XMLUtilities.h
@@ -96,6 +96,16 @@ void updateRenamedPort(QDomElement &rDomElement, const QString componentType, co
 void updateRenamedParameter(QDomElement &rDomElement, const QString componentType, const QString oldName, const QString newName);
 void updateRenamedComponentName(QDomElement &rDomElement, const QString oldName, const QString newName);
 
+//SSV help functions
+class SsvParameter {
+public:
+    QString name;
+    QString dataType;
+    QString unit;
+    QString value;
+};
+void readFromSsv(const QString filePath, QList<SsvParameter> &rParameters);
+
 //Save Load Definitions
 //! @todo clean up this list and give some smarter names, remove TAG from end, also make sure we use theses defines where appropriate instead of hardcoded strings
 #define HPF_ROOTTAG "hopsanparameterfile"

--- a/componentLibraries/exampleComponentLib/HydraulicComponents/MyExampleVolume.xml
+++ b/componentLibraries/exampleComponentLib/HydraulicComponents/MyExampleVolume.xml
@@ -8,5 +8,10 @@
             <port x="0" y="0.5" a="0" name="P1"/>
             <port x="1" y="0.5" a="0" name="P2"/>
         </ports>
+		<parametersets>
+            <parameterset name="Small volume (1 l)" path="smallvolume.ssv"/>
+            <parameterset name="Medium volume (2 l) " path="mediumvolume.ssv"/>
+			<parameterset name="Large volume (5 l) " path="largevolume.ssv"/>
+        </parametersets>
     </modelobject>
 </hopsanobjectappearance>

--- a/componentLibraries/exampleComponentLib/HydraulicComponents/largevolume.ssv
+++ b/componentLibraries/exampleComponentLib/HydraulicComponents/largevolume.ssv
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet version="1.0" name="LargeVolume" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues">
+	<ssv:Parameters>
+		<ssv:Parameter name="V#Value">
+			<ssv:Real value="5" unit="l"/>
+		</ssv:Parameter>
+	</ssv:Parameters>
+	<ssv:Units>
+		<ssv:Unit name="l">
+			<ssv:BaseUnit m="3" factor="0.001"/>
+		</ssv:Unit>
+	</ssv:Units>
+</ssv:ParameterSet>

--- a/componentLibraries/exampleComponentLib/HydraulicComponents/mediumvolume.ssv
+++ b/componentLibraries/exampleComponentLib/HydraulicComponents/mediumvolume.ssv
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet version="1.0" name="MediumVolume" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues">
+	<ssv:Parameters>
+		<ssv:Parameter name="V#Value">
+			<ssv:Real value="2" unit="l"/>
+		</ssv:Parameter>
+	</ssv:Parameters>
+	<ssv:Units>
+		<ssv:Unit name="l">
+			<ssv:BaseUnit m="3" factor="0.001"/>
+		</ssv:Unit>
+	</ssv:Units>
+</ssv:ParameterSet>

--- a/componentLibraries/exampleComponentLib/HydraulicComponents/smallvolume.ssv
+++ b/componentLibraries/exampleComponentLib/HydraulicComponents/smallvolume.ssv
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet version="1.0" name="SmallVolume" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues">
+	<ssv:Parameters>
+		<ssv:Parameter name="V#Value">
+			<ssv:Real value="1" unit="l"/>
+		</ssv:Parameter>
+	</ssv:Parameters>
+	<ssv:Units>
+		<ssv:Unit name="l">
+			<ssv:BaseUnit m="3" factor="0.001"/>
+		</ssv:Unit>
+	</ssv:Units>
+</ssv:ParameterSet>

--- a/doc/devWritingCustomComponents.dox
+++ b/doc/devWritingCustomComponents.dox
@@ -260,6 +260,10 @@ Information about the component for the graphical interface, such as icon, port 
       <port name="P2" x="0.0" y="0.5" a="180" visible="true"/>
       <port name="Kc" x="0.5" y="0.0" a="270" visible="false"/>
     </ports>
+	  <parametersets>
+        <parameterset name="First parameter set" path="firstparameterset.ssv"/>
+        <parameterset name="Second parameter set" path="secondparameterset.ssv"/>
+    </parametersets>
   </modelobject>
 </hopsanobjectappearance>
 \endverbatim
@@ -289,6 +293,9 @@ The first line contains basic information about the XML code, and should always 
   - \b y Y-position fraction of component icon height (0 = top, 1 = bottom)
   - \b a Angle of port, 0 = right, 90 = down, 180 = left, 270 = up, ports shall normally point outwards from the component
   - \b visible If the port is visible by default, \e true or \e false. (If omitted defaults to true)
+- \b parametersets Defines available pre-defined parameter sets for the component in [System Structure Parameter Values](https://ssp-standard.org/) format
+  - \b name Name of each parameter set
+  - \b path Relative path from the .xml file to the parameter set (.ssv)
   
  \page devWritingCppComponentsPageMarkdownHelp Markdown help with LaTeX equation support
  You can write component help documentation in markdown with additional support for LaTeX equations.


### PR DESCRIPTION
Parameter sets are specified in component XML files:
```
<?xml version='1.0' encoding='UTF-8'?>
<hopsanobjectappearance version="0.3">
    <modelobject [...]>
        <parametersets>
            <parameterset name="Small Piston" path="smallpiston.ssv"/>
            <parameterset name="Big Piston" path="bigpiston.ssv"/>
        </parametersets>
        [...]
    </modelobject>
</hopsanobjectappearance>
```

The SSV file must be a System Structure Parameter Values file according to the [SSP standard](https://ssp-standard.org/), where values to some or all parameters in the component are stored. 

If parameter sets are specified, they appear in the component properties dialog, where they can be selected from a drop-down menu and then applied with a button. Units are automatically converted depending on what is currently selected in the drop-down menus in the component properties dialog.

This PR also moves the reading of the SSV file to a separate utilty, and adds an SSV parameter specification class.