### PR TITLE
Fix link path for libzip and xerces dependencies

### DIFF
--- a/dependencies/libzip.pri
+++ b/dependencies/libzip.pri
@@ -3,7 +3,7 @@ zlib_dir = $${PWD}/zlib
 message(libzip_dir)
 exists($${libzip_dir}) {
   INCLUDEPATH *= $${libzip_dir}/include
-  LIBS *= -L$${libzip_dir}/bin -lzip
+  LIBS *= -L$${libzip_dir}/bin -L$${libzip_dir}/lib -lzip
 
   macx {
   # Not supported

--- a/dependencies/xerces.pri
+++ b/dependencies/xerces.pri
@@ -2,7 +2,7 @@ xerces_dir = $${PWD}/xerces
 
 exists($${xerces_dir}) {
   INCLUDEPATH *= $${xerces_dir}/include
-  LIBS *= -L$${xerces_dir}/bin -lxerces-c
+  LIBS *= -L$${xerces_dir}/bin -L$${xerces_dir}/lib -lxerces-c
 
   macx {
   # Not supported


### PR DESCRIPTION
Link path is set to "bin", but on Linux the .so files are located in the "lib" folder.