### PR TITLE
Fix missing finalize of real-time animation

### DIFF
--- a/HopsanGUI/CoreAccess.cpp
+++ b/HopsanGUI/CoreAccess.cpp
@@ -200,7 +200,7 @@ bool CoreSimulationHandler::simulate(const double startTime, const double stopTi
     return gHopsanCore.getSimulationHandler()->simulateSystem(startTime, stopTime, nThreads, coreSystems, modelHasNotChanged, algorithm);
 }
 
-bool CoreSimulationHandler::startRealtimeSimumlation(CoreSystemAccess *pCoreSystemAccess, double realtimeFactor)
+bool CoreSimulationHandler::startRealtimeSimulation(CoreSystemAccess *pCoreSystemAccess, double realtimeFactor)
 {
     return gHopsanCore.getSimulationHandler()->startRealtimeSimulation(pCoreSystemAccess->getCoreSystemPtr(), realtimeFactor);
 }

--- a/HopsanGUI/CoreAccess.h
+++ b/HopsanGUI/CoreAccess.h
@@ -326,7 +326,7 @@ public:
     bool simulate(const double startTime, const double stopTime, const int nThreads, CoreSystemAccess* pCoreSystemAccess, bool modelHasNotChanged=false);
     bool simulate(const double startTime, const double stopTime, const int nThreads, QVector<CoreSystemAccess*> &rvCoreSystemAccess, bool modelHasNotChanged=false);
 
-    bool startRealtimeSimumlation(CoreSystemAccess *pCoreSystemAccess, double realTimeFactor=1);
+    bool startRealtimeSimulation(CoreSystemAccess *pCoreSystemAccess, double realTimeFactor=1);
     void stopRealtimeSimulation(CoreSystemAccess *pCoreSystemAccess);
 
     void finalize(CoreSystemAccess* pCoreSystemAccess);

--- a/HopsanGUI/Widgets/ModelWidget.cpp
+++ b/HopsanGUI/Widgets/ModelWidget.cpp
@@ -697,6 +697,7 @@ void ModelWidget::stopRealtimeSimulation()
 {
     CoreSimulationHandler mCoreSimulationHandler;
     mCoreSimulationHandler.stopRealtimeSimulation(mpToplevelSystem->getCoreSystemAccessPtr());
+    mCoreSimulationHandler.finalize(mpToplevelSystem->getCoreSystemAccessPtr());
     mSimulateMutex.unlock();
 }
 

--- a/HopsanGUI/Widgets/ModelWidget.cpp
+++ b/HopsanGUI/Widgets/ModelWidget.cpp
@@ -689,8 +689,7 @@ bool ModelWidget::startRealtimeSimulation(const double realtimeFactor)
         return false;
     }
     CoreSimulationHandler mCoreSimulationHandler;
-    mCoreSimulationHandler.startRealtimeSimumlation(mpToplevelSystem->getCoreSystemAccessPtr(), realtimeFactor);
-    return true;
+    return mCoreSimulationHandler.startRealtimeSimulation(mpToplevelSystem->getCoreSystemAccessPtr(), realtimeFactor);
 }
 
 void ModelWidget::stopRealtimeSimulation()


### PR DESCRIPTION
Just add a missing call to `finalize()`.

Related to #2126.