### PR TITLE
Fix crash when using non-existing variables in FMI port specifications

### DIFF
--- a/componentLibraries/defaultLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/defaultLibrary/Connectivity/FMIWrapper.hpp
@@ -1270,7 +1270,6 @@ public:
             if(NULL == fmu) {
                 return;
             }
-            fmi1_terminateSlave(fmu);
             fmi1_freeSlaveInstance(fmu);
             fmi4c_freeFmu(fmu);
             fmu = NULL;
@@ -1279,7 +1278,6 @@ public:
             if(NULL == fmu) {
                 return;
             }
-            fmi2_terminate(fmu);
             fmi2_freeInstance(fmu);
             fmi4c_freeFmu(fmu);
             fmu = NULL;
@@ -1288,7 +1286,6 @@ public:
             if(NULL == fmu) {
                 return;
             }
-            fmi3_terminate(fmu);
             fmi3_freeInstance(fmu);
             fmi4c_freeFmu(fmu);
             fmu = NULL;

--- a/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.hpp
+++ b/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.hpp
@@ -863,7 +863,12 @@ public:
                 fmi2ValueReference vr;
                 Node *pNode = mPorts[i]->getNodePtr();
                 for(size_t j=0; j<specs.size()-1; ++j) {
-                    vr = (fmi2ValueReference)fmi2_getVariableValueReference(fmi2_getVariableByName(fmu, specs[j+1].c_str()));
+                    fmi1VariableHandle *var = fmi1_getVariableByName(fmu, specs[j+1].c_str());
+                    if(nullptr == var) {
+                        stopSimulation("Did not find variable named \""+specs[j+1]+", check your port specifications.");
+                        return;
+                    }
+                    vr = (fmi1ValueReference)fmi1_getVariableValueReference(var);
                     if(pNode->getDataDescription(j)->varType == TLMType) {
                         mRealInputs[vr] = getSafeNodeDataPtr(pPort, (int)j);
                     }
@@ -936,7 +941,12 @@ public:
                 fmi2ValueReference vr;
                 Node *pNode = mPorts[i]->getNodePtr();
                 for(size_t j=0; j<specs.size()-1; ++j) {
-                    vr = (fmi2ValueReference)fmi2_getVariableValueReference(fmi2_getVariableByName(fmu, specs[j+1].c_str()));
+                    fmi2VariableHandle *var = fmi2_getVariableByName(fmu, specs[j+1].c_str());
+                    if(nullptr == var) {
+                        stopSimulation("Did not find variable named \""+specs[j+1]+", check your port specifications.");
+                        return;
+                    }
+                    vr = (fmi2ValueReference)fmi2_getVariableValueReference(var);
                     if(pNode->getDataDescription(j)->varType == TLMType) {
                         mRealInputs[vr] = getSafeNodeDataPtr(pPort, (int)j);
                     }
@@ -1021,7 +1031,12 @@ public:
                 fmi2ValueReference vr;
                 Node *pNode = mPorts[i]->getNodePtr();
                 for(size_t j=0; j<specs.size()-1; ++j) {
-                    vr = (fmi2ValueReference)fmi2_getVariableValueReference(fmi2_getVariableByName(fmu, specs[j+1].c_str()));
+                    fmi3VariableHandle *var = fmi3_getVariableByName(fmu, specs[j+1].c_str());
+                    if(nullptr == var) {
+                        stopSimulation("Did not find variable named \""+specs[j+1]+", check your port specifications.");
+                        return;
+                    }
+                    vr = (fmi3ValueReference)fmi3_getVariableValueReference(var);
                     if(pNode->getDataDescription(j)->varType == TLMType) {
                         mFloat64Inputs[vr] = getSafeNodeDataPtr(pPort, (int)j);
                     }

--- a/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.hpp
+++ b/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.hpp
@@ -1398,7 +1398,6 @@ public:
             if(NULL == fmu) {
                 return;
             }
-            fmi1_terminateSlave(fmu);
             fmi1_freeSlaveInstance(fmu);
             fmi4c_freeFmu(fmu);
             fmu = NULL;
@@ -1407,7 +1406,6 @@ public:
             if(NULL == fmu) {
                 return;
             }
-            fmi2_terminate(fmu);
             fmi2_freeInstance(fmu);
             fmi4c_freeFmu(fmu);
             fmu = NULL;
@@ -1416,7 +1414,6 @@ public:
             if(NULL == fmu) {
                 return;
             }
-            fmi3_terminate(fmu);
             fmi3_freeInstance(fmu);
             fmi4c_freeFmu(fmu);
             fmu = NULL;


### PR DESCRIPTION
Check that each variable in power port specifications actually exist in the FMU, else stop simulation at initialize.

Also removes some illegal function calls to better respect the FMU state machines.