### PR TITLE
Merge divisors after removing factor in SymHop

### DIFF
--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -2521,6 +2521,16 @@ void Expression::removeFactor(const Expression var)
     if(mFactors.size() == 1 && mDivisors.empty()) {
         this->replaceBy(Expression(mFactors.first()));
     }
+    for(int d=0; d<mDivisors.size(); ++d)
+    {
+        if(mDivisors[d].isMultiplyOrDivide())
+        {
+            mFactors.append(mDivisors[d].mDivisors);
+            mDivisors.append(mDivisors[d].mFactors);
+            mDivisors.removeAt(d);
+            --d;
+        }
+    }
     return;
 }
 


### PR DESCRIPTION
After calling `removeFactor()`, check if divisor contains its own factors and if so, merge all remaining factors to one expression.

This is to ensure correct parenthesis in the `print()` function, to avoid e.g. "a/(b*c)" being printed as "a/b*c".