### PR TITLE
Limit time vector length if simulation was stopped before reaching stop time

### DIFF
--- a/HopsanGUI/LogDataHandler2.cpp
+++ b/HopsanGUI/LogDataHandler2.cpp
@@ -1185,6 +1185,7 @@ bool LogDataHandler2::collectLogDataFromSystem(SystemObject *pCurrentSystem, con
 
     // Store the systems own time vector
     auto pCoreSysTimeVector = pCurrentSystem->getCoreSystemAccessPtr()->getLogTimeData();
+    pCoreSysTimeVector->resize(pCurrentSystem->getCoreSystemAccessPtr()->getCoreSystemPtr()->getNumActuallyLoggedSamples());
     if (pCoreSysTimeVector && !pCoreSysTimeVector->empty())
     {
         // Check so that we have not already stored this time vector in this generation

--- a/HopsanGUI/LogDataHandler2.cpp
+++ b/HopsanGUI/LogDataHandler2.cpp
@@ -58,6 +58,7 @@
 
 #include "ComponentUtilities/CSVParser.h"
 #include "HopsanTypes.h"
+#include "ComponentSystem.h"
 
 #ifdef USEHDF5
 #include "hopsanhdf5exporter.h"
@@ -1185,14 +1186,15 @@ bool LogDataHandler2::collectLogDataFromSystem(SystemObject *pCurrentSystem, con
 
     // Store the systems own time vector
     auto pCoreSysTimeVector = pCurrentSystem->getCoreSystemAccessPtr()->getLogTimeData();
-    pCoreSysTimeVector->resize(pCurrentSystem->getCoreSystemAccessPtr()->getCoreSystemPtr()->getNumActuallyLoggedSamples());
     if (pCoreSysTimeVector && !pCoreSysTimeVector->empty())
     {
         // Check so that we have not already stored this time vector in this generation
         if (!rGenTimeVectors.contains(pCoreSysTimeVector))
         {
             //! @todo here we need to copy (convert) from std vector to qvector, don know if that slows down (probably not much)
-            auto pSysTimeVector = insertTimeVectorVariable(QVector<double>::fromStdVector(*pCoreSysTimeVector), sharedSystemHierarchy);
+            auto time_vec = QVector<double>::fromStdVector(*pCoreSysTimeVector);
+            time_vec.resize(pCurrentSystem->getCoreSystemAccessPtr()->getCoreSystemPtr()->getNumActuallyLoggedSamples());
+            auto pSysTimeVector = insertTimeVectorVariable(time_vec, sharedSystemHierarchy);
             rGenTimeVectors.insert(pCoreSysTimeVector, pSysTimeVector);
         }
     }
@@ -1262,7 +1264,9 @@ bool LogDataHandler2::collectLogDataFromSystem(SystemObject *pCurrentSystem, con
                         // Else create a unique variable time vector for this component
                         else
                         {
-                            auto pVarTimeVec = insertTimeVectorVariable(QVector<double>::fromStdVector(*pCoreVarTimeVector), SharedSystemHierarchyT());
+                            auto time_vec = QVector<double>::fromStdVector(*pCoreVarTimeVector);
+                            time_vec.resize(pCurrentSystem->getCoreSystemAccessPtr()->getCoreSystemPtr()->getNumActuallyLoggedSamples());
+                            auto pVarTimeVec = insertTimeVectorVariable(time_vec, SharedSystemHierarchyT());
                             pNewData = insertTimeDomainVariable(pVarTimeVec, dataVec, pVarDesc);
                         }
                     }

--- a/HopsanGUI/PlotTab.cpp
+++ b/HopsanGUI/PlotTab.cpp
@@ -1361,7 +1361,7 @@ void PlotTab::openFrequencyAnalysisDialog(PlotCurve *pCurve)
 
     double xdiff = maxX-minX;
     if(0 == xdiff) {
-            gpMessageHandler->addErrorMessage("Minimum and maximum value of X-vector must not be equal when creating frequency spectrum");
+        gpMessageHandler->addErrorMessage("Minimum and maximum value of X-vector must not be equal when creating frequency spectrum");
         return;
     }
 
@@ -1449,16 +1449,20 @@ void PlotTab::openFrequencyAnalysisDialog(PlotCurve *pCurve)
                 break;
         }
         SharedVectorVariableT pNewVar = pCurve->getSharedVectorVariable()->toFrequencySpectrum(SharedVectorVariableT(), type, function, minTime, maxTime);
+        if (pNewVar) {
+            PlotTab *pTab = mpParentPlotWindow->addPlotTab();
+            pTab->addCurve(new PlotCurve(pNewVar, QwtPlot::yLeft, FrequencyAnalysisType));
+            pTab->setTabName("Frequency Spectrum");
 
-        PlotTab *pTab = mpParentPlotWindow->addPlotTab();
-        pTab->addCurve(new PlotCurve(pNewVar, QwtPlot::yLeft, FrequencyAnalysisType));
-        pTab->setTabName("Frequency Spectrum");
-
-        if(pLogScaleCheckBox->isChecked())
-        {
-            pTab->getPlotArea(0)->setBottomAxisLogarithmic(true); //!< @todo maybe need a set all logarithmic function
-            pTab->getPlotArea(0)->setLeftAxisLogarithmic(true);
-            pTab->rescaleAxesToCurves(); //!< @todo maybe we should not need to call this here
+            if(pLogScaleCheckBox->isChecked())
+            {
+                pTab->getPlotArea(0)->setBottomAxisLogarithmic(true); //!< @todo maybe need a set all logarithmic function
+                pTab->getPlotArea(0)->setLeftAxisLogarithmic(true);
+                pTab->rescaleAxesToCurves(); //!< @todo maybe we should not need to call this here
+            }
+        }
+        else {
+            gpMessageHandler->addErrorMessage("Failed to create frequency spectrum");
         }
     }
     pDialog->deleteLater();


### PR DESCRIPTION
Restrict length of time vector in log data hadnler to actually number of log samples. This is already done for data variables. 

Having different length of time and data vector causes FFT analysis (and perhaps other features) to crash.

Resolves #2132.