### PR TITLE
Support inline transformation of Laplace operator

### DIFF
--- a/HopsanGenerator/src/generators/HopsanModelicaGenerator.cpp
+++ b/HopsanGenerator/src/generators/HopsanModelicaGenerator.cpp
@@ -790,6 +790,7 @@ bool HopsanModelicaGenerator::generateComponentObject(ComponentSpecification &co
     removeDuplicates(unknowns);
     unknowns.removeAll(Expression("mTime"));
     unknowns.removeAll(Expression("mTimestep"));
+    unknowns.removeAll(Expression("s"));
 
     //Verify equation system
     printMessage("Found "+QString::number(systemEquations.size())+" equations, "+QString::number(knowns.size())+" known variables and "+QString::number(unknowns.size())+" unknown variables.");

--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -2300,6 +2300,11 @@ Expression Expression::inlineTransform(const InlineTransformT transform, bool &o
             retExpr = retExpr.inlineTransform(transform, ok);
         }
     }
+    else if(this->isSymbol()) {
+        if(mString == "s") {
+            retExpr = Expression(transformStr.arg("1"));
+        }
+    }
 
     ok = true;
     return retExpr;


### PR DESCRIPTION
Support laplace `s` in inline transformation and thereby also in Modelica models alongside with the `der()` operator. In inline integration it simply replaced by the integration method, similarly to `der(1)`.