### PR TITLE
Fix text editor parenthesis crash

### DIFF
--- a/HopsanGUI/Widgets/HcomWidget.cpp
+++ b/HopsanGUI/Widgets/HcomWidget.cpp
@@ -238,7 +238,7 @@ TerminalConsole::TerminalConsole(TerminalWidget *pParent)
     mpCompleter->setCompletionMode(QCompleter::PopupCompletion);
     mpCompleter->setCaseSensitivity(Qt::CaseInsensitive);
 #if QT_VERSION >= 0x050700
-    connect(mpCompleter, qOverload<const QString&>(&QCompleter::activated), this, &TerminalConsole::insertCompletion);
+    connect(mpCompleter, QOverload<const QString&>::of(&QCompleter::activated), this, &TerminalConsole::insertCompletion);
 #else
     QObject::connect(mpCompleter, SIGNAL(activated(QString)), this, SLOT(insertCompletion(QString)));
 #endif

--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -778,7 +778,10 @@ void TextEditor::keyPressEvent(QKeyEvent* event)
         else {
             auto cursor = textCursor();
             int pos = cursor.position();
-            QChar next = this->toPlainText().at(pos);
+            QChar next = '\n';
+            if(pos < this->toPlainText().size()) {
+                next = this->toPlainText().at(pos);
+            }
             cursor.beginEditBlock();
             if(next.isSpace() || next == '\n') {
                 insertPlainText("()");


### PR DESCRIPTION
Checking for end of line by checking if next character is a newline fails on the very last line, since it does not end with a newline.

Also replaced `qOverload<const QString&>` with `QOverload<const QString&>::of`. It seems like the existance of qOverload depends on both Qt version and C++ standard somehow.