### PR TITLE
Image widgets

### DIFF
--- a/HopsanGUI/GUIObjects/GUIContainerObject.h
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.h
@@ -50,6 +50,7 @@ class QGraphicsScene;
 class Port;
 class Widget;
 class TextBoxWidget;
+class ImageWidget;
 class QTableView;
 class QRadioButton;
 
@@ -196,6 +197,8 @@ public:
     //GUIWidgets methods
     TextBoxWidget *addTextBoxWidget(QPointF position, UndoStatusEnumT undoSettings=Undo);
     TextBoxWidget *addTextBoxWidget(QPointF position, int desiredWidgetId, UndoStatusEnumT undoSettings=Undo);
+    ImageWidget *addImageWidget(QPointF position, UndoStatusEnumT undoSettings=Undo);
+    ImageWidget *addImageWidget(QPointF position, int desiredWidgetId, UndoStatusEnumT undoSettings=Undo);
     void deleteWidget(Widget *pWidget, UndoStatusEnumT undoSettings=Undo);
     void deleteWidget(const int id, UndoStatusEnumT undoSettings=Undo);
 

--- a/HopsanGUI/GUIObjects/GUIWidgets.h
+++ b/HopsanGUI/GUIObjects/GUIWidgets.h
@@ -49,8 +49,10 @@
 #include <QCheckBox>
 #include <QDialog>
 #include <QPointer>
+#include <QGraphicsSvgItem>
+#include <QFileInfo>
 
-enum WidgetTypesEnumT {UndefinedWidgetType, TextBoxWidgetType};
+enum WidgetTypesEnumT {UndefinedWidgetType, TextBoxWidgetType, ImageWidgetType};
 
 class Widget : public WorkspaceObject
 {
@@ -155,6 +157,57 @@ private:
     QPointF mPosBeforeResize;
     double mWidthBeforeResize;
     double mHeightBeforeResize;
+};
+
+
+class ImageWidget : public Widget
+{
+    Q_OBJECT
+
+public:
+    ImageWidget(QPointF pos, double rot, SelectionStatusEnumT startSelected, SystemObject *pSystem, size_t widgetIndex, QGraphicsItem *pParent=0);
+    ImageWidget(const ImageWidget &other, SystemObject *pSystem);
+
+    // Type info
+    virtual WidgetTypesEnumT getWidgetType() const;
+    virtual QString getHmfTagName() const;
+
+    // Save and load
+    void saveToDomElement(QDomElement &rDomElement, SaveContentsEnumT contents=FullModel);
+    void loadFromDomElement(QDomElement domElement);
+
+    void setImage(const QString &path, double iconScale = 1.0);
+
+protected:
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event);
+    void hoverMoveEvent(QGraphicsSceneHoverEvent *event);
+    void mousePressEvent(QGraphicsSceneMouseEvent *event);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
+
+    virtual void refreshSelectionBoxSize();
+
+public slots:
+    void deleteMe(UndoStatusEnumT undoSettings=Undo);
+    virtual void flipVertical(UndoStatusEnumT undoSettings = Undo);
+    virtual void flipHorizontal(UndoStatusEnumT undoSettings = Undo);
+
+private slots:
+    void browseForImageFile();
+    void updateWidgetFromDialog();
+
+private:
+    QGraphicsSvgItem *mpImage = nullptr;
+    QString mImagePath;
+    QString mDefaultImage = QString(GRAPHICSPATH) + "hopsan-logo.svg";
+
+    QPointer<QDialog> mpEditDialog;
+    QLabel *mpEditDialogPathLabel;
+    QLineEdit *mpEditDialogPathLineEdit;
+    QToolButton *mpEditDialogBrowseButton;
+    QLabel *mpEditDialogScaleLabel;
+    QDoubleSpinBox *mpEditDialogScaleSpinBox;
+    void refreshWidgetSize();
 };
 
 #endif // GUIWIDGETS_H

--- a/HopsanGUI/GraphicsView.cpp
+++ b/HopsanGUI/GraphicsView.cpp
@@ -126,6 +126,8 @@ void GraphicsView::contextMenuEvent ( QContextMenuEvent * event )
             QMenu menu(this);
             QAction *addTextBoxAction = menu.addAction("Add Text Box Widget");
             addTextBoxAction->setDisabled(mpParentModelWidget->isEditingLimited() || mpContainerObject->isLocallyLocked());
+            QAction *addImageWidgetAction = menu.addAction("Add Image Widget");
+            addImageWidgetAction->setDisabled(mpParentModelWidget->isEditingLimited() || mpContainerObject->isLocallyLocked());
 
             QCursor cursor;
             QAction *selectedAction = menu.exec(cursor.pos());
@@ -134,6 +136,10 @@ void GraphicsView::contextMenuEvent ( QContextMenuEvent * event )
             {
                 mpContainerObject->getUndoStackPtr()->newPost();
                 mpContainerObject->addTextBoxWidget(this->mapToScene(event->pos()).toPoint());
+            }
+            else if(selectedAction == addImageWidgetAction) {
+                mpContainerObject->getUndoStackPtr()->newPost();
+                mpContainerObject->addImageWidget(this->mapToScene(event->pos()).toPoint());
             }
         }
     }

--- a/HopsanGUI/UndoStack.h
+++ b/HopsanGUI/UndoStack.h
@@ -79,6 +79,9 @@
 #define UNDO_MOVEDCONNECTOR "movedconnector"
 #define UNDO_CHANGEDPARAMETER "changedparameter"
 #define UNDO_ADDEDTEXTBOXWIDGET "addedtextboxwidget"
+#define UNDO_ADDEDIMAGEWIDGET "addedimagewidget"
+#define UNDO_DELETEDIMAGEWIDGET "deletedimagewidget"
+#define UNDO_MODIFIEDIMAGEWIDGET "modifiedimagewidget"
 #define UNDO_DELETEDTEXTBOXWIDGET "deletedtextboxwidget"
 #define UNDO_RESIZEDTEXTBOXWIDGET "resizedtextboxwidget"
 #define UNDO_MODIFIEDTEXTBOXWIDGET "modifiedtextboxwidget"
@@ -128,7 +131,7 @@ public:
     void registerDeletedWidget(Widget *item);
     void registerMovedWidget(Widget *item, QPointF oldPos, QPointF newPos);
     void registerResizedTextBoxWidget(const int index, const double w_old, const double h_old, const double w_new, const double h_new, const QPointF oldPos, const QPointF newPos);
-    void registerModifiedTextBoxWidget(Widget *pItem);
+    void registerModifiedWidget(Widget *pItem);
 
 private:
     SystemObject *mpParentSystemObject;
@@ -138,6 +141,10 @@ private:
     void addTextboxwidget(const QDomElement &rStuffElement);
     void removeTextboxWidget(const QDomElement &rStuffElement);
     void modifyTextboxWidget(QDomElement &rStuffElement);
+
+    void addImageWidget(const QDomElement &rStuffElement);
+    void removeImageWidget(const QDomElement &rStuffElement);
+    void modifyImageWidget(QDomElement &rStuffElement);
 
     QDomElement getCurrentPost();
     QDomDocument mDomDocument;

--- a/HopsanGUI/Utilities/XMLUtilities.h
+++ b/HopsanGUI/Utilities/XMLUtilities.h
@@ -243,6 +243,16 @@ void readFromSsv(const QString filePath, QList<SsvParameter> &rParameters);
 #define HMF_AVERAGE "average"
 #define HMF_SIGMA "sigma"
 
+namespace hmf {
+    constexpr auto imagewidget="imagewidget";
+    constexpr auto x="x";
+    constexpr auto y="y";
+    constexpr auto image="image";
+    constexpr auto path="path";
+    constexpr auto scale="scale";
+    constexpr auto index="index";
+}
+
 #define XML_LIBS "libs"
 #define XML_USERLIB "userlib"
 #define XML_LIBTYPE "libtype"

--- a/HopsanGUI/Widgets/UndoWidget.cpp
+++ b/HopsanGUI/Widgets/UndoWidget.cpp
@@ -250,6 +250,9 @@ QString UndoWidget::translateTag(QString tag)
     tagMap.insert(UNDO_MOVEDCONNECTOR,          "Moved Connector");
     tagMap.insert(UNDO_CHANGEDPARAMETER,        "Changed Parameter");
     tagMap.insert(UNDO_ADDEDTEXTBOXWIDGET,      "Added Text Box Widget");
+    tagMap.insert(UNDO_ADDEDIMAGEWIDGET,        "Added Image Widget");
+    tagMap.insert(UNDO_DELETEDIMAGEWIDGET,      "Deleted Image Widget");
+    tagMap.insert(UNDO_MODIFIEDIMAGEWIDGET,     "Modified Image Widget");
     tagMap.insert(UNDO_DELETEDTEXTBOXWIDGET,    "Deleted Text Box Widget");
     tagMap.insert(UNDO_RESIZEDTEXTBOXWIDGET,    "Resized Text Box Widget");
     tagMap.insert(UNDO_MODIFIEDTEXTBOXWIDGET,   "Modified Text Box Widget");

--- a/HopsanGUI/loadFunctions.cpp
+++ b/HopsanGUI/loadFunctions.cpp
@@ -599,3 +599,18 @@ TextBoxWidget *loadTextBoxWidget(QDomElement &rDomElement, SystemObject *pContai
 
     return pWidget;
 }
+
+ImageWidget *loadImageWidget(QDomElement &rDomElement, SystemObject *pContainer, UndoStatusEnumT undoSettings)
+{
+    ImageWidget *pWidget = pContainer->addImageWidget(QPointF(1,1), NoUndo);
+    pWidget->loadFromDomElement(rDomElement);
+
+    if(undoSettings == Undo) {
+        pContainer->getUndoStackPtr()->registerAddedWidget(pWidget);
+    }
+
+    pWidget->setSelected(true);     //!< @todo Stupid!
+    pWidget->setSelected(false);    //For some reason this is needed...
+
+    return pWidget;
+}

--- a/HopsanGUI/loadFunctions.h
+++ b/HopsanGUI/loadFunctions.h
@@ -43,6 +43,7 @@ class LibraryWidget;
 class ModelObject;
 class SystemObject;
 class TextBoxWidget;
+class ImageWidget;
 
 
 ModelObject* loadModelObject(const QDomElement &domElement, SystemObject* pSystem, UndoStatusEnumT undoSettings=Undo);
@@ -60,5 +61,7 @@ void loadSystemParameter(QDomElement &rDomElement, bool doAdd, const QString hmf
 void loadPlotAlias(QDomElement &rDomElement, SystemObject* pContainer);
 
 TextBoxWidget* loadTextBoxWidget(QDomElement &rDomElement, SystemObject *pContainer, UndoStatusEnumT undoSettings=Undo);
+
+ImageWidget* loadImageWidget(QDomElement &rDomElement, SystemObject *pContainer, UndoStatusEnumT undoSettings=Undo);
 
 #endif // LOADFUNCTIONS_H


### PR DESCRIPTION
New image widget class that can be added to workspace, similar to text box widgets.

You can choose an SVG file and a scale factor. A default image is used if no file is selected. Full support for undo/redo, copy/paste and saving/loading.