### PR TITLE
Issue 2268 hcom hide plot window widgets

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -792,6 +792,15 @@ void HcomHandler::createCommands()
     pwccCmd.group = "Plot Commands";
     mCmdList << pwccCmd;
 
+
+    HcomCommand pwleCmd;
+    pwleCmd.cmd = "pwle";
+    pwleCmd.description.append("Toggles plot window legends visibility");
+    pwleCmd.help.append(" Usage: pwle on/off");
+    pwleCmd.fnc = &HcomHandler::executeTogglePlotWindowLegends;
+    pwleCmd.group = "Plot Commands";
+    mCmdList << pwleCmd;
+
     HcomCommand chpvlCmd;
     chpvlCmd.cmd = "chpvl";
     chpvlCmd.description.append("Changes plot variables on left axis in current plot");
@@ -3054,6 +3063,23 @@ void HcomHandler::executeTogglePlotWindowCurveControls(const QString cmd)
     }
     else if(cmd == "off") {
         mpCurrentPlotWindow->toggleCurveControls(false);
+    }
+    else {
+        HCOMERR("Unknown argument: "+cmd);
+    }
+}
+
+void HcomHandler::executeTogglePlotWindowLegends(const QString cmd)
+{
+    if(getNumberOfCommandArguments(cmd) != 1) {
+        HCOMERR("Wrong number of arguments.");
+        return;
+    }
+    if(cmd == "on") {
+        mpCurrentPlotWindow->setLegendsVisible(true);
+    }
+    else if(cmd == "off") {
+        mpCurrentPlotWindow->setLegendsVisible(false);
     }
     else {
         HCOMERR("Unknown argument: "+cmd);

--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -776,6 +776,22 @@ void HcomHandler::createCommands()
     dipwCmd.group = "Plot Commands";
     mCmdList << dipwCmd;
 
+    HcomCommand pwvlCmd;
+    pwvlCmd.cmd = "pwvl";
+    pwvlCmd.description.append("Toggles plot window varible list visibility");
+    pwvlCmd.help.append(" Usage: pwvl on/off");
+    pwvlCmd.fnc = &HcomHandler::executeTogglePlotWindowVariableList;
+    pwvlCmd.group = "Plot Commands";
+    mCmdList << pwvlCmd;
+
+    HcomCommand pwccCmd;
+    pwccCmd.cmd = "pwcc";
+    pwccCmd.description.append("Toggles plot window curve control visibility");
+    pwccCmd.help.append(" Usage: pwcc on/off");
+    pwccCmd.fnc = &HcomHandler::executeTogglePlotWindowCurveControls;
+    pwccCmd.group = "Plot Commands";
+    mCmdList << pwccCmd;
+
     HcomCommand chpvlCmd;
     chpvlCmd.cmd = "chpvl";
     chpvlCmd.description.append("Changes plot variables on left axis in current plot");
@@ -3003,6 +3019,44 @@ void HcomHandler::executeDisplayPlotWindowCommand(const QString /*cmd*/)
     else
     {
         HCOMPRINT("Current plotwindow not set");
+    }
+}
+
+
+//! @brief Execute function for "pwvl" command
+void HcomHandler::executeTogglePlotWindowVariableList(const QString cmd)
+{
+    if(getNumberOfCommandArguments(cmd) != 1) {
+        HCOMERR("Wrong number of arguments.");
+        return;
+    }
+    if(cmd == "on") {
+        mpCurrentPlotWindow->toggleVariablesWidget(true);
+    }
+    else if(cmd == "off") {
+        mpCurrentPlotWindow->toggleVariablesWidget(false);
+    }
+    else {
+        HCOMERR("Unknown argument: "+cmd);
+    }
+}
+
+
+//! @brief Execute function for "pwcc" command
+void HcomHandler::executeTogglePlotWindowCurveControls(const QString cmd)
+{
+    if(getNumberOfCommandArguments(cmd) != 1) {
+        HCOMERR("Wrong number of arguments.");
+        return;
+    }
+    if(cmd == "on") {
+        mpCurrentPlotWindow->toggleCurveControls(true);
+    }
+    else if(cmd == "off") {
+        mpCurrentPlotWindow->toggleCurveControls(false);
+    }
+    else {
+        HCOMERR("Unknown argument: "+cmd);
     }
 }
 

--- a/HopsanGUI/HcomHandler.h
+++ b/HopsanGUI/HcomHandler.h
@@ -134,6 +134,8 @@ private:
 
     void executeChangePlotWindowCommand(const QString cmd);
     void executeDisplayPlotWindowCommand(const QString cmd);
+    void executeTogglePlotWindowVariableList(const QString cmd);
+    void executeTogglePlotWindowCurveControls(const QString cmd);
     void executePlotCommand(const QString cmd);
     void executePlotLeftAxisCommand(const QString cmd);
     void executePlotRightAxisCommand(const QString cmd);

--- a/HopsanGUI/HcomHandler.h
+++ b/HopsanGUI/HcomHandler.h
@@ -136,6 +136,7 @@ private:
     void executeDisplayPlotWindowCommand(const QString cmd);
     void executeTogglePlotWindowVariableList(const QString cmd);
     void executeTogglePlotWindowCurveControls(const QString cmd);
+    void executeTogglePlotWindowLegends(const QString cmd);
     void executePlotCommand(const QString cmd);
     void executePlotLeftAxisCommand(const QString cmd);
     void executePlotRightAxisCommand(const QString cmd);

--- a/HopsanGUI/PlotWindow.cpp
+++ b/HopsanGUI/PlotWindow.cpp
@@ -316,19 +316,19 @@ PlotWindow::PlotWindow(const QString name, QWidget *parent)
     // Setup PlotVariable List stuff
     PlotWidget2 *pLocalPlotWidget = new PlotWidget2(this);
     pLocalPlotWidget->setPreferedPlotWindow(this);
-    QDockWidget *pLocalPlotWidgetDock = new QDockWidget(tr("Plot Variables"), this);
-    pLocalPlotWidgetDock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
-    addDockWidget(Qt::RightDockWidgetArea, pLocalPlotWidgetDock);
-    pLocalPlotWidgetDock->setWidget(pLocalPlotWidget);
+    mpLocalVariablesWidgetDock = new QDockWidget(tr("Plot Variables"), this);
+    mpLocalVariablesWidgetDock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+    addDockWidget(Qt::RightDockWidgetArea, mpLocalVariablesWidgetDock);
+    mpLocalVariablesWidgetDock->setWidget(pLocalPlotWidget);
     if(gpModelHandler->count() != 0)
     {
         //pLocalPlotWidget->setLogDataHandler(gpModelHandler->getCurrentViewContainerObject()->getLogDataHandler()); //!< @todo not necessarily the same as where the plot data will come from if plot by script
         pLocalPlotWidget->setLogDataHandler(gpModelHandler->getCurrentLogDataHandler().data()); //!< @todo not necessarily the same as where the plot data will come from if plot by script
     }
 
-    pLocalPlotWidgetDock->toggleViewAction()->setToolTip("Toggle Variable List");
-    pLocalPlotWidgetDock->toggleViewAction()->setIcon(QIcon(QString(ICONPATH) + "svg/Hopsan-ShowPlotWindowVariableList.svg"));
-    connect(pLocalPlotWidgetDock->toggleViewAction(), SIGNAL(hovered()), this, SLOT(showToolBarHelpPopup()));
+    mpLocalVariablesWidgetDock->toggleViewAction()->setToolTip("Toggle Variable List");
+    mpLocalVariablesWidgetDock->toggleViewAction()->setIcon(QIcon(QString(ICONPATH) + "svg/Hopsan-ShowPlotWindowVariableList.svg"));
+    connect(mpLocalVariablesWidgetDock->toggleViewAction(), SIGNAL(hovered()), this, SLOT(showToolBarHelpPopup()));
 
     // Setup CurveInfoBox stuff
     mpPlotCurveControlsStack = new QStackedWidget(this);
@@ -372,7 +372,7 @@ PlotWindow::PlotWindow(const QString name, QWidget *parent)
     mpToolBar->addAction(mpLocktheAxis);
     mpToolBar->addAction(mpToggleAxisLockButton);
     mpToolBar->addAction(mpPlotCurveControlsDock->toggleViewAction());
-    mpToolBar->addAction(pLocalPlotWidgetDock->toggleViewAction());
+    mpToolBar->addAction(mpLocalVariablesWidgetDock->toggleViewAction());
     mpToolBar->addSeparator();
     mpToolBar->addAction(mpNewWindowFromTabButton);
     mpToolBar->setMouseTracking(true);
@@ -547,6 +547,16 @@ void PlotWindow::setXData(SharedVectorVariableT xdata, bool force)
     }
 
     pTab->setCustomXVectorForAll(xdata, 0, force);
+}
+
+void PlotWindow::toggleVariablesWidget(bool visible)
+{
+    mpLocalVariablesWidgetDock->setVisible(visible);
+}
+
+void PlotWindow::toggleCurveControls(bool visible)
+{
+    mpPlotCurveControlsDock->setVisible(visible);
 }
 
 

--- a/HopsanGUI/PlotWindow.h
+++ b/HopsanGUI/PlotWindow.h
@@ -89,6 +89,9 @@ public:
     PlotCurve* addPlotCurve(SharedVectorVariableT xdata, SharedVectorVariableT ydata, const QwtPlot::Axis axisY=QwtPlot::yLeft, PlotCurveStyle style=PlotCurveStyle());
     void setXData(SharedVectorVariableT xdata, bool force=false);
 
+    void toggleVariablesWidget(bool visible);
+    void toggleCurveControls(bool visible);
+
 signals:
     void windowClosed(PlotWindow *pWindow);
 
@@ -126,6 +129,7 @@ private:
     QPointF dragStartPosition;
 
     PlotTabWidget *mpPlotTabWidget;
+    QDockWidget *mpLocalVariablesWidgetDock;
     QDockWidget *mpPlotCurveControlsDock;
     QStackedWidget *mpPlotCurveControlsStack;
     HelpPopUpWidget *mpHelpPopup;


### PR DESCRIPTION
New HCOM commands:
- `pwvl`: Toggle plot window variable list visibility
- `pwcc`: Toggle plot window curve controls visibility
- `pwle`: Toggle plot window legends visibility

Resolves #2268.