### PR TITLE
Remove local variables with same name when adding system parameters

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -2111,6 +2111,9 @@ void HcomHandler::executeAddParameterCommand(const QString cmd)
         }
         CoreParameterData paramData(args[0], args[1], type);
         pContainer->setOrAddParameter(paramData);
+
+        //Make sure to remove local variables with same name
+        mLocalVars.remove(args[0]);
     }
 }
 


### PR DESCRIPTION
If they are not removed, the following problem will occur:
```
>> y=3
Assigning scalar y with 3
>> adpa y 4
>> y
3
```
The value in the system parameters widget, however, was actually 4.