### PR TITLE
Add unit definitions, model structure and time variable to exported FMUs

### DIFF
--- a/HopsanGenerator/include/GeneratorTypes.h
+++ b/HopsanGenerator/include/GeneratorTypes.h
@@ -298,7 +298,7 @@ enum ModelVariableCausality {Input, Output};
 class ModelVariableSpecification
 {
 public:
-    ModelVariableSpecification(QStringList systemHierarchy, QString componentName, QString portName, QString dataName, int dataId, double startValue, ModelVariableCausality causality);
+    ModelVariableSpecification(QStringList systemHierarchy, QString componentName, QString portName, QString dataName, int dataId, double startValue, ModelVariableCausality causality, QString unit);
     QString getName() const;
     QString getCausalityStr() const;
     QStringList systemHierarchy;
@@ -308,6 +308,7 @@ public:
     int dataId;
     double startValue;
     ModelVariableCausality causality;
+    QString unit;
 };
 
 void getInterfaces(QList<InterfacePortSpec> &interfaces, hopsan::ComponentSystem *pSystem, QStringList &path);

--- a/HopsanGenerator/src/GeneratorTypes.cpp
+++ b/HopsanGenerator/src/GeneratorTypes.cpp
@@ -785,7 +785,7 @@ void getModelVariables(hopsan::ComponentSystem *pSystem, QList<ModelVariableSpec
                     causality = ModelVariableCausality::Input;
                 }
             }
-            vars.append(ModelVariableSpecification(systemHierarchy, names[i].c_str(), portName, node.shortname.c_str(), node.id, pPort->getStartValue(node.id), causality));
+            vars.append(ModelVariableSpecification(systemHierarchy, names[i].c_str(), portName, node.shortname.c_str(), node.id, pPort->getStartValue(node.id), causality, QString(node.unit.c_str())));
         }
     }
 }
@@ -890,7 +890,7 @@ void getParameters(QList<ParameterSpecification> &parameters, hopsan::ComponentS
     }
 }
 
-ModelVariableSpecification::ModelVariableSpecification(QStringList systemHierarchy, QString componentName, QString portName, QString dataName, int dataId, double startValue, ModelVariableCausality causality)
+ModelVariableSpecification::ModelVariableSpecification(QStringList systemHierarchy, QString componentName, QString portName, QString dataName, int dataId, double startValue, ModelVariableCausality causality, QString unit)
 {
     this->systemHierarchy = systemHierarchy;
     this->componentName = componentName;
@@ -899,6 +899,7 @@ ModelVariableSpecification::ModelVariableSpecification(QStringList systemHierarc
     this->dataId = dataId;
     this->startValue = startValue;
     this->causality = causality;
+    this->unit = unit;
 }
 
 QString ModelVariableSpecification::getName() const


### PR DESCRIPTION
Some fixes to ensure compliance with the FMI standard:
- include model structure in XML
- include definitions of all units
- include independent variable (time) in FMI 3 export