### PR TITLE
Use real variable names in Matlab (.m) export

### DIFF
--- a/HopsanGUI/LogVariable.cpp
+++ b/HopsanGUI/LogVariable.cpp
@@ -323,11 +323,16 @@ QString VectorVariable::getFullVariableNameWithSeparator(const QString sep) cons
     return mpVariableDescription->getFullNameWithSeparator(sep);
 }
 
-QString VectorVariable::getSmartName() const
+QString VectorVariable::getSmartName(const QString sep) const
 {
     if (mpVariableDescription->mAliasName.isEmpty())
     {
-        return mpVariableDescription->getFullName();
+        if(sep.isEmpty()) {
+            return mpVariableDescription->getFullName();
+        }
+        else {
+            return mpVariableDescription->getFullNameWithSeparator(sep);
+        }
     }
     else
     {

--- a/HopsanGUI/LogVariable.h
+++ b/HopsanGUI/LogVariable.h
@@ -137,7 +137,7 @@ public:
     const QString &getAliasName() const;
     QString getFullVariableName() const;
     QString getFullVariableNameWithSeparator(const QString sep) const;
-    QString getSmartName() const;
+    QString getSmartName(const QString sep="") const;
     const SharedSystemHierarchyT getSystemHierarchy() const;
     const QString &getModelPath() const;
     const QString &getComponentName() const;


### PR DESCRIPTION
Use the real names of the varaibles instead of the annoying x0, y0, x1, y1...

- Alias names are prefered
- Underscore is used as separator when full variable names are used
- Generation is appended after each name
- Duplicate variables are not exported (e.g. Time might be used multiple times)
- Also added a separator argument to `getSmartName()` function, which is empty by default and in that case ignored