### PR TITLE
Fix weird disabling of signal disconnect

### DIFF
--- a/HopsanGUI/ModelHandler.cpp
+++ b/HopsanGUI/ModelHandler.cpp
@@ -721,7 +721,7 @@ void ModelHandler::disconnectMainWindowConnections(ModelWidget *pModel)
 
 void ModelHandler::disconnectMainWindowConnections(TextEditorWidget* pScriptEditor)
 {
-    //disconnect(gpMainWindow->mpSaveAction,      SIGNAL(triggered()),    pScriptEditor, SLOT(save()));
+    disconnect(gpMainWindow->mpSaveAction,      SIGNAL(triggered()),    pScriptEditor, SLOT(save()));
     disconnect(gpMainWindow->mpSaveAndRunAction,  SIGNAL(triggered()),    pScriptEditor,  SLOT(saveAndRun()));
     disconnect(gpMainWindow->mpSaveAsAction,      SIGNAL(triggered()),    pScriptEditor, SLOT(saveAs()));
     disconnect(gpMainWindow->mpCutAction,      SIGNAL(triggered()),    pScriptEditor, SLOT(cut()));


### PR DESCRIPTION
Not sure why this line was disabled in the first place, but it caused two problems which are resolved by this PR:
- Constant warnings that file has changed on disk, even if it was saved by Hopsan
- Severe delays when saving text files
The problems occured because a new signal connection was established every time you changed to a text editor tab, but they were never disconnected. The file was then saved multiple times when user clicked "save". The first saving was ignored by the file monitor as it should be, but it did not expect it to be saved more than once. Even worse, all open text files was saved every time.