### PR TITLE
Prevent recompilation of library with XML flag

### DIFF
--- a/HopsanGUI/LibraryHandler.cpp
+++ b/HopsanGUI/LibraryHandler.cpp
@@ -33,6 +33,8 @@
 
 //Defines
 #define XML_LIBRARY "hopsancomponentlibrary"
+#define XML_VERSION "version"
+#define XML_RECOMPILABLE "recompilable"
 #define XML_LIBRARY_NAME "name"
 #define XML_LIBRARY_ID "id"
 #define XML_LIBRARY_LIB "lib"
@@ -1124,7 +1126,8 @@ bool LibraryHandler::loadLibrary(SharedComponentLibraryPtrT pLibrary, LibraryTyp
                 QDomElement xmlRoot = domDocument.documentElement();
                 if(xmlRoot.tagName() == QString(XML_LIBRARY))
                 {
-                    pLibrary->version = xmlRoot.attribute("version");
+                    pLibrary->version = xmlRoot.attribute(XML_VERSION);
+                    pLibrary->recompilable = parseAttributeBool(xmlRoot, XML_RECOMPILABLE, true);
                     // Read name of library
                     pLibrary->name = xmlRoot.firstChildElement(XML_LIBRARY_NAME).text();
                     if (pLibrary->name.isEmpty()) {
@@ -1685,6 +1688,11 @@ void LibraryHandler::importFmu()
 //! @param solver Solver to use (for Modelica code only)
 void LibraryHandler::recompileLibrary(SharedComponentLibraryPtrT pLib, bool dontUnloadAndLoad)
 {
+    if(!pLib->recompilable) {
+        gpMessageHandler->addErrorMessage("Library is not recompilable.");
+        return;
+    }
+
     CoreLibraryAccess coreLibrary;
     auto spGenerator = createDefaultImportGenerator();
 

--- a/HopsanGUI/LibraryHandler.h
+++ b/HopsanGUI/LibraryHandler.h
@@ -55,6 +55,7 @@ class GUIComponentLibrary
 public:
     QString id;
     QString version;
+    bool recompilable;
     QString name;
     QString loadPath;
     QString xmlFilePath;

--- a/HopsanGUI/Widgets/LibraryWidget.cpp
+++ b/HopsanGUI/Widgets/LibraryWidget.cpp
@@ -531,6 +531,10 @@ void LibraryWidget::handleItemClick(QTreeWidgetItem *item, int column)
         else if (pReply == pRecompileAction) {
             gpModelHandler->saveState();
             SharedComponentLibraryPtrT pLib = mItemToLibraryMap[item];
+            if(!pLib->recompilable) {
+                gpMessageHandler->addErrorMessage("Library is not recompilable.");
+                return;
+            }
             bool expanded = getLibraryItem(pLib)->isExpanded();
             // First unload the library
             QString libPath = pLib->xmlFilePath;

--- a/HopsanGenerator/templates/library_template.xml
+++ b/HopsanGenerator/templates/library_template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hopsancomponentlibrary version="0.3">
+<hopsancomponentlibrary version="0.3" recompilable="true">
   <id><<<libid>>></id>
   <name><<<libname>>></name>
   <lib debug_ext="<<<libdebugext>>>"><<<libname>>></lib>


### PR DESCRIPTION
Adds a `recompilable` attribute to the root tag in library XML files. Setting this to `false` prevents users from recompiling the library. Default value is `true`.