### PR TITLE
Enable saving and loading plot window specifications

### DIFF
--- a/HopsanGUI/Utilities/XMLUtilities.h
+++ b/HopsanGUI/Utilities/XMLUtilities.h
@@ -344,4 +344,19 @@ namespace ssv {
                                                      {"conditional", ssv::datatype::integer}};
 }
 
+namespace plotwindow {
+    constexpr auto hopsanplot = "hopsanplot";
+    constexpr auto plottab = "plottab";
+    constexpr auto curve = "curve";
+    constexpr auto xcurve = "xcurve";
+    constexpr auto grid = "grid";
+    constexpr auto color = "color";
+    constexpr auto generation = "component";
+    constexpr auto component = "component";
+    constexpr auto port = "port";
+    constexpr auto data = "data";
+    constexpr auto axis = "axis";
+    constexpr auto width = "width";
+}
+
 #endif // XMLUTILITIES_H


### PR DESCRIPTION
Resolves #532.

Save and load plot windows to XML files.

Only support basic features such as left, right and X axis, line thickness and line color. We can add more data later if requrested.