### PR TITLE
Remove erroneous code from mechanic interface component

### DIFF
--- a/componentLibraries/defaultLibrary/Connectivity/MechanicInterfaceC.hpp
+++ b/componentLibraries/defaultLibrary/Connectivity/MechanicInterfaceC.hpp
@@ -40,14 +40,10 @@ namespace hopsan {
 
     //!
     //! @brief
-    //! @ingroup MechanicalComponents
+    //! @ingroup InterfaceComponents
     //!
     class MechanicInterfaceC : public ComponentC
     {
-        double Zc, dT;
-        double *mpv2, *mpf2, *mpP1_c, *mpP1_Zc;
-
-        double f0, f1, f2, v0, v1, v2, t0, t1, t2, fi, vi, fi0, vi0;
 
     private:
         Port *mpP1;
@@ -61,68 +57,18 @@ namespace hopsan {
         void configure()
         {
             mpP1 = addPowerPort("P1", "NodeMechanic");
-            addInputVariable("v2", "received (delayed) velocity", "m/s", 0, &mpv2);
-            addInputVariable("f2", "receive (delayed) force", "N", 0, &mpf2);
-            addConstant("Zc", "Characteristic Impedance", "Ns/m", Zc);
-            addConstant("Td", "Time delay", "s", dT);
         }
 
         void initialize()
         {
-            mpP1_c = getSafeNodeDataPtr(mpP1, NodeMechanic::WaveVariable);
-            mpP1_Zc = getSafeNodeDataPtr(mpP1, NodeMechanic::CharImpedance);
-            f0 = 0;
-            f1 = 0;
-            f2 = 0;
-            v0 = 0;
-            v1 = 0;
-            v2 = 0;
-            t0 = mTime-2*mTimestep;
-            t1 = mTime-mTimestep;
-            t2 = mTime;
-            fi0 = fi;
-            vi0 = v0;
+            //Interfacing is handled through readnode/writenode from the RT wrapper file
         }
 
         void simulateOneTimestep()
         {
-            if(dT < 1.01*mTimestep && dT > 0.99*mTimestep) {
-                fi = (*mpf2);
-                vi = (*mpv2);
-            }
-            else {
-                if(f2 != (*mpf2) || v2 != (*mpv2)) {
-                    f0 = f1;
-                    f1 = f2;
-                    f2 = (*mpf2);
-                    v0 = v1;
-                    v1 = v2;
-                    v2 = (*mpv2);
-                    t0 = t1;
-                    t1 = t2;
-                    t2 = mTime;
-                }
-
-                double t = mTime-dT;
-                //fi = interpolateLinear(f1, f2,  t1, t2, t);
-                //vi = interpolateLinear(v1, v2,  t1, t2, t);
-
-                fi = interpolateQuadratic(f0, f1, f2,  t0, t1, t2, t);
-                vi = interpolateQuadratic(v0, v1, v2,  t0, t1, t2, t);
-            }
-
-            (*mpP1_c) = fi + Zc*vi;
-            (*mpP1_Zc) = Zc;
+            //Interfacing is handled through readnode/writenode from the RT wrapper file
         }
 
-        double interpolateLinear(double x1, double x2, double t1, double t2, double t) {
-            return x1+(x2-x1)/(t2-t1)*(t-t1);
-        }
-
-        double interpolateQuadratic(double x0, double x1, double x2, double t0, double t1, double t2, double t) {
-            double theta = (t-t1)/(t2-t1);
-            return x0*(theta*(theta-1.0))/2.0 + x1*(1.0-theta*theta) + x2*(theta*(theta+1))/2.0;
-        }
     };
 }
 


### PR DESCRIPTION
For some reason the MechanicInteraceC has gotten code that was intended for MechanicInterfaceTLM. This gave very weird results when running FMI co-simulation with mechanical power ports.