### PR TITLE
Fix hdf5 binary filename

### DIFF
--- a/build-instructions.md
+++ b/build-instructions.md
@@ -65,7 +65,7 @@ You also need  Microsoft Visual Studio Build Tools or Microsoft Visual Studio.
 To download, verify and unpack the source code for third-party dependencies, use the ```dependencies/download-dependencies.py``` script.
 * Open a terminal and got to the ```dependencies``` directory
 * To fetch all dependencies: ```download-dependencies.py --all```
-* To fetch only the bare minimum run: ```download-dependencies.py qwt fmilibrary tclap```
+* To fetch only the bare minimum run: ```download-dependencies.py qwt tclap```
 
 #### Build Third-party Dependencies (MinGW)
 Build the dependencies using each ```setupName.bat``` scripts. Run them by double-clicking or running them from a CMD terminal.

--- a/dependencies/hdf5.pri
+++ b/dependencies/hdf5.pri
@@ -38,8 +38,8 @@ have_local_hdf5() {
   LIBS *= -L$${libdir} -L$${bindir} -lhdf5$${dbg_ext} -lhdf5_cpp$${dbg_ext}
   win32 {
      # On Windows, since RPATH is ignored by LoadLibrary(), copy the library file to the bin directory after build instead
-     src_file1 = $$quote($${homedir}/bin/hdf5$${dbg_ext}.dll)
-     src_file2 = $$quote($${homedir}/bin/hdf5_cpp$${dbg_ext}.dll)
+     src_file1 = $$quote($${homedir}/bin/libhdf5$${dbg_ext}.dll)
+     src_file2 = $$quote($${homedir}/bin/libhdf5_cpp$${dbg_ext}.dll)
      dst_dir = $$quote($${PWD}/../bin)
      # Replace slashes in paths with backslashes for Windows
      src_file1 ~= s,/,\\,g

--- a/runUnitTests.bat
+++ b/runUnitTests.bat
@@ -16,7 +16,7 @@ for /r "." %%a in (tst_*.exe) do (
 REM Run HopsanGUI built-in tests
 REM Assume libstd++ and Qt libraries are in PATH already, set PATH to find local dependencies
 set deps=%~dp0\dependencies
-set PATH=%deps%\qwt\lib;%deps%\zeromq\bin;%deps%\hdf5\bin;%deps%\discount\bin;%deps%\fmilibrary\lib;%PATH%
+set PATH=%deps%\qwt\lib;%deps%\zeromq\bin;%deps%\hdf5\bin;%deps%\discount\bin;%PATH%
 hopsangui.exe --test --platform offscreen
 if !errorlevel! neq 0 (
   echo HopsanGUI test FAILED


### PR DESCRIPTION
In the new version binary files have the "lib" prefix also on Windows - this prevented release builds.

Also remove some legacy stuff related to fmilibrary.