### PR TITLE
Only expand powers for integer exponents in SymHop

### DIFF
--- a/SymHop/include/SymHop.h
+++ b/SymHop/include/SymHop.h
@@ -114,6 +114,7 @@ public:
     bool isFunction() const;
     bool isSymbol() const;
     bool isNumericalSymbol() const;
+    bool isInteger() const;
     bool isVariable() const;
     bool isAssignment() const;
     bool isEquation() const;

--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -1619,6 +1619,10 @@ bool Expression::isNumericalSymbol() const
     return (!mString.isEmpty() && (mString[0].isNumber() || mString == "-1.0"));
 }
 
+bool Expression::isInteger() const
+{
+    return (this->isNumericalSymbol()) && (trunc(this->toDouble()) == this->toDouble());
+}
 
 //! @brief Tells whether or not this is a variable
 bool Expression::isVariable() const
@@ -2624,8 +2628,8 @@ void Expression::expand(const ExpressionSimplificationT simplifications)
 //Expand power functions from e.g. "pow(x,3)" to "x*x*x". This will improve performance in generated code.
 void Expression::expandPowers()
 {
-    if(this->isPower() && this->getPower()->isNumericalSymbol()) {
-        int nFactors = int(mpPower->toDouble());
+    if(this->isPower() && this->getPower()->isInteger()) {
+        int nFactors = int(mpPower->toDouble()+0.5);
         QList<Expression> factors;
         for(int i=0; i<nFactors; ++i) {
             factors << (*mpBase);


### PR DESCRIPTION
`x^3` should be expanded to `x*x*x` to improve performance, but `x^2.5` should obviously not be expanded.