### PR TITLE
Reload FMU option in right-click menu

### DIFF
--- a/HopsanGUI/GUIConnector.h
+++ b/HopsanGUI/GUIConnector.h
@@ -74,7 +74,7 @@ public:
     void setStartPort(Port *pPort);
     void setEndPort(Port *pPort);
 
-    void finishCreation();
+    void finishCreation(bool doCorrectGeometries=true);
 
     void addPoint(QPointF point);
     void removePoint(bool deleteIfEmpty = false);

--- a/HopsanGUI/GUIObjects/GUIModelObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIModelObject.cpp
@@ -1331,6 +1331,11 @@ QAction *ModelObject::buildBaseContextMenu(QMenu &rMenu, QGraphicsSceneContextMe
     bool allowLimitedEditing = (!isLocallyLocked() && (getModelLockLevel() <= LimitedLock));
     rMenu.addSeparator();
 
+    QAction *pReloadAction=0;
+    if(getTypeName() == "FMIWrapper" || getTypeName() == "FMIWrapperQ") {
+        pReloadAction = rMenu.addAction(tr("Reload FMU"));
+        pReloadAction->setEnabled(!getParameterValue("path").isEmpty());
+    }
     QAction *pRotateRightAction=0, *pRotateLeftAction=0, *pFlipVerticalAction=0, *pFlipHorizontalAction=0;
     QAction *pLockedAction=0;
     QAction *pDisabledAction=0;
@@ -1445,6 +1450,23 @@ QAction *ModelObject::buildBaseContextMenu(QMenu &rMenu, QGraphicsSceneContextMe
       for(ModelObject *pObj : mpParentSystemObject->getSelectedModelObjectPtrs()) {
           pObj->setDisabled(pDisabledAction->isChecked());
       }
+    }
+    else if(selectedAction == pReloadAction) {
+        QMap<QString, QString> parametersBeforeReconfigure;
+        QStringList parameterNames = getParameterNames();
+        for(const auto &par : qAsConst(parameterNames)) {
+            if(par == "path") {
+                continue;
+            }
+            parametersBeforeReconfigure.insert(par, getParameterValue(par));
+        }
+        setParameterValue("path", getParameterValue("path")); //Reload FMU by "changing" the path variable to the existing value
+        QMapIterator<QString,QString> it(parametersBeforeReconfigure);
+        while(it.hasNext())
+        {
+            it.next();
+            setParameterValue(it.key(), it.value());
+        }
     }
     else
     {

--- a/componentLibraries/defaultLibrary/Connectivity/FMIWrapper.hpp
+++ b/componentLibraries/defaultLibrary/Connectivity/FMIWrapper.hpp
@@ -242,9 +242,6 @@ public:
 
     void reconfigure()
     {
-        if(mFmuPath == mLastFmuPath) {
-            return; //Path did not change, do nothing
-        }
         mLastFmuPath = mFmuPath;
 
         deconfigure(); //Make sure to unload FMU and free memory before loading a new one

--- a/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.hpp
+++ b/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.hpp
@@ -245,9 +245,6 @@ public:
 
     void reconfigure()
     {
-        if((mFmuPath == mLastFmuPath) && (mPortSpecs == mLastPortSpecs)) {
-            return; //Path did not change, do nothing
-        }
         mLastFmuPath = mFmuPath;
         mLastPortSpecs = mPortSpecs;
 


### PR DESCRIPTION
Option to reload FMU by right-clicking on it. All parameter values and port specifications are preserved. Connections are automatically reconnected. Resolves #2245.