### PR TITLE
Support dot before exponential in HCOM

### DIFF
--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -384,7 +384,12 @@ void Expression::commonConstructorCode(QStringList symbols, bool &ok, const Expr
                              (i>1 && str.size() > i+2 && str.at(i-2).isNumber() && str.at(i-1) == 'e' && str.at(i) == '-' && str.at(i+1) == '+' && str.at(i+2).isNumber()) ||
                              (i>1 && str.size() > i+1 && str.at(i-2).isNumber() && str.at(i-1) == 'e' && str.at(i) == '+' && str.at(i+1).isNumber()) ||
                              (i>2 && str.size() > i+1 && str.at(i-3).isNumber() && str.at(i-2) == "e" && str.at(i-1) == '+' && str.at(i) == '-' && str.at(i+1).isNumber()) ||
-                             (i>2 && str.size() > i+1 && str.at(i-3).isNumber() && str.at(i-2) == "e" && str.at(i-1) == '-' && str.at(i) == '+' && str.at(i+1).isNumber())))     //End of variable, append it to symbols (last two checks makes sure that Xe+Y and Xe-Y are treated as one symbol)
+                             (i>2 && str.size() > i+1 && str.at(i-3).isNumber() && str.at(i-2) == "e" && str.at(i-1) == '-' && str.at(i) == '+' && str.at(i+1).isNumber()) ||
+                             (i>1 && str.size() > i+2 && str.at(i-2) == '.' && str.at(i-1) == 'e' && str.at(i) == '+' && str.at(i+1) == '-' && str.at(i+2).isNumber()) ||
+                             (i>1 && str.size() > i+2 && str.at(i-2) == '.' && str.at(i-1) == 'e' && str.at(i) == '-' && str.at(i+1) == '+' && str.at(i+2).isNumber()) ||
+                             (i>1 && str.size() > i+1 && str.at(i-2) == '.' && str.at(i-1) == 'e' && str.at(i) == '+' && str.at(i+1).isNumber()) ||
+                             (i>2 && str.size() > i+1 && str.at(i-3) == '.' && str.at(i-2) == "e" && str.at(i-1) == '+' && str.at(i) == '-' && str.at(i+1).isNumber()) ||
+                             (i>2 && str.size() > i+1 && str.at(i-3) == '.' && str.at(i-2) == "e" && str.at(i-1) == '-' && str.at(i) == '+' && str.at(i+1).isNumber())))     //End of variable, append it to symbols (last two checks makes sure that Xe+Y and Xe-Y are treated as one symbol)
             {
                 var = false;
                 symbols.append(str.mid(start, i-start));


### PR DESCRIPTION
Fixes issue with HCOM commands like
```
x=14.e-3
```
It used to assume the "e" should have a number  before it. This fix extends this to also allow a dot.