### PR TITLE
Use same scene rect for animation as for modelling view

### DIFF
--- a/HopsanGUI/GraphicsView.cpp
+++ b/HopsanGUI/GraphicsView.cpp
@@ -985,7 +985,7 @@ AnimatedGraphicsView::AnimatedGraphicsView(QGraphicsScene *pScene, QWidget *pPar
     this->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
     this->setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
     this->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-    this->setSceneRect(0,0,5000,5000);
+    this->setSceneRect(-25000+2500,-25000+2500,50000,50000);
     this->centerOn(this->sceneRect().center());
 
     mIsoColor = QColor("white");


### PR DESCRIPTION
Animation mode needs to use same scene rect as the regular model, otherwise components may move outside of the visible view when pressing animation button.

- [x] Make sure it works with new models
- [x] Make sure it works with existing models