### PR TITLE
Support systemports with connection not required

### DIFF
--- a/HopsanCore/include/ComponentSystem.h
+++ b/HopsanCore/include/ComponentSystem.h
@@ -87,7 +87,7 @@ namespace hopsan {
         virtual std::list<HString> getModelAssets() const;
 
         // Handle system ports
-        Port* addSystemPort(HString portName, const HString &rDescription="");
+        Port* addSystemPort(HString portName, const HString &rDescription="", const Port::RequireConnectionEnumT reqConnect=Port::Required);
         HString renameSystemPort(const HString &rOldname, const HString &rNewname);
         void deleteSystemPort(const HString &rName);
 

--- a/HopsanCore/src/ComponentSystem.cpp
+++ b/HopsanCore/src/ComponentSystem.cpp
@@ -1079,7 +1079,7 @@ std::list<HString> ComponentSystem::getModelAssets() const
 }
 
 //! @brief Adds a transparent SubSystemPort
-Port* ComponentSystem::addSystemPort(HString portName, const HString &rDescription)
+Port* ComponentSystem::addSystemPort(HString portName, const HString &rDescription, const Port::RequireConnectionEnumT reqConnect)
 {
     // Force default port name p, if nothing else specified
     if (portName.empty())
@@ -1087,7 +1087,7 @@ Port* ComponentSystem::addSystemPort(HString portName, const HString &rDescripti
         portName = "p";
     }
 
-    return addPort(portName, SystemPortType, "NodeEmpty", rDescription, Port::Required);
+    return addPort(portName, SystemPortType, "NodeEmpty", rDescription, reqConnect);
 }
 
 


### PR DESCRIPTION
Added connection-not-required argument to `addSystemPort()` function. This will only affect hand-coded "subsystem components". Deafult value for argument is to require a connection.