### PR TITLE
Allow local HCOM functions in temporary expression evaluations

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -7491,7 +7491,7 @@ void HcomHandler::evaluateExpression(QString expr, VariableType desiredType)
     bool ok;
     SymHop::Expression symHopExpr = SymHop::Expression(expr, &ok, SymHop::Expression::NoSimplifications);
 
-    if(!ok || !symHopExpr.verifyExpression(mLocalFunctionoidPtrs.keys()))
+    if(!ok || !symHopExpr.verifyExpression(mLocalFunctionoidPtrs.keys()+mLocalFunctionDescriptions.keys()))
     {
         HCOMERR("Could not evaluate expression: "+expr);
         mAnsType = Wildcard;


### PR DESCRIPTION
This for example enables commands like:
```
chpv 5*linspace(0,1,100)
```
which did not work before, since "linspace" was not recognized as a legal function by SymHop.