### PR TITLE
Timestep parameter in exported FMUs

### DIFF
--- a/HopsanGenerator/src/generators/HopsanFMIGenerator.cpp
+++ b/HopsanGenerator/src/generators/HopsanFMIGenerator.cpp
@@ -263,7 +263,7 @@ bool HopsanFMIGenerator::generateToFmu(QString savePath, ComponentSystem *pSyste
 
     dataStr.append("\n#define NUMDATAPTRS "+QString::number(vars.size()+pars.size()));
     dataStr.append("\n#define INITDATAPTRS ");
-    int vr = 0;
+    int vr = 1; //Value reference 0 reserved for timestep
     for(const auto &var : vars) {
         dataStr.append("\\\nfmu->dataPtrs["+QString::number(vr)+"] = fmu->pSystem");
         for(const auto &system : var.systemHierarchy) {
@@ -529,7 +529,19 @@ bool HopsanFMIGenerator::generateModelDescriptionXmlFile(ComponentSystem *pSyste
         QStringList systemHierarchy = QStringList();
         getModelVariables(pSystem, vars, systemHierarchy);
 
-        long vr = 0;
+        mdWriter.writeStartElement("ScalarVariable");
+        mdWriter.writeAttribute("name", "timestep");
+        mdWriter.writeAttribute("valueReference", "0");
+        mdWriter.writeAttribute("causality", "input");
+        mdWriter.writeAttribute("variability", "parameter");
+        mdWriter.writeAttribute("description", "Hopsan time step");
+        mdWriter.writeStartElement("Real");
+        mdWriter.writeAttribute("start", QString::number(pSystem->getDesiredTimeStep()));
+        mdWriter.writeAttribute("unit", "s");
+        mdWriter.writeEndElement(); //Real
+        mdWriter.writeEndElement(); //ScalarVariable
+
+        long vr = 1;    //vr=0 reserved for timestep
         for(const auto &var : vars) {
             mdWriter.writeStartElement("ScalarVariable");
             mdWriter.writeAttribute("name", var.getName());
@@ -611,7 +623,19 @@ bool HopsanFMIGenerator::generateModelDescriptionXmlFile(ComponentSystem *pSyste
         QStringList systemHierarchy = QStringList();
         getModelVariables(pSystem, vars, systemHierarchy);
 
-        long vr = 0;
+        mdWriter.writeStartElement("ScalarVariable");
+        mdWriter.writeAttribute("name", "timestep");
+        mdWriter.writeAttribute("valueReference", "0");
+        mdWriter.writeAttribute("causality", "parameter");
+        mdWriter.writeAttribute("variability", "fixed");
+        mdWriter.writeAttribute("description", "Hopsan time step");
+        mdWriter.writeStartElement("Real");
+        mdWriter.writeAttribute("start", QString::number(pSystem->getDesiredTimeStep()));
+        mdWriter.writeAttribute("unit", "s");
+        mdWriter.writeEndElement(); //Real
+        mdWriter.writeEndElement(); //ScalarVariable
+
+        long vr = 1;    //vr = 0 reserved for timestep
         for(const auto &var : vars) {
             mdWriter.writeStartElement("ScalarVariable");
             mdWriter.writeAttribute("name", var.getName());
@@ -692,10 +716,20 @@ bool HopsanFMIGenerator::generateModelDescriptionXmlFile(ComponentSystem *pSyste
         QStringList systemHierarchy = QStringList();
         getModelVariables(pSystem, vars, systemHierarchy);
 
+        mdWriter.writeStartElement("Float64");
+        mdWriter.writeAttribute("name", "timestep");
+        mdWriter.writeAttribute("valueReference", "0");
+        mdWriter.writeAttribute("causality", "parameter");
+        mdWriter.writeAttribute("variability", "fixed");
+        mdWriter.writeAttribute("description", "Hopsan time step");
+        mdWriter.writeAttribute("start", QString::number(pSystem->getDesiredTimeStep()));
+        mdWriter.writeAttribute("unit", "s");
+        mdWriter.writeEndElement(); //Float64
+
         nReals=0;
         nInputs=0;
         nOutputs=0;
-        long vr = 0;
+        long vr = 1;    //! vr = 0 is reserved for timestep
         for(const auto &var : vars) {
             mdWriter.writeStartElement("Float64");
             if(var.systemHierarchy.isEmpty()) {

--- a/HopsanGenerator/templates/fmu1_model.c
+++ b/HopsanGenerator/templates/fmu1_model.c
@@ -211,6 +211,8 @@ fmiStatus fmiInitializeSlave(fmiComponent c,
     get_all_hopsan_messages(fmu);
 
     state = Initialized;
+
+    return fmiOK;
 }
 
 void fmiFreeSlaveInstance(fmiComponent c)

--- a/UnitTests/GeneratorTest/tst_generatortest.cpp
+++ b/UnitTests/GeneratorTest/tst_generatortest.cpp
@@ -269,13 +269,22 @@ private slots:
 
         args << "-s" << testStopTime;
         args << "-l" << "2";
-        args << "-o" << "log.txt";
+        args << "-e" << "log.txt";
+        args << "-o" << "results.txt";
         args << qcwd+"/fmu1 32/unittestmodel_export.fmu";
         p.start(fmuChecker32, args);
         p.waitForFinished();
 
         QVERIFY2(p.exitStatus() == QProcess::NormalExit,
                  "Failed to generate valid FMU 1.0 (32-bit), FMUChecker crashed");
+        if(p.exitCode() != 0) {
+            QFile f("log.txt");
+
+            if(f.open(QFile::ReadOnly | QFile::Text)) {
+                QTextStream in(&f);
+                std::cout << in.readAll().toStdString().c_str() << "\n";
+            }
+        }
         QVERIFY2(p.exitCode() == 0,
                  "Failed to generate valid FMU 1.0 (32-bit), FMU not accepted by FMUChecker.");
 
@@ -293,13 +302,22 @@ private slots:
         args.clear();
         args << "-s" << testStopTime;
         args << "-l" << "2";
-        args << "-o" << "log.txt";
+        args << "-e" << "log.txt";
+        args << "-o" << "results.txt";
         args << qcwd+"/fmu2 32/unittestmodel_export.fmu";
         p.start(fmuChecker32, args);
         p.waitForFinished();
 
         QVERIFY2(p.exitStatus() == QProcess::NormalExit,
                  "Failed to generate valid FMU 2.0 (32-bit), FMUChecker crashed");
+        if(p.exitCode() != 0) {
+            QFile f("log.txt");
+
+            if(f.open(QFile::ReadOnly | QFile::Text)) {
+                QTextStream in(&f);
+                std::cout << in.readAll().toStdString().c_str() << "\n";
+            }
+        }
         QVERIFY2(p.exitCode() == 0,
                  "Failed to generate valid FMU 2.0 (32-bit), FMU not accepted by FMUChecker.");
 #endif
@@ -318,13 +336,22 @@ private slots:
         args.clear();
         args << "-s" << testStopTime;
         args << "-l" << "2";
-        args << "-o" << "log.txt";
+        args << "-e" << "log.txt";
+        args << "-o" << "results.txt";
         args << qcwd+"/fmu1 64/unittestmodel_export.fmu";
         p.start(fmuChecker64, args);
         p.waitForFinished();
 
         QVERIFY2(p.exitStatus() == QProcess::NormalExit,
                  "Failed to generate valid FMU 1.0 (64-bit), FMUChecker crashed");
+        if(p.exitCode() != 0) {
+            QFile f("log.txt");
+
+            if(f.open(QFile::ReadOnly | QFile::Text)) {
+                QTextStream in(&f);
+                std::cout << in.readAll().toStdString().c_str() << "\n";
+            }
+        }
         QVERIFY2(p.exitCode() == 0,
                  "Failed to generate valid FMU 1.0 (64-bit), FMU not accepted by FMUChecker.");
 
@@ -340,13 +367,22 @@ private slots:
         args.clear();
         args << "-s" << testStopTime;
         args << "-l" << "2";
-        args << "-o" << "log.txt";
+        args << "-e" << "log.txt";
+        args << "-o" << "results.txt";
         args << qcwd+"/fmu2 64/unittestmodel_export.fmu";
         p.start(fmuChecker64, args);
         p.waitForFinished();
 
         QVERIFY2(p.exitStatus() == QProcess::NormalExit,
                  "Failed to generate valid FMU 2.0 (64-bit), FMUChecker crashed");
+        if(p.exitCode() != 0) {
+            QFile f("log.txt");
+
+            if(f.open(QFile::ReadOnly | QFile::Text)) {
+                QTextStream in(&f);
+                std::cout << in.readAll().toStdString().c_str() << "\n";
+            }
+        }
         QVERIFY2(p.exitCode() == 0,
                  "Failed to generate valid FMU 2.0 (64-bit), FMU not accepted by FMUChecker.");
 #endif

--- a/componentLibraries/defaultLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/defaultLibrary/Connectivity/FMIWrapper.hpp
@@ -527,10 +527,9 @@ public:
 
     
             //Instantiate FMU
-            fmi2_instantiate(fmu, fmi2CoSimulation, FMIWrapper_fmi2Logger, calloc, free, NULL, (fmi2ComponentEnvironment*)this, fmi2False, mLoggingOn);
-                 
-            if(NULL == fmu) {
+            if(!fmi2_instantiate(fmu, fmi2CoSimulation, FMIWrapper_fmi2Logger, calloc, free, NULL, (fmi2ComponentEnvironment*)this, fmi2False, mLoggingOn)) {
                 stopSimulation("Failed to instantiate FMU");
+                fmu = NULL;
                 return;
             }
     
@@ -780,10 +779,9 @@ public:
 
             //Instantiate FMU
             size_t nRequiredIntermediateVariables = 0;
-            fmi3_instantiateCoSimulation(fmu, fmi3False, mLoggingOn, fmi3False, fmi3False, NULL, nRequiredIntermediateVariables, this, FMIWrapper_fmi3Logger, FMIWrapper_fmi3IntermediateUpdate);
-    
-            if (NULL == fmu) {
+            if(!fmi3_instantiateCoSimulation(fmu, fmi3False, mLoggingOn, fmi3False, fmi3False, NULL, nRequiredIntermediateVariables, this, FMIWrapper_fmi3Logger, FMIWrapper_fmi3IntermediateUpdate)) {
                 stopSimulation("Failed to instantiate FMU");
+                fmu = NULL;
                 return;
             }
     


### PR DESCRIPTION
This allows the importing tool to control the internal timestep used in the Hopsan model inside the FMU. Default value is the timestep used by the Hopsan model that was exported (which used to be the hard-coded value).

Also fixes some bugs in the export to FMI3.