### PR TITLE
Store loaded subtypename in HopsanCore components

### DIFF
--- a/HopsanGUI/CoreAccess.cpp
+++ b/HopsanGUI/CoreAccess.cpp
@@ -699,7 +699,7 @@ void CoreSystemAccess::finalize()
     mpCoreComponentSystem->finalize();
 }
 
-QString CoreSystemAccess::createComponent(QString type, QString name)
+QString CoreSystemAccess::createComponent(QString type, QString name, QString subType)
 {
     //qDebug() << "createComponent: " << "type: " << type << " desired name:  " << name << " in system: " << this->getRootSystemName();
     hopsan::Component *pCoreComponent = gHopsanCore.createComponent(type.toStdString().c_str());
@@ -710,6 +710,7 @@ QString CoreSystemAccess::createComponent(QString type, QString name)
         {
             pCoreComponent->setName(name.toStdString().c_str());
         }
+        pCoreComponent->setSubTypeName(subType.toStdString().c_str());
         //qDebug() << "createComponent: name after add: " << QString::fromStdString(pCoreComponent->getName()) << " added to: " << QString::fromStdString(mpCoreComponentSystem->getName());
         return pCoreComponent->getName().c_str();
     }

--- a/HopsanGUI/CoreAccess.h
+++ b/HopsanGUI/CoreAccess.h
@@ -228,7 +228,7 @@ public:
     QStringList getPortNames(const QString &componentName);
 
     // Component creation and removal
-    QString createComponent(QString type, QString name="");
+    QString createComponent(QString type, QString name="", QString subType="");
     QString createSubSystem(QString name="");
     QString createConditionalSubSystem(QString name="");
     void removeSubComponent(QString componentName, bool doDelete);

--- a/HopsanGUI/GUIObjects/GUIComponent.cpp
+++ b/HopsanGUI/GUIObjects/GUIComponent.cpp
@@ -56,7 +56,7 @@ Component::Component(QPointF position, double rotation, ModelObjectAppearance* p
     : ModelObject(position, rotation, pAppearanceData, startSelected, gfxType, pParentSystem, pParentSystem)
 {
     // Create the object in core, and get its default core name
-    mName = mpParentSystemObject->getCoreSystemAccessPtr()->createComponent(mModelObjectAppearance.getTypeName(), mModelObjectAppearance.getDisplayName());
+    mName = mpParentSystemObject->getCoreSystemAccessPtr()->createComponent(mModelObjectAppearance.getTypeName(), mModelObjectAppearance.getDisplayName(), mModelObjectAppearance.getSubTypeName());
     refreshDisplayName(); //Make sure name window is correct size for center positioning
 
     // Sets the ports


### PR DESCRIPTION
Components in HopsanCore has a member variable for subtypename with get and set functions, but the value is only set if loading the library from HopsanCore. It should be set also when loading from HopsanGUI.