### PR TITLE
Use all dependencie in Debian and Snap

### DIFF
--- a/packaging/deb/bookworm/debian/rules
+++ b/packaging/deb/bookworm/debian/rules
@@ -20,6 +20,9 @@ override_dh_auto_build:
 	cd dependencies; ./setupFmi4c.sh
 	cd dependencies; ./setupKatex.sh
 	cd dependencies; ./setupTclap.sh
+	cd dependencies; ./setupXerces.sh
+	cd dependencies; ./setupDCPLib.sh
+	cd dependencies; ./setupLibzip.sh
 
 #       Now build Hopsan using qmake
 	mkdir -p hopsanShadowBuild

--- a/packaging/deb/bullseye/debian/rules
+++ b/packaging/deb/bullseye/debian/rules
@@ -20,6 +20,9 @@ override_dh_auto_build:
 	cd dependencies; ./setupFmi4c.sh
 	cd dependencies; ./setupKatex.sh
 	cd dependencies; ./setupTclap.sh
+	cd dependencies; ./setupXerces.sh
+	cd dependencies; ./setupDCPLib.sh
+	cd dependencies; ./setupLibzip.sh
 
 #       Now build Hopsan using qmake
 	mkdir -p hopsanShadowBuild

--- a/packaging/deb/focal/debian/rules
+++ b/packaging/deb/focal/debian/rules
@@ -20,6 +20,9 @@ override_dh_auto_build:
 	cd dependencies; ./setupFmi4c.sh
 	cd dependencies; ./setupKatex.sh
 	cd dependencies; ./setupTclap.sh
+	cd dependencies; ./setupXerces.sh
+	cd dependencies; ./setupDCPLib.sh
+	cd dependencies; ./setupLibzip.sh
 
 #       Now build Hopsan using qmake
 	mkdir -p hopsanShadowBuild

--- a/packaging/deb/qt5py3_buster/debian/rules
+++ b/packaging/deb/qt5py3_buster/debian/rules
@@ -20,6 +20,9 @@ override_dh_auto_build:
 	cd dependencies; ./setupFmi4c.sh
 	cd dependencies; ./setupKatex.sh
 	cd dependencies; ./setupTclap.sh
+	cd dependencies; ./setupXerces.sh
+	cd dependencies; ./setupDCPLib.sh
+	cd dependencies; ./setupLibzip.sh
 
 #       Now build Hopsan using qmake
 	mkdir -p hopsanShadowBuild

--- a/snap/local/snapcraft.yaml.in
+++ b/snap/local/snapcraft.yaml.in
@@ -125,6 +125,9 @@ parts:
       ./setupFMILibrary.sh
       ./setupKatex.sh
       ./setupTclap.sh
+      ./setupXerces.sh
+      ./setupDCPLib.sh
+      ./setupLibzip.sh
       cd ..
       snapcraftctl build
 


### PR DESCRIPTION
DCPLib, Libzip and Xerces were missing when building 2.23.0 release.