### PR TITLE
Support port names in FMIWrapperQ

### DIFF
--- a/HopsanGUI/GUIObjects/GUIComponent.cpp
+++ b/HopsanGUI/GUIObjects/GUIComponent.cpp
@@ -195,7 +195,13 @@ bool Component::setParameterValue(QString name, QString value, bool force)
                 app->x = double(1+i)/double(1+portSpecs.size());
                 app->rot = 270;
                 app->mEnabled = true;
-                QString portName = "P"+QString::number(i+1);
+                QString portName;
+                if(portSpecs[i].contains(':')) {
+                    portName = portSpecs[i].split(',').at(0).split(':').at(1);
+                }
+                else {
+                    portName = "P"+QString::number(i+1);
+                }
                 this->getAppearanceData()->addPortAppearance(portName, app);
                 this->createRefreshExternalPort(portName);
             }

--- a/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.hpp
+++ b/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.hpp
@@ -13,6 +13,8 @@
 #include "HopsanEssentials.h"
 #include "ComponentEssentials.h"
 #include "ComponentUtilities.h"
+#include "CoreUtilities/StringUtilities.h"
+#include <algorithm>
 
 #ifdef USEFMI4C
 #include "fmi4c.h"
@@ -328,8 +330,17 @@ public:
         HVector<HString> ports = mPortSpecs.split(';');
         int portNumber = 1;
         for(size_t i=0; i<ports.size(); ++i) {
+            ports[i] = ports[i].replace(" ", "");
             HVector<HString> specs = ports[i].split(',');
-            HString nodeType = specs[0];
+            HString nodeType, portName;
+            if(specs[0].containes(':')) {
+                nodeType = specs[0].split(':')[0];
+                portName = specs[0].split(':')[1];
+            }
+            else {
+                nodeType = specs[0];
+                portName = "P"+to_hstring(portNumber);
+            }
 
             //Check that node is not empty (parameter not given)
             if(nodeType.empty()) {
@@ -341,10 +352,12 @@ public:
             std::vector<HString> v = hopsanCore.getRegisteredNodeTypes();
             if(std::find(v.begin(), v.end(), nodeType) == v.end()) {
                 addErrorMessage("Unsupported node type: "+nodeType);
-                for(size_t i=0; i<mPorts.size(); ++i) {
-                    removePort(mPorts[i]->getName());
-                }
-                mPorts.clear();
+                return;
+            }
+
+            //Check port name
+            if(!hopsan::isNameValid(portName)) {
+                addErrorMessage("Illegal port name: "+portName);
                 return;
             }
 
@@ -357,17 +370,35 @@ public:
             if(numberOfVariables != expectedNumberOfVariables)
             {
                 addErrorMessage("Error in port type specification: \""+nodeType+"\" requires "+to_hstring(expectedNumberOfVariables)+" variables.");
-                for(size_t i=0; i<mPorts.size(); ++i) {
-                    removePort(mPorts[i]->getName());
-                }
-                mPorts.clear();
                 return;
             }
-            Port *pPort = addPowerPort("P"+to_hstring(portNumber), nodeType, "");
-            mPorts.push_back(pPort);
+
+            //Check that all variables exist and are unique
             for(size_t i=0; i<numberOfVariables; ++i) {
+                if(usedVariables.contains(specs[i+1])) {
+                    addErrorMessage("Variable \""+specs[i+1]+"\" can only be used once in the \"portspecs\" parameter.");
+                    return;
+                }
+                std::vector<HString> portNames = getPortNames();
+                if(mFmiVersion == fmiVersion1 && fmi1_getVariableByName(fmu, specs[i+1].c_str()) == nullptr) {
+                    addErrorMessage("Variable \""+specs[i+1]+"\" does not exist in FMU.");
+                    return;
+                }
+                else if(mFmiVersion == fmiVersion2 && fmi2_getVariableByName(fmu, specs[i+1].c_str()) == nullptr) {
+                    addErrorMessage("Variable \""+specs[i+1]+"\" does not exist in FMU.");
+                    return;
+                }
+                else if(mFmiVersion == fmiVersion3 && fmi3_getVariableByName(fmu, specs[i+1].c_str()) == nullptr) {
+                    addErrorMessage("Variable \""+specs[i+1]+"\" does not exist in FMU.");
+                    return;
+                }
+
                 usedVariables.append(specs[i+1]);
             }
+
+            Port *pPort = addPowerPort(portName, nodeType, "");
+            mPorts.push_back(pPort);
+
             ++portNumber;
         }
 

--- a/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.md
+++ b/componentLibraries/defaultLibrary/Connectivity/FMIWrapperQ.md
@@ -19,6 +19,12 @@ Example:
 
 `NodeHydraulic,q1,p1,T1,c1,Zc1,Q1;NodeMechanic,v2,f2,x2,c2,Zc2,me2;NodeElectric,u3,i3,c3,Zc3;NodePneumatic,Qdot4,p4,c4,Zc4,mdot4,rho4,crho4,Zcrho4,T4`
 
+You can also specify port names by adding a colon after the node type.
+
+Example:
+
+`NodeHydraulic:PA,q1,p1,T1,c1,Zc1,Q1;NodeMechanic:PB,v2,f2,x2,c2,Zc2,me2;NodeElectric:PC,u3,i3,c3,Zc3;NodePneumatic:PD,Qdot4,p4,c4,Zc4,mdot4,rho4,crho4,Zcrho4,T4`
+
 **NodeHydraulic**
 
 | Variable    | Description          | Unit      | Causality |


### PR DESCRIPTION
Names are by default P1, P2 and so on. This enables user to speciy port names in the portspecs parameter with the following format:
`nodetype:portname;variable1,variable2,...,variableN`

Port name is optional.

This PR also adds some additional error checking of the portspecs parameter.

Resolves #2244 and #2243.