### PR TITLE
Only close find widget when it has focus, otherwise give it focus

### DIFF
--- a/HopsanGUI/Widgets/FindWidget.cpp
+++ b/HopsanGUI/Widgets/FindWidget.cpp
@@ -373,11 +373,17 @@ void FindWidget::replaceAll()
 
 void FindWidget::setVisible(bool visible)
 {
-    //If text is selected in current editor, update it in find widget
     if(mpTextEditor) {
+
+        //If text is selected in current editor, update it in find widget
         QString selection = mpTextEditor->getSelectedText();
         if(!selection.contains("\u2029") && mpFindLineEdit->text() != selection && !selection.isEmpty()) {
             mpFindLineEdit->setText(selection);
+            visible = true;
+        }
+
+        //If find widget does not have focus, give it focus instead of hiding it
+        if(gpMainWindowWidget->focusWidget() != mpFindLineEdit) {
             visible = true;
         }
     }


### PR DESCRIPTION
Pressing Ctrl-F should:
- Open find widget if a model/text file is open
- Give focus to find widget if it is not already focused
- Hide find widget if it is focused
I often press ctrl-f when I want to search, and it is really annoying having to press it twice if the find widget is already open but not active.