### PR TITLE
New HCOM functions/commands

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -9898,10 +9898,15 @@ double HcomFunctionoidTime::operator()(QString &str, bool &ok)
 double HcomFunctionoidExists::operator()(QString &str, bool &ok)
 {
     ok = true;
-    if(mpHandler->getModelPtr()->getTopLevelSystemContainer()->hasModelObject(str))
-    {
-        return 1;
+    auto modelPtr = mpHandler->getModelPtr();
+    if(modelPtr) {
+        auto system = modelPtr->getTopLevelSystemContainer();
+        if(system && system->hasModelObject(str))
+        {
+            return 1;
+        }
     }
+
     return 0;
 }
 

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -6394,6 +6394,7 @@ void HcomHandler::evaluateExpression(QString expr, VariableType desiredType)
     funcMap.insert("atan", static_cast<ScalarMathFunction_t>(atan));
     funcMap.insert("log", static_cast<ScalarMathFunction_t>(log));
     funcMap.insert("log2", static_cast<ScalarMathFunction_t>(log2));
+    funcMap.insert("log10", static_cast<ScalarMathFunction_t>(log10));
     funcMap.insert("exp", static_cast<ScalarMathFunction_t>(exp));
     funcMap.insert("sqrt", static_cast<ScalarMathFunction_t>(sqrt));
     funcMap.insert("round", static_cast<ScalarMathFunction_t>(round));

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -1274,6 +1274,13 @@ void HcomHandler::createCommands()
     echoCmd.fnc = &HcomHandler::executeEchoCommand;
     mCmdList << echoCmd;
 
+    HcomCommand clearCmd;
+    clearCmd.cmd = "clear";
+    clearCmd.description.append("Clears terminal output");
+    clearCmd.help.append(" Usage: echo");
+    clearCmd.fnc = &HcomHandler::executeClearCommand;
+    mCmdList << clearCmd;
+
     HcomCommand editCmd;
     editCmd.cmd = "edit";
     editCmd.description.append("Open file in external editor");
@@ -5739,6 +5746,13 @@ void HcomHandler::executeEchoCommand(const QString cmd)
     {
         HCOMERR("Unknown argument, use \"on\" or \"off\"");
     }
+}
+
+void HcomHandler::executeClearCommand(const QString cmd)
+{
+    Q_UNUSED(cmd);
+    //mpConsole->clear();
+    qobject_cast<QTextEdit*>(mpConsole)->clear();
 }
 
 

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -423,6 +423,7 @@ HcomHandler::HcomHandler(TerminalConsole *pConsole) : QObject(pConsole)
     registerFunctionoid("minpar", new HcomFunctionoidMinPar(this), "Returns the minimum value of specified parameter for specified component type", "Usage: minpar(type,par)");
     registerFunctionoid("hg", new HcomFunctionoidHg(this), "Returns highest generation number", "Usage: hg()");
     registerFunctionoid("ans", new HcomFunctionoidAns(this), "Returns the answer from the previous computation", "Usage: ans()");
+    registerFunctionoid("count", new HcomFunctionoidCount(this), "Counts number of components in model with specified type name.", "Usage: count(typename)");
     createCommands();
 
     mLocalVars.insert("true",1);
@@ -9902,6 +9903,26 @@ double HcomFunctionoidExists::operator()(QString &str, bool &ok)
         return 1;
     }
     return 0;
+}
+
+
+//! @brief Function operator for the "count" functionoid
+double HcomFunctionoidCount::operator()(QString &str, bool &ok)
+{
+    ok = true;
+    int count = 0;
+    auto modelPtr = mpHandler->getModelPtr();
+    if(modelPtr) {
+        auto system = modelPtr->getTopLevelSystemContainer();
+        if(system) {
+            for(const auto &comp : system->getModelObjects()) {
+                if(comp->getTypeName() == str) {
+                    ++count;
+                }
+            }
+        }
+    }
+    return count;
 }
 
 

--- a/HopsanGUI/HcomHandler.h
+++ b/HopsanGUI/HcomHandler.h
@@ -466,4 +466,11 @@ public:
     HcomFunctionoidExists(HcomHandler *pHandler) : HcomFunctionoid(pHandler) {}
     double operator()(QString &str, bool &ok);
 };
+
+class HcomFunctionoidCount : public HcomFunctionoid
+{
+public:
+    HcomFunctionoidCount(HcomHandler *pHandler) : HcomFunctionoid(pHandler) {}
+    double operator()(QString &str, bool &ok);
+};
 #endif // HCOMHANDLER_H

--- a/HopsanGUI/HcomHandler.h
+++ b/HopsanGUI/HcomHandler.h
@@ -217,6 +217,7 @@ private:
     void executeOptimizationCommand(const QString cmd);
     void executeCallFunctionCommand(const QString cmd);
     void executeEchoCommand(const QString cmd);
+    void executeClearCommand(const QString cmd);
     void executeEditCommand(const QString cmd);
     void executeSetMultiThreadingCommand(const QString cmd);
     void executeLockAllAxesCommand(const QString cmd);


### PR DESCRIPTION
New HCOM functions:
- `count(typename)`: counts number of components with specific type name
- `log10()` - 10-base logarithm

New HCOM commands:
- `clear`: Clears the terminal output

HCOM fixes:
- Fix crash when calling `exists()` function with no model open.