### PR TITLE
Support whitespaces in FMIWrapper portspec parameter

### DIFF
--- a/HopsanGUI/GUIObjects/GUIComponent.cpp
+++ b/HopsanGUI/GUIObjects/GUIComponent.cpp
@@ -194,7 +194,7 @@ bool Component::setParameterValue(QString name, QString value, bool force)
             this->createRefreshExternalPort(outputs[i]);
         }
 
-        QStringList portSpecs = getParameterValue("portspecs").split(";");
+        QStringList portSpecs = getParameterValue("portspecs").remove(' ').split(";");
         for(int i=0; i<portSpecs.size(); ++i) {
             if(!portSpecs[i].isEmpty()) {
                 SharedPortAppearanceT app(new PortAppearance());


### PR DESCRIPTION
Remove all whitespaces from portspecs parameter in FMIWrapper components. Whitespaces are not supported in port names anyway.

Resolves #2243.