### PR TITLE
Fix symhop power underscore

### DIFF
--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -286,7 +286,7 @@ void Expression::commonConstructorCode(QStringList symbols, bool &ok, const Expr
                 str[i] = ',';
                 int j=i-1;
                 int parBal = 0;
-                while(j>=0 && (str[j].isLetterOrNumber() || str[j] == '.' || str[j] == ')' || (str[j] == '(' && parBal != 0) || parBal > 0
+                while(j>=0 && (str[j].isLetterOrNumber() || str[j] == '.' || str[j] == '_' || str[j] == ')' || (str[j] == '(' && parBal != 0) || parBal > 0
                                || (j>=1 && str[j]=='-' && str[j-1] == 'e') || (j>=1 && str[j]=='+' && str[j-1] == 'e')))
                 {
                     if(str[j] == ')') parBal++;
@@ -298,7 +298,7 @@ void Expression::commonConstructorCode(QStringList symbols, bool &ok, const Expr
 
                 j = i+6;
                 parBal = 0;
-                while(j<str.size() && (str[j].isLetterOrNumber() || str[j] == '.' || str[j] == '(' || (str[j] == ')' && parBal != 0) || parBal > 0))
+                while(j<str.size() && (str[j].isLetterOrNumber() || str[j] == '.' || str[j] == '_' || str[j] == '(' || (str[j] == ')' && parBal != 0) || parBal > 0))
                 {
                     if(str[j] == ')') parBal--;
                     if(str[j] == '(') parBal++;

--- a/UnitTests/SymHopTest/tst_symhoptest.cpp
+++ b/UnitTests/SymHopTest/tst_symhoptest.cpp
@@ -858,9 +858,11 @@ private Q_SLOTS:
         double x = 5.1;
         double y = 32.12;
         double z = 12.13;
+        double a_b = 3;
         variables.insert("x", x);
         variables.insert("y", y);
         variables.insert("z", z);
+        variables.insert("a_b", a_b);
         QTest::newRow("0") << Expression("sin(x)") << variables << sin(x) << true;
         QTest::newRow("1") << Expression("floor(x)") << variables << floor(x) << true;
         QTest::newRow("2") << Expression("limit(x,0,4)") << variables << 4.0 << true;
@@ -900,6 +902,7 @@ private Q_SLOTS:
         QTest::newRow("35") << Expression("2.61-1.44") << variables << 1.17 << true;
         QTest::newRow("36") << Expression("3.1415/4*15e-3^2*7800*.05") << variables << 0.068916656 << true;
         QTest::newRow("37") << Expression("x*y*y") << variables << x*y*y << true;
+        QTest::newRow("38") << Expression("a_b^2") << variables << pow(a_b,2) << true;
     }
 
 


### PR DESCRIPTION
This fixes a bug with SymHop evaluation when taking the power of a variable containg an underscore:
```
>> a=3
Assigning scalar a with 3
>> a_b=3
Assigning scalar a_b with 3
>> a^2
9
>> a_b^2
0
```
With this fix, `a_b^2` evaluates to 9 as it should. A unit test for this problem is also added.