### PR TITLE
Fix build issues for 2.23.0

### DIFF
--- a/Common.prf
+++ b/Common.prf
@@ -13,10 +13,12 @@ CONFIG(debug, debug|release) {
 # O3 = highest optimization level for speed
 CONFIG(debug, debug|release) {
   #QMAKE_CXXFLAGS += -Og
-  QMAKE_CXXFLAGS += -v -Wa,-mbig-obj
+  QMAKE_CXXFLAGS += -v
+  win32:QMAKE_CXXFLAGS += -Wa,-mbig-obj
 }
 CONFIG(release, debug|release) {
-  QMAKE_CXXFLAGS += -O3 -v -Wa,-mbig-obj
+  QMAKE_CXXFLAGS += -O3 -v
+  win32:QMAKE_CXXFLAGS += -Wa,-mbig-obj
 }
 message("QMAKE_CXXFLAGS: $${QMAKE_CXXFLAGS}")
 

--- a/dependencies/download-dependencies.py
+++ b/dependencies/download-dependencies.py
@@ -318,6 +318,10 @@ class DependenciesXML:
             if len(files_matching_platform) == 0:
                 files_matching_platform = files_without_platform
 
+            if not files_matching_platform:
+                print('No files matches this platform. Skipping.')
+                continue;
+
             # Trigger the actual download and unpacking
             this_verified = False
             for releasefile in files_matching_platform:
@@ -327,6 +331,8 @@ class DependenciesXML:
                         clear_and_unpack(file_name, dep_name)
                 this_verified |= verified_ok
             all_verified &= this_verified
+            if not this_verified:
+              print('Failed!')
         return all_verified
 
 


### PR DESCRIPTION
- Do not use -mbig-obj for non-Windows builds 
  - Used to give only a warning on Linux, but job fails on newer compilers
- The download dependencies script should not report a failure for dependencie only available for other platforms
  - Relevant for zlib, which is only available for Windows