### PR TITLE
Fix bug in hg() function in HCOM

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -9855,5 +9855,6 @@ double HcomFunctionoidHg::operator()(QString &str, bool &ok)
         mpHandler->mpConsole->printErrorMessage("No model is open", "", false);
         return 0;
     }
+    ok = true;
     return mpHandler->getModelPtr()->getLogDataHandler()->getHighestGenerationNumber()+1;
 }


### PR DESCRIPTION
The `ok` variabel was never set to `true`. As a consequence, the return value was ignored by HCOM and the function always returned zero.