### PR TITLE
Control logging of data during simulation from HCOM

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -4133,6 +4133,14 @@ void HcomHandler::executeSetCommand(const QString cmd)
         }
         getConfigPtr()->setIntegerSetting(cfg::progressbarstep, mAnsScalar);
     }
+    else if(pref == "logduringsimulation")
+    {
+        if(value != "on" && value != "off")
+        {
+            HCOMERR("Unknown value.");
+        }
+        getConfigPtr()->setBoolSetting(cfg::logduringsimulation, value=="on");
+    }
     else
     {
         HCOMERR("Unknown command.");
@@ -4265,6 +4273,15 @@ void HcomHandler::executeGetCommand(const QString cmd)
     {
         QString output = "Progress bar step size:    ";
         output.append(QString::number(getConfigPtr()->getIntegerSetting(cfg::progressbarstep))+"");
+        HCOMPRINT(output);
+    }
+    if(all || pref == "logduringsimulation")
+    {
+        QString output = "Collect log data during simulation:               ";
+        if(getConfigPtr()->getBoolSetting(cfg::logduringsimulation))
+            output.append("ON");
+        else
+            output.append("OFF");
         HCOMPRINT(output);
     }
 }


### PR DESCRIPTION
Enables controlling the _collect log data during simualtion_ from HCOM:
```
> set logduringsimulation on
> get logduringsimulation
> Collect log data during simulation:               ON
> set logduringsimulation off
> get logduringsimulation
> Collect log data during simulation:               OFF
```