### PR TITLE
Fix FMI3 export value references

### DIFF
--- a/HopsanGenerator/src/GeneratorTypes.cpp
+++ b/HopsanGenerator/src/GeneratorTypes.cpp
@@ -905,6 +905,9 @@ ModelVariableSpecification::ModelVariableSpecification(QStringList systemHierarc
 QString ModelVariableSpecification::getName() const
 {
     if(systemHierarchy.isEmpty()) {
+        if(dataName == "y") {
+            return componentName;   //Only use component name for signal interfaces (does not affect DLL, only XML)
+        }
         return componentName+"."+portName+"."+dataName;
     }
     else {

--- a/HopsanGenerator/src/generators/HopsanFMIGenerator.cpp
+++ b/HopsanGenerator/src/generators/HopsanFMIGenerator.cpp
@@ -261,9 +261,17 @@ bool HopsanFMIGenerator::generateToFmu(QString savePath, ComponentSystem *pSyste
     QList<ParameterSpecification> pars;
     getParameters(pars, pSystem);
 
-    dataStr.append("\n#define NUMDATAPTRS "+QString::number(vars.size()+pars.size()));
+    if(version == 3) {
+        dataStr.append("\n#define NUMDATAPTRS "+QString::number(vars.size()+pars.size()+1));
+    }
+    else {
+        dataStr.append("\n#define NUMDATAPTRS "+QString::number(vars.size()+pars.size()));
+    }
     dataStr.append("\n#define INITDATAPTRS ");
     int vr = 1; //Value reference 0 reserved for timestep
+    if(version == 3) {
+        vr = 2; //In FMI 3, 0 = time and 1 = timestep
+    }
     for(const auto &var : vars) {
         dataStr.append("\\\nfmu->dataPtrs["+QString::number(vr)+"] = fmu->pSystem");
         for(const auto &system : var.systemHierarchy) {

--- a/HopsanGenerator/src/generators/HopsanFMIGenerator.cpp
+++ b/HopsanGenerator/src/generators/HopsanFMIGenerator.cpp
@@ -827,12 +827,7 @@ bool HopsanFMIGenerator::generateModelDescriptionXmlFile(ComponentSystem *pSyste
         long vr = 2;    //! vr = 0 and vr = 1 are reserved for time and timestep
         for(const auto &var : qAsConst(vars)) {
             mdWriter.writeStartElement("Float64");
-            if(var.systemHierarchy.isEmpty()) {
-                mdWriter.writeAttribute("name", var.componentName+"."+var.portName+"."+var.dataName);
-            }
-            else {
-                mdWriter.writeAttribute("name", var.systemHierarchy.join(".")+"."+var.componentName+"."+var.portName+"."+var.dataName);
-            }
+            mdWriter.writeAttribute("name", var.getName());
             mdWriter.writeAttribute("valueReference", QString::number(vr));
             mdWriter.writeAttribute("variability", "continuous");
             if(var.causality == ModelVariableCausality::Input) {

--- a/HopsanGenerator/templates/fmu3_model.c
+++ b/HopsanGenerator/templates/fmu3_model.c
@@ -280,10 +280,13 @@ fmi3Status fmi3GetFloat64(fmi3Instance instance,
     fmuContext *fmu =(fmuContext*)instance;
     fmi3Status status = fmi3OK;
     for(size_t i=0; i<nValueReferences; ++i) {
-        if(valueReferences[i] >= NUMDATAPTRS+1) {
+        if(valueReferences[i] >= NUMDATAPTRS+2) {
             status = fmi3Error;   //Illegal value reference
         }
-        else if(valueReferences[i]==0) {
+        else if(valueReferences[i] == 0) {
+            values[i] = fmu->pSystem->getTime();
+        }
+        else if(valueReferences[i] == 1) {
             values[i] = fmu->pSystem->getDesiredTimeStep();
         }
         else {
@@ -307,7 +310,7 @@ fmi3Status fmi3SetFloat64(fmi3Instance instance,
             status = fmi3Error;
         }
         else {
-            if(valueReferences[i] == 0) {
+            if(valueReferences[i] == 1) {
                 if(state == Instantiated || state == Initializing) {
                     fmu->pSystem->setDesiredTimestep(values[i]);
                 }

--- a/UnitTests/GeneratorTest/tst_generatortest.cpp
+++ b/UnitTests/GeneratorTest/tst_generatortest.cpp
@@ -430,9 +430,9 @@ private slots:
         Component *pSourceComponent = mHopsanCore.createComponent("SignalSineWave");
         pSystem->addComponent(pSourceComponent);
         Port *pPort1 = pSourceComponent->getPort("out");
-        Port *pPort2 = pFmuComponent->getPort("in1_out_y");
+        Port *pPort2 = pFmuComponent->getPort("in1");
         QVERIFY2(pPort2 != nullptr, "Input port is missing from imported FMU");
-        Port *pPort3 = pFmuComponent->getPort("out1_in_y");
+        Port *pPort3 = pFmuComponent->getPort("out1");
         QVERIFY2(pPort3 != nullptr, "Output port is missing from imported FMU");
         pSystem->connect(pPort1, pPort2);
         pSystem->initialize(0, 100);


### PR DESCRIPTION
FMI 3 reserves both value references 0 (time) and 1 (timestep), unlike FMI 1 & 2 which only reserves 0. The Hopsan export used to handle this wrong, which caused an offset by 1 in exported FMUs.