### PR TITLE
Automatically rename FMIWrappers to FMU base file name

### DIFF
--- a/HopsanGUI/GUIObjects/GUIComponent.cpp
+++ b/HopsanGUI/GUIObjects/GUIComponent.cpp
@@ -204,6 +204,8 @@ bool Component::setParameterValue(QString name, QString value, bool force)
         //Adjust icon scale
         this->getAppearanceData()->setIconScale(qMax(qMax(inputs.size(),outputs.size())/3.0,1.0), UserGraphics);
 
+        mpParentSystemObject->renameModelObject(this->getName(), QFileInfo(getParameterValue("path")).baseName());
+
         //Refresh appearance
         this->refreshAppearance();
 


### PR DESCRIPTION
When setting the FMU path, the FMIWrapper is automatically renamed to the base file name (without extension) of the file.

This can later be improved to use the model name specified in the FMU modelDescription, but fmi4c does not yet provide access to this information for FMI 1 and 2.