### PR TITLE
Fix crash when replacing subtype components with missing component

### DIFF
--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -4655,6 +4655,7 @@ void SystemObject::loadFromDomElement(QDomElement domElement)
                 // Insert missing component dummy instead
                 QString typeName = xmlSubObject.attribute(HMF_TYPENAME);
                 xmlSubObject.setAttribute(HMF_TYPENAME, "MissingComponent");
+                xmlSubObject.setAttribute(HMF_SUBTYPENAME, "");
                 pObj = loadModelObject(xmlSubObject, this, NoUndo);
                 xmlSubObject.setAttribute(HMF_TYPENAME, typeName);
                 pObj->setFallbackDomElement(xmlSubObject);


### PR DESCRIPTION
Don't keep subtypename attribute when replacing missing components with MissingComponent typename. This attemtps to load a component which is a subtype of MissingComponent, which does not exist.