### PR TITLE
Real-time simulation in HopsanCore

### DIFF
--- a/HopsanCore/include/ComponentSystem.h
+++ b/HopsanCore/include/ComponentSystem.h
@@ -130,6 +130,7 @@ namespace hopsan {
         virtual bool preInitialize();
         bool initialize(const double startT, const double stopT);
         void simulate(const double stopT);
+        bool startRealtimeSimulation(double realTimeFactor=1);
         virtual void simulateMultiThreaded(const double startT, const double stopT, const size_t nDesiredThreads = 0, const bool noChanges=false, ParallelAlgorithmT algorithm=OfflineSchedulingAlgorithm);
         void finalize();
 

--- a/HopsanCore/include/CoreUtilities/MultiThreadingUtilities.h
+++ b/HopsanCore/include/CoreUtilities/MultiThreadingUtilities.h
@@ -107,6 +107,8 @@ HOPSANCORE_DLLAPI void simSlave(ComponentSystem *pSystem, std::vector<Component*
                                 double timeStep, size_t numSimSteps, BarrierLock *pBarrier_S,
                                 BarrierLock *pBarrier_C, BarrierLock *pBarrier_Q, BarrierLock *pBarrier_N);
 
+HOPSANCORE_DLLAPI void simWholeSystemInRealtime(double realTimeFactor, volatile bool *pStopSimulation, double *pTime, double timeStep, std::vector<Component *> signalComponentPtrs, std::vector<Component *> cComponentPtrs, std::vector<Component *> qComponentPtrs);
+
 HOPSANCORE_DLLAPI void simWholeSystems(std::vector<ComponentSystem *> systemPtrs, double stopTime);
 
 

--- a/HopsanCore/include/CoreUtilities/SimulationHandler.h
+++ b/HopsanCore/include/CoreUtilities/SimulationHandler.h
@@ -62,6 +62,9 @@ public:
     bool simulateSystem(const double startT, const double stopT, const int nDesiredThreads, ComponentSystem* pSystem, bool noChanges=false, ParallelAlgorithmT algorithm=OfflineSchedulingAlgorithm);
     bool simulateSystem(const double startT, const double stopT, const int nDesiredThreads, std::vector<ComponentSystem*> &rSystemVector, bool noChanges=false, ParallelAlgorithmT algorithm=OfflineSchedulingAlgorithm);
 
+    bool startRealtimeSimulation(ComponentSystem *pSystem, double realtimeFactor=1);
+    void stopRealtimeSimulation(ComponentSystem *pSystem);
+
     void finalizeSystem(ComponentSystem* pSystem);
     void finalizeSystem(std::vector<ComponentSystem*> &rSystemVector);
 

--- a/HopsanCore/src/ComponentSystem.cpp
+++ b/HopsanCore/src/ComponentSystem.cpp
@@ -37,6 +37,7 @@
 #include <iostream>
 #include <algorithm>
 #include <map>
+#include <time.h>
 
 #include "ComponentSystem.h"
 #include "HopsanEssentials.h"
@@ -54,6 +55,8 @@ using namespace std;
 #if (__cplusplus >= 201103L)
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 #include <functional>
 #include <chrono>
@@ -3345,8 +3348,7 @@ void ComponentSystem::simulate(const double stopT)
     //Simulate
     for (size_t i=0; i<numSimulationSteps; ++i)
     {
-        if (mStopSimulation)
-        {
+        if (mStopSimulation) {
             break;
         }
 
@@ -3376,6 +3378,18 @@ void ComponentSystem::simulate(const double stopT)
 
         logTimeAndNodes(mTotalTakenSimulationSteps);
     }
+}
+
+bool ComponentSystem::startRealtimeSimulation(double realTimeFactor)
+{
+#if (__cplusplus >= 201103L)
+    std::thread rtThread(simWholeSystemInRealtime, realTimeFactor, &mStopSimulation, &mTime, mTimestep, mComponentSignalptrs, mComponentCptrs, mComponentQptrs);
+    rtThread.detach();
+    return true;
+#else
+    stopSimulation("Real-time simulation requires C++11 or above.");
+    return false;
+#endif
 }
 
 

--- a/HopsanCore/src/CoreUtilities/SimulationHandler.cpp
+++ b/HopsanCore/src/CoreUtilities/SimulationHandler.cpp
@@ -102,6 +102,16 @@ bool SimulationHandler::simulateSystem(const double startT, const double stopT, 
     return false;
 }
 
+bool SimulationHandler::startRealtimeSimulation(ComponentSystem *pSystem, double realtimeFactor)
+{
+    return pSystem->startRealtimeSimulation(realtimeFactor);
+}
+
+void SimulationHandler::stopRealtimeSimulation(ComponentSystem *pSystem)
+{
+    pSystem->stopSimulation();
+}
+
 void SimulationHandler::finalizeSystem(ComponentSystem* pSystem)
 {
     pSystem->finalize();

--- a/HopsanGUI/CoreAccess.cpp
+++ b/HopsanGUI/CoreAccess.cpp
@@ -200,6 +200,16 @@ bool CoreSimulationHandler::simulate(const double startTime, const double stopTi
     return gHopsanCore.getSimulationHandler()->simulateSystem(startTime, stopTime, nThreads, coreSystems, modelHasNotChanged, algorithm);
 }
 
+bool CoreSimulationHandler::startRealtimeSimumlation(CoreSystemAccess *pCoreSystemAccess, double realtimeFactor)
+{
+    return gHopsanCore.getSimulationHandler()->startRealtimeSimulation(pCoreSystemAccess->getCoreSystemPtr(), realtimeFactor);
+}
+
+void CoreSimulationHandler::stopRealtimeSimulation(CoreSystemAccess *pCoreSystemAccess)
+{
+    return gHopsanCore.getSimulationHandler()->stopRealtimeSimulation(pCoreSystemAccess->getCoreSystemPtr());
+}
+
 void CoreSimulationHandler::finalize(CoreSystemAccess* pCoreSystemAccess)
 {
     gHopsanCore.getSimulationHandler()->finalizeSystem(pCoreSystemAccess->getCoreSystemPtr());

--- a/HopsanGUI/CoreAccess.h
+++ b/HopsanGUI/CoreAccess.h
@@ -326,6 +326,9 @@ public:
     bool simulate(const double startTime, const double stopTime, const int nThreads, CoreSystemAccess* pCoreSystemAccess, bool modelHasNotChanged=false);
     bool simulate(const double startTime, const double stopTime, const int nThreads, QVector<CoreSystemAccess*> &rvCoreSystemAccess, bool modelHasNotChanged=false);
 
+    bool startRealtimeSimumlation(CoreSystemAccess *pCoreSystemAccess, double realTimeFactor=1);
+    void stopRealtimeSimulation(CoreSystemAccess *pCoreSystemAccess);
+
     void finalize(CoreSystemAccess* pCoreSystemAccess);
     void finalize(QVector<CoreSystemAccess*> &rvCoreSystemAccess);
 

--- a/HopsanGUI/Widgets/AnimationWidget.h
+++ b/HopsanGUI/Widgets/AnimationWidget.h
@@ -58,6 +58,7 @@ class MainWindow;
 class ModelObject;
 class LogDataHandler2;
 class ModelObjectAnimationData;
+class CoreSimulationHandler;
 
 class QGraphicsScene;
 class QTextEdit;
@@ -180,6 +181,8 @@ private:
     int mFps;
     double mTotalTime;
     double mnSamples;
+
+    CoreSimulationHandler *mpCoreSimulationHandler;
 
 public slots:
     void changeSpeed(double newSpeed);

--- a/HopsanGUI/Widgets/ModelWidget.cpp
+++ b/HopsanGUI/Widgets/ModelWidget.cpp
@@ -682,6 +682,23 @@ bool ModelWidget::simulate_blocking()
 
 }
 
+bool ModelWidget::startRealtimeSimulation(const double realtimeFactor)
+{
+    if(!mSimulateMutex.tryLock()) {
+        gpMessageHandler->addErrorMessage("Simulation mutex is locked. Aborting.");
+        return false;
+    }
+    CoreSimulationHandler mCoreSimulationHandler;
+    mCoreSimulationHandler.startRealtimeSimumlation(mpToplevelSystem->getCoreSystemAccessPtr(), realtimeFactor);
+}
+
+void ModelWidget::stopRealtimeSimulation()
+{
+    CoreSimulationHandler mCoreSimulationHandler;
+    mCoreSimulationHandler.stopRealtimeSimulation(mpToplevelSystem->getCoreSystemAccessPtr());
+    mSimulateMutex.unlock();
+}
+
 
 //! Slot that saves current project to old file name if it exists.
 //! @see saveModel(int index)

--- a/HopsanGUI/Widgets/ModelWidget.h
+++ b/HopsanGUI/Widgets/ModelWidget.h
@@ -119,6 +119,8 @@ public slots:
     void setTopLevelSimulationTime(const QString startTime, const QString timeStep, const QString stopTime);
     bool simulate_nonblocking();
     bool simulate_blocking();
+    bool startRealtimeSimulation(const double realtimeFactor);
+    void stopRealtimeSimulation();
     void save();
     void saveAs();
     void exportModelParametersToHpf();


### PR DESCRIPTION
- Functions in HopsanCore for starting and stopping detached realtime simulations
- Relative realtime simulation speed can be controlled using a `realtimeFactor` argument
- Access functions in HopsanGUI CoreAccess classes
- Replaces the old (very inefficient) simulation for real-time animation

This feature only works if HopsanCore is compiled with C++11 or above. I could not find any easy way of achieving the same functionality using old C++. 

Performance of realtime animation is greatly improved.