### PR TITLE
Paste system parameters before components

### DIFF
--- a/HopsanCore/src/Parameters.cpp
+++ b/HopsanCore/src/Parameters.cpp
@@ -745,7 +745,7 @@ bool ParameterEvaluatorHandler::setParameter(const HString &rName, const HString
 //! @return true if success, otherwise false
 bool ParameterEvaluatorHandler::setParameterValue(const HString &rName, const HString &rValue, bool force)
 {
-    return setParameter(rName, rValue, "", "", "", "", force);
+    return setParameter(rName, rValue, "", "", "", "", false, force);
 }
 
 

--- a/HopsanGUI/GUIObjects/GUIContainerObject.cpp
+++ b/HopsanGUI/GUIObjects/GUIContainerObject.cpp
@@ -1665,6 +1665,26 @@ void SystemObject::paste(CopyStack *xmlStack)
         }
     };
 
+    // Paste system parameters
+    QDomElement parElement = copyRoot->firstChildElement(hmf::parameter::root);
+    while(!parElement.isNull())
+    {
+        QString name = parElement.attribute(hmf::name);
+        if(!getParameterNames().contains(name))
+        {
+            QString value = parElement.attribute(hmf::value);
+            QString type = parElement.attribute(hmf::type);
+            QString quantityORunit = parElement.attribute(hmf::quantity, parElement.attribute(hmf::unit));
+            QString description = parElement.attribute(hmf::modelinfo::description);
+            bool internal = parseAttributeBool(parElement, hmf::internal, false);
+
+            CoreParameterData parData = CoreParameterData(name, value, type, quantityORunit, "", description, internal);
+            setOrAddParameter(parData);
+            didPaste = true;
+        }
+        parElement = parElement.nextSiblingElement(hmf::parameter::root);
+    }
+
     // Paste Components and Systems
     pasteComponentOrSystem(hmf::component);
     pasteComponentOrSystem(hmf::system);
@@ -1746,26 +1766,6 @@ void SystemObject::paste(CopyStack *xmlStack)
             mpUndoStack->registerMovedWidget(pWidget, prevPos, pWidget->pos());
         }
         imageElement = imageElement.nextSiblingElement(hmf::widget::imagewidget);
-    }
-
-    // Paste system parameters
-    QDomElement parElement = copyRoot->firstChildElement(hmf::parameter::root);
-    while(!parElement.isNull())
-    {
-        QString name = parElement.attribute(hmf::name);
-        if(!getParameterNames().contains(name))
-        {
-            QString value = parElement.attribute(hmf::value);
-            QString type = parElement.attribute(hmf::type);
-            QString quantityORunit = parElement.attribute(hmf::quantity, parElement.attribute(hmf::unit));
-            QString description = parElement.attribute(hmf::modelinfo::description);
-            bool internal = parseAttributeBool(parElement, hmf::internal, false);
-
-            CoreParameterData parData = CoreParameterData(name, value, type, quantityORunit, "", description, internal);
-            setOrAddParameter(parData);
-            didPaste = true;
-        }
-        parElement = parElement.nextSiblingElement(hmf::parameter::root);
     }
 
     if (didPaste) {


### PR DESCRIPTION
When pasting a component with some parameters mapped to a system parameter, the system parameters needs to be pasted before the component, so that it exists when it is needed.