### PR TITLE
Ignore semicolons in HCOM if within quotation marks

### DIFF
--- a/HopsanGUI/HcomHandler.cpp
+++ b/HopsanGUI/HcomHandler.cpp
@@ -1435,10 +1435,11 @@ void HcomHandler::executeCommand(QString cmd)
     if(cmd.isEmpty()) return;
 
     //Allow several commands on one line, separated by semicolon
-    if(cmd.contains(";"))
+    if(containsOutsideQuotes(cmd, ';'))
     {
-        QStringList cmdList = cmd.split(";");
-        for(const QString &tempCmd : cmdList) {
+        QStringList cmdList;
+        splitWithRespectToQuotations(cmd, ';', cmdList);
+        for(const QString &tempCmd : qAsConst(cmdList)) {
             executeCommand(tempCmd);
         }
         return;

--- a/HopsanGUI/Utilities/GUIUtilities.cpp
+++ b/HopsanGUI/Utilities/GUIUtilities.cpp
@@ -823,7 +823,7 @@ double findSmallestValueGreaterThanZero(QVector<double> data)
 //! @param str String to split
 //! @param c Character to split at
 //! @param split Reference to list with split strings
-void splitWithRespectToQuotations(const QString str, const QChar c, QStringList &split)
+void splitWithRespectToQuotations(const QString &str, const QChar c, QStringList &split)
 {
     bool withinQuotations=false;
     int start=0;
@@ -843,6 +843,23 @@ void splitWithRespectToQuotations(const QString str, const QChar c, QStringList 
         ++len;
     }
     split.append(str.mid(start,len));
+}
+
+
+//! @brief Checks if a string contains a character, but ignores all characters within quotations
+//! @param str String to search
+//! @param c Character to search for
+bool containsOutsideQuotes(const QString &str, const QChar c) {
+    bool withinQuotations = false;
+    for(int i=0; i<str.size(); ++i) {
+        if (str[i] == '"') {
+            withinQuotations = !withinQuotations;
+        }
+        else if(str[i] == c && !withinQuotations) {
+            return true;
+        }
+    }
+    return false;
 }
 
 //! @brief Splits a string at specified character, but does not split inside quotations and parenthesis

--- a/HopsanGUI/Utilities/GUIUtilities.h
+++ b/HopsanGUI/Utilities/GUIUtilities.h
@@ -83,7 +83,8 @@ bool verifyParameterValue(QString &rValue, const QString type, const QStringList
 QStringList getAllAccessibleSystemParameterNames(SystemObject* pSystem);
 
 double findSmallestValueGreaterThanZero(QVector<double> data);
-void splitWithRespectToQuotations(const QString str, const QChar c, QStringList &split);
+void splitWithRespectToQuotations(const QString &str, const QChar c, QStringList &split);
+bool containsOutsideQuotes(const QString &str, const QChar c);
 void splitRespectingQuotationsAndParanthesis(const QString str, const QChar c, QStringList &rSplit);
 void extractSectionsRespectingQuotationsAndParanthesis(const QString str, const QChar c, QStringList &rSplit, QList<int> &rSectionIndexes);
 void extractSections(const QString str, const QChar c, QStringList &rSplit, QList<int> &rSectionIndexes);


### PR DESCRIPTION
Do not split HCOM commands into subcommands if semicolon is within quotes. This enables e.g. using semicolons in strings with the `print` command.

Resolves #2269.