### PR TITLE
Do not remove last factor in SymHop simplification

### DIFF
--- a/SymHop/src/SymHop.cpp
+++ b/SymHop/src/SymHop.cpp
@@ -1243,7 +1243,7 @@ QString Expression::toString() const
 
     //Simplify output
     ret.replace("+-", "-");
-    ret.replace("--", "");
+    ret.replace("--", "+");
 
     return ret;
 }
@@ -2981,6 +2981,9 @@ void Expression::_simplify(ExpressionSimplificationT type, const ExpressionRecur
             if(nNeg % 2 != 0)
             {
                 mFactors << Expression("-1");
+            }
+            else if(mFactors.isEmpty()) {
+                mFactors << Expression("1");
             }
         }
     }


### PR DESCRIPTION
This fixes SymHop simplification of the expression "(-1)*(-1)", which should be simplified to "1" if there are no other factors.

Also minor fix in SymHop print function.