### PR TITLE
Fix crash when adding new component to library

### DIFF
--- a/HopsanGUI/Widgets/LibraryWidget.cpp
+++ b/HopsanGUI/Widgets/LibraryWidget.cpp
@@ -589,7 +589,7 @@ void LibraryWidget::handleItemClick(QTreeWidgetItem *item, int column)
         else if(pReply == pAddComponentAction) {
             SharedComponentLibraryPtrT pLib = mItemToLibraryMap[item];
             QStringList folders;
-            while(item->parent() != nullptr && isExternalLibrariesItem(item->parent())) {
+            while(item->parent() != nullptr && !isExternalLibrariesItem(item->parent())) {
                 folders.prepend(item->text(0));
                 item = item->parent();
             }


### PR DESCRIPTION
Fixed inverted check in if-statement, resulting in crash when trying to add a new component.