### PR TITLE
Adds the Chocolatey package as a way to install Hopsan

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ You can also choose if you want the compiler included for importing and exportin
 
 If you choose the zip version, no start menu entry for Hopsan will be added, instead go into the bin directory and double-click hopsangui.exe to start.
 
+#### Chocolatey (a.k.a. [Chocolatey Package Manager](https://community.chocolatey.org/packages/hopsan), App Installer):
+
+```
+choco install hopsan
+```
+
 ### Ubuntu and Debian Packages
 
 You can download official release packages from  


### PR DESCRIPTION
Hi Hopsan devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1368) and now, we can install **hopsan** using [Chocolatey](https://community.chocolatey.org/packages/hopsan).

For now, only the latest version (`2.20.0`) is available on Chocolatey. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

