### PR TITLE
Home button should move to beginning of line if there are only spaces before cursor

### DIFF
--- a/HopsanGUI/Widgets/TextEditorWidget.cpp
+++ b/HopsanGUI/Widgets/TextEditorWidget.cpp
@@ -566,16 +566,28 @@ void TextEditor::keyPressEvent(QKeyEvent* event)
     {
         if((event->modifiers().testFlag(Qt::ShiftModifier)))
         {
-            moveCursor(QTextCursor::StartOfBlock, QTextCursor::KeepAnchor); //Shift+home = select until start of line (Excluding whitespace at beginning)
-            if(this->textCursor().selection().toPlainText().startsWith(" ")) {
-                moveCursor(QTextCursor::NextWord, QTextCursor::KeepAnchor);
+            QString textLeftOfCursor = textCursor().block().text().left(textCursor().positionInBlock());
+            if(textLeftOfCursor.trimmed().isEmpty()) {
+                moveCursor(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+            }
+            else {
+                moveCursor(QTextCursor::StartOfBlock, QTextCursor::KeepAnchor); //Shift+home = select until start of line (Excluding whitespace at beginning)
+                if(this->textCursor().selection().toPlainText().startsWith(" ")) {
+                    moveCursor(QTextCursor::NextWord, QTextCursor::KeepAnchor);
+                }
             }
         }
         else
         {
-            moveCursor(QTextCursor::StartOfBlock);      //Home = move cursor to start of line, excluding initial whitespace
-            if(this->textCursor().block().text().startsWith(" ")) {
-                moveCursor(QTextCursor::NextWord);
+            QString textLeftOfCursor = textCursor().block().text().left(textCursor().positionInBlock());
+            if(textLeftOfCursor.trimmed().isEmpty()) {
+                moveCursor(QTextCursor::StartOfLine);
+            }
+            else {
+                moveCursor(QTextCursor::StartOfBlock);      //Home = move cursor to start of line, excluding initial whitespace
+                if(this->textCursor().block().text().startsWith(" ")) {
+                    moveCursor(QTextCursor::NextWord);
+                }
             }
         }
     }


### PR DESCRIPTION
In text editor: If user presses home and there are text before cursor, it should move to the beginning of the text. If there is only space before cursor, it should move to beginning of line. That is, first press on home usually moves to beginning of text, and second press to beginning of line. 

This works also while pressing shift for selecting text.