### PR TITLE
Reconnect also in HopsanCore after reconfiguring components

### DIFF
--- a/HopsanGUI/GUIObjects/GUIComponent.cpp
+++ b/HopsanGUI/GUIObjects/GUIComponent.cpp
@@ -233,6 +233,13 @@ bool Component::setParameterValue(QString name, QString value, bool force)
                 }
 
                 con->finishCreation(false);  //Re-establish connection
+
+                //Reconnect connector in HopsanCore
+                CoreSystemAccess *pCore = mpParentSystemObject->getCoreSystemAccessPtr();
+                pCore->connect(con->getStartPort()->getParentModelObjectName(),
+                               con->getStartPort()->getName(),
+                               con->getEndPort()->getParentModelObjectName(),
+                               con->getEndPort()->getName());
             }
         }
 


### PR DESCRIPTION
After reconfiguring e.g. an FMI component, connectors were reconnected when possible, but only graphically. This adds the missing reconnection in HopsanCore.