### PR TITLE
Hcom ans() function

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -422,7 +422,7 @@ HcomHandler::HcomHandler(TerminalConsole *pConsole) : QObject(pConsole)
     registerFunctionoid("maxpar", new HcomFunctionoidMaxPar(this), "Returns the maximum value of specified parameter for specified component type", "Usage: maxpar(type,par)");
     registerFunctionoid("minpar", new HcomFunctionoidMinPar(this), "Returns the minimum value of specified parameter for specified component type", "Usage: minpar(type,par)");
     registerFunctionoid("hg", new HcomFunctionoidHg(this), "Returns highest generation number", "Usage: hg()");
-
+    registerFunctionoid("ans", new HcomFunctionoidAns(this), "Returns the answer from the previous computation", "Usage: ans()");
     createCommands();
 
     mLocalVars.insert("true",1);
@@ -6136,6 +6136,7 @@ void HcomHandler::evaluateExpression(QString expr, VariableType desiredType)
         bool ok;
         QString parVal;
 
+        double orgAnsScalar = mAnsScalar;
         while(true)
         {
             parVal = getParameterValue(fullName, parType, true);
@@ -6178,6 +6179,8 @@ void HcomHandler::evaluateExpression(QString expr, VariableType desiredType)
             }
             else
             {
+                mAnsScalar = orgAnsScalar;
+                mAnsType = Scalar;
                 break;
             }
         }
@@ -10126,4 +10129,16 @@ double HcomFunctionoidHg::operator()(QString &str, bool &ok)
     }
     ok = true;
     return mpHandler->getModelPtr()->getLogDataHandler()->getHighestGenerationNumber()+1;
+}
+
+double HcomFunctionoidAns::operator()(QString &str, bool &ok)
+{
+    Q_UNUSED(str);
+    if(mpHandler->mAnsType != HcomHandler::Scalar) {
+        ok = false;
+        mpHandler->mpConsole->printErrorMessage("ans() function only work with scalar computations.");
+        return 0;
+    }
+    ok = true;
+    return mpHandler->mAnsScalar;
 }

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -7468,7 +7468,7 @@ void HcomHandler::evaluateExpression(QString expr, VariableType desiredType)
     bool ok;
     SymHop::Expression symHopExpr = SymHop::Expression(expr, &ok, SymHop::Expression::NoSimplifications);
 
-    if(!ok)
+    if(!ok || !symHopExpr.verifyExpression(mLocalFunctionoidPtrs.keys()))
     {
         HCOMERR("Could not evaluate expression: "+expr);
         mAnsType = Wildcard;
@@ -7698,6 +7698,12 @@ void HcomHandler::evaluateExpression(QString expr, VariableType desiredType)
         //timer.toc("local pars to local vars");
 
         bool ok;
+        if(!symHopExpr.verifyExpression(mLocalFunctionoidPtrs.keys())) {
+            mAnsType = Wildcard;
+            HCOMERR("Illegal SymHop expression: "+symHopExpr.toString());
+            mAnsWildcard = symHopExpr.toString();
+        }
+
         double scalar = symHopExpr.evaluate(localVars, &mLocalFunctionoidPtrs, &ok);
         if(ok)
         {

--- a/HopsanGUI/HcomHandler.h
+++ b/HopsanGUI/HcomHandler.h
@@ -451,6 +451,13 @@ public:
     double operator()(QString &str, bool &ok);
 };
 
+class HcomFunctionoidAns : public HcomFunctionoid
+{
+public:
+    HcomFunctionoidAns(HcomHandler *pHandler) : HcomFunctionoid(pHandler) {}
+    double operator()(QString &str, bool &ok);
+};
+
 class HcomFunctionoidExists : public HcomFunctionoid
 {
 public:

--- a/SymHop/include/SymHop.h
+++ b/SymHop/include/SymHop.h
@@ -157,10 +157,10 @@ public:
     void factor(const Expression var);
     void factorMostCommonFactor();
 
-    bool verifyExpression() const;
+    bool verifyExpression(const QStringList &userFunctions = QStringList()) const;
 
     //Public functions that are not intended to be used externally
-    bool _verifyFunctions() const;
+    bool _verifyFunctions(const QStringList &userFunctions) const;
     void _simplify(ExpressionSimplificationT type = Expression::FullSimplification, const ExpressionRecursiveT recursive=NonRecursive);
 
     double countTerm(const Expression &expr) const;

--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -2849,11 +2849,10 @@ void Expression::factorMostCommonFactor()
 
 //! @brief Verifies that the expression is correct
 //FIXED
-bool Expression::verifyExpression() const
+bool Expression::verifyExpression(const QStringList &userFunctions) const
 {
-
     //Verify all functions
-    if(!_verifyFunctions())
+    if(!_verifyFunctions(userFunctions))
     {
         return false;
     }
@@ -2864,14 +2863,14 @@ bool Expression::verifyExpression() const
 
 //! @brief Verifies that all functions are supported
 //FIXED
-bool Expression::_verifyFunctions() const
+bool Expression::_verifyFunctions(const QStringList &userFunctions) const
 {
     bool success = true;
 
     QStringList functions = this->getFunctions();
     for(int i=0; i<functions.size(); ++i)
     {
-        if(!getSupportedFunctionsList().contains(functions[i]) && !getCustomFunctionList().contains(functions[i]))
+        if(!getSupportedFunctionsList().contains(functions[i]) && !getCustomFunctionList().contains(functions[i]) && !userFunctions.contains(functions[i]))
         {
             //QMessageBox::critical(0, "SymHop", "Function \""+functions[i]+"\" is not supported by component generator.");
             success = false;


### PR DESCRIPTION
- New HCOM function `ans()`: returns the answer from the previous computation. Only works for scalars.
- Show error message when using unsupported functions (used to simply return zero)