### PR TITLE
Fix bug in FMI3 export

### DIFF
--- a/HopsanGenerator/templates/fmu3_model.c
+++ b/HopsanGenerator/templates/fmu3_model.c
@@ -233,7 +233,7 @@ fmi3Status fmi3EnterInitializationMode(fmi3Instance instance,
     }
 
     if(fmu->loggingOn) {
-        fmu->logger(fmu->instanceEnvironment, fmi3Info, "info", "Entering initialization mode...");
+        fmu->logger(fmu->instanceEnvironment, fmi3OK, "info", "Entering initialization mode...");
     }
 
     fmu->pSystem->initialize(startTime, stopTime);


### PR DESCRIPTION
Code template used non-existing class "fmi3Info", which shall be "fmi3OK".