### PR TITLE
Finalize components after measureing time

### DIFF
--- a/HopsanCore/src/ComponentSystem.cpp
+++ b/HopsanCore/src/ComponentSystem.cpp
@@ -2427,6 +2427,7 @@ void ComponentSystem::simulateMultiThreaded(const double startT, const double st
 
             // Re-initialize the system to reset values and timers
             //! @note This only work for top level systems where the simulateMultiThreaded will not be called more than once
+            this->finalize(); //Always run finalize before initialize
             this->initialize(startT, stopT);
         }
         else


### PR DESCRIPTION
Before multithreaded simualtion, components are simulated a few steps to measure time. After this they are initialized a second time. However, the also need to be finalized in between, in order to avoid components appearing in the wrong state (especially FMUs).

In other words, it should be:
initialize - simulate - finalize - initialize - simulate - finalize

Not:
initialize - simulate - initialize - simulate - finalize