### PR TITLE
Remember dangling connectors when changing FMIWrapper portspecs

### DIFF
--- a/HopsanGUI/GUIObjects/GUIObject.h
+++ b/HopsanGUI/GUIObjects/GUIObject.h
@@ -37,6 +37,7 @@
 #include <QGraphicsWidget>
 #include <QObject>
 #include <QPen>
+#include <GUIConnector.h>
 
 #include "common.h"
 
@@ -116,6 +117,7 @@ protected:
     bool mIsLocked = false;
     WorkspaceObjectSelectionBox *mpSelectionBox = nullptr;
     QPointF mPreviousPos;
+    QMap<QString, QVector<Connector*> > mConnectionsBeforeReconfigure;
 };
 
 


### PR DESCRIPTION
Dangling connectors will now be remembered even after multiple reconfigurations, e.g. removing a port and adding it again, or changing to another FMU and back again.