### PR TITLE
Fix FMI exports for models without HMF extension

### DIFF
--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -3388,7 +3388,7 @@ void SystemObject::exportToFMU(QString savePath, int version, ArchitectureEnumT 
     }
 
     //Save model to hmf in export directory
-    mpModelWidget->saveTo(savePath+"/"+mModelFileInfo.fileName().replace(" ", "_"));
+    mpModelWidget->saveTo(savePath+"/"+mModelFileInfo.completeBaseName().replace(" ", "_")+".hmf");
 
     auto spGenerator = createDefaultExportGenerator();
     spGenerator->setCompilerPath(gpConfig->getCompilerPath(arch));


### PR DESCRIPTION
If model file does not end with ".hmf" it should still be possible to export it to FMI.