### PR TITLE
Use QtWebEngine on Linux

### DIFF
--- a/HopsanGUI/HopsanGUI.pro
+++ b/HopsanGUI/HopsanGUI.pro
@@ -15,12 +15,17 @@ CONFIG -= app_bundle
 
 isEqual(QT_MAJOR_VERSION, 5){
     QT += widgets printsupport
-    qtHaveModule(webkitwidgets) {
-        QT += webkitwidgets
-        DEFINES *= USEWEBKIT
-        message(Using WebKit)
-    } else {
-        message(WebKit is not available)
+    unix {
+        QT += webenginewidgets
+    }
+    win32 {
+        qtHaveModule(webkitwidgets) {
+            QT += webkitwidgets
+            #DEFINES *= USEWEBKIT
+            message(Using WebKit)
+        } else {
+            message(WebKit is not available)
+        }
     }
 } else {
     QT += webkit

--- a/HopsanGUI/Utilities/WebviewWrapper.cpp
+++ b/HopsanGUI/Utilities/WebviewWrapper.cpp
@@ -6,7 +6,7 @@
 #ifdef USEWEBKIT
 #include <QWebView>
 #else
-#include <QLabel>
+#include <QWebEngineView>
 #endif
 
 #include "common.h"
@@ -17,8 +17,7 @@ public:
 #ifdef USEWEBKIT
     QWebView* mpWebView = nullptr;
 #else
-    QLabel* mpNotice = nullptr;
-    QLabel* mpText = nullptr;
+    QWebEngineView* mpWebView = nullptr;
 #endif
 
 };
@@ -28,31 +27,28 @@ WebViewWrapper::WebViewWrapper(const bool useToolbar, QWidget *parent) : QWidget
     mpPrivates->mpLayout = new QVBoxLayout(this);
 #ifdef USEWEBKIT
     mpPrivates->mpWebView = new QWebView(this);
+#else
+    mpPrivates->mpWebView = new QWebEngineView(this);
+#endif
     if (useToolbar)
     {
+#ifdef USEWEBKIT
         QAction *pBackAction = mpPrivates->mpWebView->pageAction(QWebPage::Back);
-        pBackAction->setIcon(QIcon(QString(QString(ICONPATH) + "svg/Hopsan-StepLeft.svg")));
         QAction *pForwardAction = mpPrivates->mpWebView->pageAction(QWebPage::Forward);
+#else
+        QAction *pBackAction = mpPrivates->mpWebView->pageAction(QWebEnginePage::Back);
+        QAction *pForwardAction = mpPrivates->mpWebView->pageAction(QWebEnginePage::Forward);
+#endif
+        pBackAction->setIcon(QIcon(QString(QString(ICONPATH) + "svg/Hopsan-StepLeft.svg")));
         pForwardAction->setIcon(QIcon(QString(QString(ICONPATH) + "svg/Hopsan-StepRight.svg")));
 
         QToolBar *pToolBar = new QToolBar(this);
         pToolBar->addAction(pBackAction);
         pToolBar->addAction(pForwardAction);
-
         mpPrivates->mpLayout->addWidget(pToolBar);
     }
     mpPrivates->mpLayout->addWidget(mpPrivates->mpWebView);
     mpPrivates->mpLayout->setStretch(1,1);
-#else
-    Q_UNUSED(useToolbar)
-    mpPrivates->mpNotice = new QLabel(this);
-    mpPrivates->mpText = new QLabel(this);
-    mpPrivates->mpText->setOpenExternalLinks(true);
-    mpPrivates->mpLayout->addWidget(mpPrivates->mpNotice);
-    mpPrivates->mpLayout->addWidget(mpPrivates->mpText);
-    mpPrivates->mpLayout->addStretch(1);
-#endif
-
 }
 
 WebViewWrapper::~WebViewWrapper()
@@ -64,25 +60,13 @@ WebViewWrapper::~WebViewWrapper()
 
 void WebViewWrapper::loadHtmlFile(const QUrl &url)
 {
-#ifdef USEWEBKIT
     mpPrivates->mpWebView->load(url);
 #ifdef _WIN32
     mpPrivates->mpWebView->setZoomFactor(1.3);
 #endif
-#else
-    mpPrivates->mpNotice->setText("Sorry, no WebKit or WebEngine support in this release, open in external browser!");
-    mpPrivates->mpNotice->show(); // If previously hidden by showText
-    mpPrivates->mpText->setText(QString("<a href=\"%1\">%2</a>").arg(url.toString()).arg(url.toString()));
-#endif
-
 }
 
 void WebViewWrapper::showText(const QString &text)
 {
-#ifdef USEWEBKIT
     mpPrivates->mpWebView->setHtml(QString("<p>%1</p>").arg(text));
-#else
-    mpPrivates->mpNotice->hide();
-    mpPrivates->mpText->setText(text);
-#endif
 }


### PR DESCRIPTION
Use QtWebEngine instead of QtWebKit on Linux. This should make it possible to build new Debian releases without the depracated QtWebkit dependency, while still building Windows releases using MinGW and the custom built QtWebkit.

Involves platform specific code, not tested on Windows yet.