### PR TITLE
Fix undesired abort script if using if statement without else in HCOM

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -8001,7 +8001,7 @@ QString HcomHandler::runScriptCommands(QStringList &lines, bool *pAbort)
                     }
                 }
                 else {
-                    return QString();
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
Fixes a small mistake in the code which resulted in HCOM scripts aborting prematurely when using if-statements without else.