### PR TITLE
Remember original data when saving models with missing components

### DIFF
--- a/HopsanGUI/GUIConnector.cpp
+++ b/HopsanGUI/GUIConnector.cpp
@@ -621,6 +621,9 @@ void Connector::saveToDomElement(QDomElement &rDomElement)
     // Ignore if connector broken
     if (mIsBroken)
     {
+        if(!mFallbackDomElement.isNull()) {
+            rDomElement.appendChild(mFallbackDomElement.cloneNode().toElement());
+        }
         return;
     }
 
@@ -1199,6 +1202,12 @@ void Connector::setDashed(bool value)
     mIsDashed=value;
     refreshPen();
     mpParentSystemObject->mpModelWidget->hasChanged();
+}
+
+//! @brief Stores XML data that can be used if the component is missing and cannot save itself
+void Connector::setFallbackDomElement(const QDomElement &rElement)
+{
+    mFallbackDomElement = rElement.cloneNode().toElement();
 }
 
 

--- a/HopsanGUI/GUIConnector.h
+++ b/HopsanGUI/GUIConnector.h
@@ -125,6 +125,7 @@ public slots:
     void deselect();
     void select();
     void setDashed(bool value);
+    void setFallbackDomElement(const QDomElement &rElement);
 
 private slots:
     void setVisible(bool visible);
@@ -157,6 +158,8 @@ private:
     QVector<QPointF> mPoints;
 
     Component *mpVolunectorComponent;
+
+    QDomElement mFallbackDomElement;
 };
 
 

--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -4658,8 +4658,11 @@ void SystemObject::loadFromDomElement(QDomElement domElement)
                                                                     xmlSubObject.attribute(HMF_TYPENAME) + QString(", Name: ") + xmlSubObject.attribute(HMF_NAMETAG));
 
                 // Insert missing component dummy instead
+                QString typeName = xmlSubObject.attribute(HMF_TYPENAME);
                 xmlSubObject.setAttribute(HMF_TYPENAME, "MissingComponent");
                 pObj = loadModelObject(xmlSubObject, this, NoUndo);
+                xmlSubObject.setAttribute(HMF_TYPENAME, typeName);
+                pObj->setFallbackDomElement(xmlSubObject);
             }
             else
             {

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -701,6 +701,12 @@ bool ModelObject::isLossesDisplayVisible()
     return mpLossesDisplay->isVisible();
 }
 
+//! @brief Stores XML data that can be used if the component is missing and cannot save itself
+void ModelObject::setFallbackDomElement(const QDomElement &rDomElement)
+{
+    mFallbackDomElement = rDomElement.cloneNode().toElement();
+}
+
 
 //! @brief Get a pointer to the port with the specified name
 //! @param [in] rName The port name
@@ -1025,10 +1031,15 @@ bool ModelObject::getCustomParameterUnitScale(QString name, UnitConverter &rUs)
 
 void ModelObject::saveToDomElement(QDomElement &rDomElement, SaveContentsEnumT contents)
 {
-    QDomElement xmlObject = appendDomElement(rDomElement, getHmfTagName());
-    saveCoreDataToDomElement(xmlObject, contents);
-    if (contents == FullModel) {
-        saveGuiDataToDomElement(xmlObject);
+    if(!mFallbackDomElement.isNull()) { //Missing component, use fallback dom element
+        rDomElement.appendChild(mFallbackDomElement.cloneNode().toElement());
+    }
+    else {
+        QDomElement xmlObject = appendDomElement(rDomElement, getHmfTagName());
+        saveCoreDataToDomElement(xmlObject, contents);
+        if (contents == FullModel) {
+            saveGuiDataToDomElement(xmlObject);
+        }
     }
 }
 

--- a/HopsanGUI/GUIObjects/GUIModelObject.h
+++ b/HopsanGUI/GUIObjects/GUIModelObject.h
@@ -153,6 +153,9 @@ public:
     void getLosses(double &total, QMap<QString, double> domainSpecificLosses);
     bool isLossesDisplayVisible();
 
+    void setFallbackDomElement(const QDomElement &rDomElement);
+    QDomElement getFallbackDomElement();
+
 public slots:
     virtual void refreshAppearance();
     virtual void refreshExternalPortsAppearanceAndPosition();
@@ -234,6 +237,8 @@ protected:
     QPointer<ComponentPropertiesDialog3> mpPropertiesDialog;
 
     QTimer mDragCopyTimer;
+
+    QDomElement mFallbackDomElement;
 
 protected slots:
     void snapNameTextPosition(QPointF pos);

--- a/HopsanGUI/loadFunctions.cpp
+++ b/HopsanGUI/loadFunctions.cpp
@@ -115,40 +115,35 @@ bool loadConnector(QDomElement &rDomElement, SystemObject* pContainer, UndoStatu
     Port *startPort = pContainer->getModelObjectPort(startComponentName, startPortName);
     Port *endPort = pContainer->getModelObjectPort(endComponentName, endPortName);
 
-    if (startPort && endPort)
+    Connector* pConn = pContainer->createConnector(startPort, endPort, NoUndo);
+    if (pConn)
     {
-        Connector* pConn = pContainer->createConnector(startPort, endPort, NoUndo);
-        if (pConn)
+        if(pointVector.isEmpty() && !pConn->isDangling() && !pConn->isBroken())   //Create a diagonal connector if no points were loaded from HMF
         {
-            if(pointVector.isEmpty() && !pConn->isDangling() && !pConn->isBroken())   //Create a diagonal connector if no points were loaded from HMF
-            {
-                pointVector.push_back(pConn->getStartPort()->boundingRect().center());
-                pointVector.push_back(pConn->getEndPort()->boundingRect().center());
-                geometryList.clear();
-                geometryList.append("diagonal");
-            }
-            pConn->setPointsAndGeometries(pointVector, geometryList);
-            pConn->setDashed(isDashed);
-            pConn->refreshConnectorAppearance();
-            pConn->setColor(color);
-
-            if(undoSettings == Undo)
-            {
-                pContainer->getUndoStackPtr()->registerAddedConnector(pConn);
-            }
-            if (pConn->isConnected())
-            {
-                success = true;
-            }
+            pointVector.push_back(pConn->getStartPort()->boundingRect().center());
+            pointVector.push_back(pConn->getEndPort()->boundingRect().center());
+            geometryList.clear();
+            geometryList.append("diagonal");
         }
-        else
+        pConn->setPointsAndGeometries(pointVector, geometryList);
+        pConn->setDashed(isDashed);
+        pConn->refreshConnectorAppearance();
+        pConn->setColor(color);
+
+        if(undoSettings == Undo)
         {
+            pContainer->getUndoStackPtr()->registerAddedConnector(pConn);
+        }
+        if (pConn->isConnected())
+        {
+            success = true;
+        }
+
+        if(startPort == nullptr || endPort == nullptr)
+        {
+            pConn->setFallbackDomElement(rDomElement);
             success = false;
         }
-    }
-    else
-    {
-        success = false;
     }
 
     gpMessageHandler->collectHopsanCoreMessages();;


### PR DESCRIPTION
When loading a model with components from a missing library, the original XML data is stored in "fallback dom elements" for both the model object and the dangling connectors. These are then used when saving the model. This both elliminates the problem of accidentally saving a model with missing components and thereby losing data, and with the backup models being damaged during a failed library recompilation.

Resolves #1009.