### PR TITLE
Keep custom FMIWrapper name when loading model

### DIFF
--- a/HopsanGUI/loadFunctions.cpp
+++ b/HopsanGUI/loadFunctions.cpp
@@ -401,7 +401,13 @@ ModelObject* loadModelObject(const QDomElement &domElement, SystemObject* pSyste
             QDomElement xmlParameter = xmlParameters.firstChildElement(hmf::parameter::root);
             while (!xmlParameter.isNull())
             {
+                QString tempName = pObj->getName();
+
                 loadParameterValue(xmlParameter, pObj, NoUndo);
+
+                //Some components might change name depending on a parameter (e.g. FMIWrapper), make sure to change it back if it was changed.
+                pSystem->renameModelObject(pObj->getName(), tempName, NoUndo);
+
                 xmlParameter = xmlParameter.nextSiblingElement(hmf::parameter::root);
             }
 


### PR DESCRIPTION
FMIWrapper components change their name depending on the FMU name. When loading the component however, the name stored in the HMF should be used.