### PR TITLE
Fix FMU initialization

### DIFF
--- a/HopsanCore/include/ComponentSystem.h
+++ b/HopsanCore/include/ComponentSystem.h
@@ -129,6 +129,7 @@ namespace hopsan {
         bool checkModelBeforeSimulation();
         virtual bool preInitialize();
         bool initialize(const double startT, const double stopT);
+        void simulateOnceWithoutIncreasingTime();
         void simulate(const double stopT);
         bool startRealtimeSimulation(double realTimeFactor=1);
         virtual void simulateMultiThreaded(const double startT, const double stopT, const size_t nDesiredThreads = 0, const bool noChanges=false, ParallelAlgorithmT algorithm=APrioriScheduling);

--- a/HopsanCore/src/ComponentSystem.cpp
+++ b/HopsanCore/src/ComponentSystem.cpp
@@ -3339,6 +3339,30 @@ void ComponentSystem::distributeNodePointers(vector< vector<Node*> > &/*rSplitNo
 //    }
 //}
 
+
+//! @brief Used for initialization in exported FMUs
+//! @details Calls simulateOneTimestep() for each component in the system. Time variable is not increased.
+void ComponentSystem::simulateOnceWithoutIncreasingTime()
+{
+    //Signal components
+    for (size_t s=0; s < mComponentSignalptrs.size(); ++s)
+    {
+        mComponentSignalptrs[s]->simulateOneTimestep();
+    }
+
+    //C components
+    for (size_t c=0; c < mComponentCptrs.size(); ++c)
+    {
+        mComponentCptrs[c]->simulateOneTimestep();
+    }
+
+    //Q components
+    for (size_t q=0; q < mComponentQptrs.size(); ++q)
+    {
+        mComponentQptrs[q]->simulateOneTimestep();
+    }
+}
+
 //! @brief Simulate function for single-threaded simulations.
 //! @param[in] stopT Simulate from current time until stop time
 void ComponentSystem::simulate(const double stopT)

--- a/HopsanGenerator/templates/fmu2_model.c
+++ b/HopsanGenerator/templates/fmu2_model.c
@@ -264,6 +264,11 @@ fmi2Status fmi2GetReal(fmi2Component c,
                        size_t nValueReferences,
                        fmi2Real values[])
 {
+    if(state == Initializing)
+    {
+      fmu->pSystem->simulateOnceWithoutIncreasingTime();  //Solve equations without increasing time during initialization
+    }
+
     fmuContext *fmu =(fmuContext*)c;
     fmi2Status status = fmi2OK;
     for(size_t i=0; i<nValueReferences; ++i) {

--- a/HopsanGenerator/templates/fmu2_model.c
+++ b/HopsanGenerator/templates/fmu2_model.c
@@ -264,12 +264,13 @@ fmi2Status fmi2GetReal(fmi2Component c,
                        size_t nValueReferences,
                        fmi2Real values[])
 {
+    fmuContext *fmu =(fmuContext*)c;
+
     if(state == Initializing)
     {
       fmu->pSystem->simulateOnceWithoutIncreasingTime();  //Solve equations without increasing time during initialization
     }
 
-    fmuContext *fmu =(fmuContext*)c;
     fmi2Status status = fmi2OK;
     for(size_t i=0; i<nValueReferences; ++i) {
         if(valueReferences[i] >= NUMDATAPTRS+1) {


### PR DESCRIPTION
When calling fmiGetReal during initialization, simulateOneTimestep must be called (without actually increasing time) to update outputs that depend on inputs.